### PR TITLE
Bclayman/add dask protocol

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.3
+current_version = 0.4.4
 
 [bumpversion:file:setup.py]
 

--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -6,4 +6,4 @@ from .decorators import (  # noqa: F401
 
 from . import protocol  # noqa: F401
 
-__version__ = u'0.4.3'
+__version__ = u'0.4.4'

--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -17,6 +17,7 @@ import yaml
 import six
 from pathlib2 import Path, PurePosixPath
 
+from bionic.exception import UnsupportedSerializedValueError
 from .datatypes import Result
 from .util import (
     check_exactly_one_present, hash_to_hex, get_gcs_client_without_warnings)
@@ -176,6 +177,8 @@ class Translator(object):
 
             try:
                 value = self._query.protocol.read(value_path, extension)
+            except UnsupportedSerializedValueError:
+                raise
             except Exception as e:
                 raise InvalidCacheStateError(
                     "Unable to load value %s due to %s: %s" % (

--- a/bionic/exception.py
+++ b/bionic/exception.py
@@ -17,3 +17,7 @@ class AlreadyDefinedEntityError(ValueError):
 
 class IncompatibleEntityError(ValueError):
     pass
+
+
+class UnsupportedSerializedValueError(Exception):
+    pass

--- a/bionic/extras.py
+++ b/bionic/extras.py
@@ -28,6 +28,7 @@ extras['viz'] = combine(['hsluv', 'networkx', 'pydot'], extras['image'])
 extras['standard'] = combine(extras['matplotlib'], extras['viz'])
 
 extras['dill'] = ['dill']
+extras['dask'] = ['dask[dataframe]']
 extras['gcp'] = ['google-cloud-storage']
 
 extras['examples'] = combine(extras['standard'], ['scikit-learn'])

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -36,6 +36,7 @@ DEFAULT_PROTOCOL = protos.CombinedProtocol(
     protos.ParquetDataFrameProtocol(),
     protos.ImageProtocol(),
     protos.NumPyProtocol(),
+    protos.DaskProtocol(),
     protos.PicklableProtocol(),
 )
 

--- a/bionic/optdep.py
+++ b/bionic/optdep.py
@@ -25,6 +25,7 @@ def first_token_from_package_desc(desc):
 alias_lists_by_package = {
     'google-cloud-storage': ['google.cloud.storage'],
     'Pillow': ['PIL', 'PIL.Image'],
+    'dask[dataframe]': ['dask.dataframe']
 }
 
 # Now we contruct a new data structure to allow us to give helpful error

--- a/bionic/protocol.py
+++ b/bionic/protocol.py
@@ -6,6 +6,7 @@ from . import protocols
 # why we instantiate them here.
 picklable = protocols.PicklableProtocol()  # noqa: F401
 dillable = protocols.DillableProtocol()  # noqa: F401
+dask = protocols.DaskProtocol()  # noqa: F401
 image = protocols.ImageProtocol()  # noqa: F401
 numpy = protocols.NumPyProtocol()  # noqa: F401
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ copyright = u'2019, Square'
 author = u'Janek Klawe'
 
 # The short X.Y version
-version = u'0.4.3'
+version = u'0.4.4'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -55,6 +55,8 @@ Subpackage  Installation Command              Enables
 dev        ``pip install bionic[dev]``        every feature; testing; building
                                               documentation
 ---------- ---------------------------------- ---------------------------------
+dask       ``pip install bionic[dask]``       the ``@dask`` decorator
+---------- ---------------------------------- ---------------------------------
 dill       ``pip install bionic[dill]``       the ``@dillable`` decorator
 ---------- ---------------------------------- ---------------------------------
 examples   ``pip install bionic[examples]``   the tutorial example code

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
 
 setup(
     name='bionic',
-    version='0.4.3',
+    version='0.4.4',
     description=(
         'A Python framework for building, running, and sharing data science '
         'workflows'),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -38,6 +38,15 @@ def assert_frames_equal_when_sorted(df1, df2):
     pdt.assert_frame_equal(df1, df2)
 
 
+def equal_frame_and_index_content(df1, df2):
+    '''
+    Checks whether the passed dataframes have the same content and index values.  This ignores
+    index type, so a dataframe with RangeIndex(start=0, stop=3, step=1) will be considered equal
+    to Int64Index([0, 1, 2], dtype='int64', name='index')
+    '''
+    return df1.equals(df2) and list(df1.index) == list(df2.index)
+
+
 def df_from_csv_str(string):
     bytestring = dedent(string).encode('utf-8')
     return pd.read_csv(BytesIO(bytestring))

--- a/tests/test_flow/test_protocols.py
+++ b/tests/test_flow/test_protocols.py
@@ -6,10 +6,13 @@ import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 from PIL import Image
+import six
 
-from ..helpers import count_calls, df_from_csv_str
+from ..helpers import count_calls, df_from_csv_str, equal_frame_and_index_content
 
 import bionic as bn
+import dask.dataframe as dd
+from bionic.exception import UnsupportedSerializedValueError
 from bionic.protocols import CombinedProtocol, PicklableProtocol
 
 
@@ -194,6 +197,100 @@ def test_dataframe_with_categorical_works_with_feather(builder):
         return df_value
 
     pdt.assert_frame_equal(builder.build().get('df'), df_value)
+
+
+def test_simple_dask_dataframe(builder):
+    df_value = df_from_csv_str('''
+    color,number
+    red,1
+    blue,2
+    green,3
+    ''')
+    dask_df = dd.from_pandas(df_value, npartitions=1)
+
+    @builder
+    @bn.protocol.dask
+    @count_calls
+    def df():
+        return dask_df
+
+    assert equal_frame_and_index_content(builder.build().get('df').compute(), dask_df.compute())
+    assert equal_frame_and_index_content(builder.build().get('df').compute(), dask_df.compute())
+    assert df.times_called() == 1
+
+
+def test_multiple_partitions_dask_dataframe(builder):
+    df_value = df_from_csv_str('''
+    color,number
+    red,1
+    blue,2
+    green,3
+    ''')
+    dask_df = dd.from_pandas(df_value, npartitions=3)
+
+    @builder
+    @bn.protocol.dask
+    @count_calls
+    def df():
+        return dask_df
+
+    assert equal_frame_and_index_content(builder.build().get('df').compute(), dask_df.compute())
+    assert equal_frame_and_index_content(builder.build().get('df').compute(), dask_df.compute())
+    assert df.times_called() == 1
+
+
+def test_typed_dask_dataframe(builder):
+    df_value = pd.DataFrame()
+    df_value['int'] = [1, 2, 3]
+    df_value['float'] = [1.0, 1.5, float('nan')]
+    df_value['str'] = ['red', 'blue', None]
+    df_value['time'] = pd.to_datetime([
+        '2011-02-07',
+        '2011-03-17',
+        '2011-04-27',
+    ])
+    dask_df = dd.from_pandas(df_value, npartitions=1)
+
+    @builder
+    @bn.protocol.dask
+    def df():
+        return dask_df
+
+    assert equal_frame_and_index_content(builder.build().get('df').compute(), dask_df.compute())
+    assert builder.build().get('df').compute().dtypes.to_dict() ==\
+        dask_df.compute().dtypes.to_dict()
+
+
+@pytest.mark.skipif(six.PY2, reason="requires python 3")
+def test_dask_dataframe_index_cols(builder):
+    df_value = df_from_csv_str('''
+        city,country,continent,metro_pop_mil
+        Tokyo,Japan,Asia,38
+        Delhi,India,Asia,26
+        Shanghai,China,Asia,24
+        Sao Paulo,Brazil,South America,21
+        Mumbai,India,21
+        Mexico City,Mexico,North America,21
+        Beijing,China,Asia,20
+        Osaka,Japan,Asia,20
+        Cairo,Egypt,Africa,19
+        New York,USA,North America,19
+        ''')
+    dask_df = dd.from_pandas(df_value, npartitions=1)
+
+    @builder
+    @bn.protocol.dask
+    def raw_df():
+        return dask_df
+
+    @builder
+    @bn.protocol.dask
+    def counts_df(raw_df):
+        return raw_df.groupby(['continent', 'country']).size()\
+            .to_frame('count')
+
+    with pytest.raises(UnsupportedSerializedValueError):
+        builder.build().get('counts_df')
 
 
 def test_image_protocol(builder):


### PR DESCRIPTION
This PR:
* Updates protocols to use `Path` objects and how `cache.py` makes use of a protocol's `read` and `write` methods
* Adds a Dask protocol, so users can now decorate with `@dask`, which will serialize to Parquet.  We don't currently support Categorical columns but may in the future.