### PR TITLE
Raise ValueError when writing DataFrame with duplicate columns

### DIFF
--- a/tests/test_flow/test_protocols.py
+++ b/tests/test_flow/test_protocols.py
@@ -184,6 +184,17 @@ def test_dataframe_with_categoricals_ignored(builder):
         df_value['cat'].astype(object))
 
 
+def test_dataframe_with_duplicate_columns_fails(builder):
+    df_value = pd.DataFrame(columns=['a', 'b', 'a'], data=[[1, 2, 3]])
+
+    @builder
+    def df():
+        return df_value
+
+    with pytest.raises(ValueError):
+        builder.build().get('df')
+
+
 def test_dataframe_with_categorical_works_with_feather(builder):
     df_value = pd.DataFrame()
     df_value['cat'] = pd.Categorical(


### PR DESCRIPTION
Previously, the call to `self._check_dtypes` within `ParquetDataFrameProtocol#write` would fail with duplicate columns because it expects `df[col]` to always be a `pd.Series`.  If the `col` in question appears more than once, `df[col]` produces a `pd.DataFrame`.  We do not support writing `DataFrame`s with duplicate columns.  This commit raises a `ValueError` if it encounters this scenario when writing.