### PR TITLE
Refactor caching to avoid loading from temp files

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -77,11 +77,10 @@ class Result(object):
     Represents one value for one entity.
     '''
     def __init__(
-            self, query, value, cache_source_name=None, cache_path_str=None):
+            self, query, value, local_cache_path=None):
         self.query = query
         self.value = value
-        self.cache_source_name = cache_source_name
-        self.cache_path_str = cache_path_str
+        self.local_cache_path = local_cache_path
 
     def __repr__(self):
         return 'Result(%r, %r)' % (self.query, self.value)

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -326,13 +326,7 @@ class EntityDeriver(object):
 
         for result in results:
             self._log(
-                'Loaded      %s from %s cache',
-                result.query.task_key, result.cache_source_name)
-
-            # Even if it was in the cache, we should write it back so it
-            # gets replicated to all tiers (local and cloud).
-            # TODO Should this be the cache's responsibility?
-            self._persistent_cache.save(result)
+                'Loaded      %s from disk cache', result.query.task_key)
 
         task_state.results_by_name = {
             result.query.entity_name: result

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -18,8 +18,7 @@ from six.moves import reload_module
 
 # A bit annoying that we have to rename this when we import it.
 from . import protocols as protos
-from .cache import (
-        LocalFileCache, GcsFileCache, PersistentCache, CACHE_SOURCE_NAME_LOCAL)
+from .cache import LocalFileCache, GcsFileCache, PersistentCache
 from .datatypes import CaseKey
 from .exception import (
     UndefinedEntityError, AlreadyDefinedEntityError, IncompatibleEntityError)
@@ -928,9 +927,9 @@ class Flow(object):
 
         result, = result_group
 
-        if result.cache_source_name != CACHE_SOURCE_NAME_LOCAL:
+        if result.local_cache_path is None:
             raise ValueError("Entity %r is not locally persisted" % name)
-        src_file_path = Path(result.cache_path_str)
+        src_file_path = result.local_cache_path
 
         if dir_path is None and file_path is None:
             return src_file_path


### PR DESCRIPTION
The original cache behavior was to do all serializing/deserializing
to/from a temporary directory, and then move files between there and the
different cache locations.  The problem is that some objects
-- specifically Dask DataFrames -- need to be backed by a long-lived
file, not a temporary one.  This commit refactors the cache to have all
loading happen directly from the local disk cache, where we expect files
to live indefinitely.  This should make it possible to implement a
protocol for Dask frames.