### PR TITLE
Don't warn for missing LibYAML on Read the Docs

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -34,11 +34,14 @@ try:
     # load.
     YamlDumper = yaml.CDumper
 except AttributeError:
-    warnings.warn(
-        "Failed to find LibYAML bindings; "
-        "falling back to slower Python implementation. "
-        "This may reduce performance on large flows. "
-        "Installing LibYAML should resolve this.")
+    import os
+    running_under_readthedocs = os.environ.get('READTHEDOCS') == 'True'
+    if not running_under_readthedocs:
+        warnings.warn(
+            "Failed to find LibYAML bindings; "
+            "falling back to slower Python implementation. "
+            "This may reduce performance on large flows. "
+            "Installing LibYAML should resolve this.")
     YamlDumper = yaml.Dumper
 
 VALUE_FILENAME_STEM = 'value.'


### PR DESCRIPTION
Suppress the "missing LibYAML" warning when running on Read the Docs.

Read the Docs doesn't have LibYAML installed, which causes a warning to
appear in tutorials (e.g.
https://bionic.readthedocs.io/en/latest/tutorials/hello_world.html).
This looks bad.  Unfortunately, there doesn't seem to be any way to
support arbitrary C dependencies on Read the Docs, so I don't think we
can make this library available there.  Instead, I'm just suppressing
the warning when the `READTHEDOCS` environment variable is `True`.

We could also mock the dependency as described here:

    https://docs.readthedocs.io/en/stable/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules

But that's more complicated and would apply to everyone who builds the
docs.