### PR TITLE
Catch YAML import error the correct way

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -13,6 +13,7 @@ import subprocess
 import tempfile
 import textwrap
 import yaml
+import warnings
 
 import six
 from pathlib2 import Path, PurePosixPath
@@ -32,7 +33,12 @@ try:
     # yaml.full_load.  This is less important since we dump much more than we
     # load.
     YamlDumper = yaml.CDumper
-except ImportError:
+except AttributeError:
+    warnings.warn(
+        "Failed to find LibYAML bindings; "
+        "falling back to slower Python implementation. "
+        "This may reduce performance on large flows. "
+        "Installing LibYAML should resolve this.")
     YamlDumper = yaml.Dumper
 
 VALUE_FILENAME_STEM = 'value.'

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -32,6 +32,13 @@ GCS bucket, and install the ``bionic[gcp]`` subpackage.
 .. _cached to Google Cloud Storage: concepts.rst#caching-in-google-cloud-storage
 .. _Google Cloud SDK : https://cloud.google.com/sdk/
 
+Finally, installing `LibYAML <https://github.com/yaml/libyaml>`_ will improve
+performance for some workloads.  LibYAML is also available via Homebrew:
+
+.. code-block:: bash
+
+    brew install libyaml
+
 Bionic should work on both Python 2.7 and Python 3.x.
 
 .. _extra-packages:


### PR DESCRIPTION
We were catching the wrong exception type when LibYAML was missing,
which broke the readthedocs build.

I also added a warning when we fall back to the slower YAML
implementation and added some LibYAML info to the docs.