### PR TITLE
Update protocols to use paths

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -144,8 +144,7 @@ class Translator(object):
         value_filename = VALUE_FILENAME_STEM + extension
         value_path = working_dir / value_filename
 
-        with value_path.open('wb') as f:
-            self._query.protocol.write(value, f)
+        self._query.protocol.write(value, value_path)
 
         descriptor = ArtifactDescriptor.from_content(
             entity_name=self._query.entity_name,
@@ -176,8 +175,7 @@ class Translator(object):
             extension = value_path.name[len(VALUE_FILENAME_STEM):]
 
             try:
-                with value_path.open('rb') as f:
-                    value = self._query.protocol.read(f, extension)
+                value = self._query.protocol.read(value_path, extension)
             except Exception as e:
                 raise InvalidCacheStateError(
                     "Unable to load value %s due to %s: %s" % (

--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -61,12 +61,12 @@ API changes may break your implementation.)
             """Returns the extension that persisted files should end with."""
             raise NotImplementedError()
 
-        def write(self, value, file_):
-            """Write the contents of ``value`` to file object ``file_``."""
+        def write(self, value, path):
+            """Write the contents of ``value`` to path object ``path``."""
             raise NotImplementedError()
 
-        def read(self, file_):
-            """Read an object from file object ``file_``, and return it."""
+        def read(self, path):
+            """Read an object from path object ``path``, and return it."""
             raise NotImplementedError()
 
 Protocol Decorators
@@ -76,6 +76,7 @@ Protocol Decorators
 .. autofunction:: bionic.protocol.enum
 .. autofunction:: bionic.protocol.frame
 .. autofunction:: bionic.protocol.image
+.. autofunction:: bionic.protocol.numpy
 .. autofunction:: bionic.protocol.picklable
 .. autofunction:: bionic.protocol.type
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -83,8 +83,8 @@ class RoundingProtocol(bn.protocols.BaseProtocol):
     def get_fixed_file_extension(self):
         return 'round'
 
-    def write(self, value, file_):
-        file_.write(str(round(value)).encode('utf-8'))
+    def write(self, value, path):
+        path.write_bytes(str(round(value)).encode('utf-8'))
 
-    def read(self, file_, extension):
-        return float(file_.read())
+    def read(self, path, extension):
+        return float(path.read_bytes())

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -209,9 +209,9 @@ def test_deps_of_cached_values_not_needed(builder):
             self.times_read_called = 0
             super(ReadCountingProtocol, self).__init__()
 
-        def read(self, file_, extension):
+        def read(self, path, extension):
             self.times_read_called += 1
-            return super(ReadCountingProtocol, self).read(file_, extension)
+            return super(ReadCountingProtocol, self).read(path, extension)
 
     y_protocol = ReadCountingProtocol()
     z_protocol = ReadCountingProtocol()

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -33,8 +33,13 @@ class Point(object):
         self.y = y
 
 
+def serialize_to_path(value, path):
+    with path.open('wb') as file_:
+        pickle.dump(value, file_)
+
+
 def test_tokenize_complex_type():
-    token = tokenize(Point(1, 2), pickle.dump)
+    token = tokenize(Point(1, 2), serialize_to_path)
     assert isinstance(token, string_types)
     assert len(token) == 10
 
@@ -46,7 +51,7 @@ def test_tokenize_no_collisions():
         for y in range(100)
     ]
     tokens = [
-        tokenize(point, pickle.dump)
+        tokenize(point, serialize_to_path)
         for point in points
     ]
     assert len(set(tokens)) == len(points)


### PR DESCRIPTION
We can't easily serialize Dask DataFrames to parquet using file objects.
So this commit updates each protocol's read and write methods to use
paths instead of file objects.