### PR TITLE
bclayman/add dask protocol

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.3
+current_version = 0.4.4
 
 [bumpversion:file:setup.py]
 

--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -6,4 +6,4 @@ from .decorators import (  # noqa: F401
 
 from . import protocol  # noqa: F401
 
-__version__ = u'0.4.3'
+__version__ = u'0.4.4'

--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -17,6 +17,7 @@ import yaml
 import six
 from pathlib2 import Path, PurePosixPath
 
+from bionic.exception import DaskMultiIndexError
 from .datatypes import Result
 from .util import (
     check_exactly_one_present, hash_to_hex, get_gcs_client_without_warnings)
@@ -176,6 +177,8 @@ class Translator(object):
 
             try:
                 value = self._query.protocol.read(value_path, extension)
+            except DaskMultiIndexError:
+                raise
             except Exception as e:
                 raise InvalidCacheStateError(
                     "Unable to load value %s due to %s: %s" % (

--- a/bionic/exception.py
+++ b/bionic/exception.py
@@ -17,3 +17,7 @@ class AlreadyDefinedEntityError(ValueError):
 
 class IncompatibleEntityError(ValueError):
     pass
+
+
+class DaskMultiIndexError(Exception):
+    pass

--- a/bionic/protocol.py
+++ b/bionic/protocol.py
@@ -6,6 +6,7 @@ from . import protocols
 # why we instantiate them here.
 picklable = protocols.PicklableProtocol()  # noqa: F401
 dillable = protocols.DillableProtocol()  # noqa: F401
+dask = protocols.DaskProtocol()  # noqa: F401
 image = protocols.ImageProtocol()  # noqa: F401
 numpy = protocols.NumPyProtocol()  # noqa: F401
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ copyright = u'2019, Square'
 author = u'Janek Klawe'
 
 # The short X.Y version
-version = u'0.4.3'
+version = u'0.4.4'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
 
 setup(
     name='bionic',
-    version='0.4.3',
+    version='0.4.4',
     description=(
         'A Python framework for building, running, and sharing data science '
         'workflows'),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -38,6 +38,15 @@ def assert_frames_equal_when_sorted(df1, df2):
     pdt.assert_frame_equal(df1, df2)
 
 
+def equal_frame_and_index_content(df1, df2):
+    '''
+    Checks whether the passed dataframes have the same content and index values.  This ignores
+    index type, so a dataframe with RangeIndex(start=0, stop=3, step=1) will be considered equal
+    to Int64Index([0, 1, 2], dtype='int64', name='index')
+    '''
+    return df1.equals(df2) and list(df1.index) == list(df2.index)
+
+
 def df_from_csv_str(string):
     bytestring = dedent(string).encode('utf-8')
     return pd.read_csv(BytesIO(bytestring))


### PR DESCRIPTION
This PR:
* Changes each protocol's `read` and `write` methods to use `Path` objects and updates caching appropriately.
* Adds the Dask protocol, enabling users to decorate with `@dask`.  Caching serializes to and reads from Parquet.  We don't support `Categorical` columns now but may in the future.