### PR TITLE
Make tokenization test faster

### DIFF
--- a/bionic/tokenization.py
+++ b/bionic/tokenization.py
@@ -6,11 +6,8 @@ from __future__ import absolute_import
 from __future__ import division
 
 from future import standard_library
-from pathlib2 import Path
 standard_library.install_aliases() # NOQA
 from builtins import str, chr, range
-import shutil
-import tempfile
 
 from .util import hash_to_hex
 
@@ -66,14 +63,8 @@ def tokenize(value, serialize_func=None):
     '''
 
     if serialize_func is not None:
-        file_name = "temp_file"
-        temp_dir = Path(tempfile.mkdtemp())
-        try:
-            temp_file_path = temp_dir / file_name
-            serialize_func(value, temp_file_path)
-            token = hash_to_hex(temp_file_path.read_bytes(), HASH_LEN)
-        finally:
-            shutil.rmtree(str(temp_dir))
+        bytestring = serialize_func(value)
+        token = hash_to_hex(bytestring, HASH_LEN)
     else:
         value_str = str(value)
         token = clean_str(value_str)

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -33,13 +33,8 @@ class Point(object):
         self.y = y
 
 
-def serialize_to_path(value, path):
-    with path.open('wb') as file_:
-        pickle.dump(value, file_)
-
-
 def test_tokenize_complex_type():
-    token = tokenize(Point(1, 2), serialize_to_path)
+    token = tokenize(Point(1, 2), pickle.dumps)
     assert isinstance(token, string_types)
     assert len(token) == 10
 
@@ -51,7 +46,7 @@ def test_tokenize_no_collisions():
         for y in range(100)
     ]
     tokens = [
-        tokenize(point, serialize_to_path)
+        tokenize(point, pickle.dumps)
         for point in points
     ]
     assert len(set(tokens)) == len(points)


### PR DESCRIPTION
The recent (necessary) change to have protocols write to paths instead
of buffers made our tokenization tests slower, because one test involved
writing 10,000 tokens, which now requries creating 10,000 temporary
directories and files.  This change moves tokenization back to working
with buffers and has the BaseProtocol convert its own `write` method
into something usable by the tokenizer.