### PR TITLE
Use chained cache exceptions in Python 3

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -21,7 +21,8 @@ from pathlib2 import Path, PurePosixPath
 from bionic.exception import UnsupportedSerializedValueError
 from .datatypes import Result
 from .util import (
-    check_exactly_one_present, hash_to_hex, get_gcs_client_without_warnings)
+    check_exactly_one_present, hash_to_hex, get_gcs_client_without_warnings,
+    raise_chained)
 
 import logging
 logger = logging.getLogger(__name__)
@@ -184,8 +185,10 @@ class Translator(object):
             try:
                 descriptor = ArtifactDescriptor.from_yaml(descriptor_yaml)
             except YamlRecordParsingError as e:
-                raise InvalidCacheStateError(
-                    "Couldn't parse descriptor file: %s" % e)
+                raise_chained(
+                    InvalidCacheStateError,
+                    "Couldn't parse descriptor file",
+                    e)
 
             value_filename = descriptor.value_filename
             value_path = working_dir / value_filename
@@ -196,9 +199,11 @@ class Translator(object):
             except UnsupportedSerializedValueError:
                 raise
             except Exception as e:
-                raise InvalidCacheStateError(
-                    "Unable to load value %s due to %s: %s" % (
-                        self._query.task_key, e.__class__.__name__, e))
+                raise_chained(
+                    InvalidCacheStateError,
+                    "Unable to load value %s due to %s" % (
+                        self._query.task_key, e.__class__.__name__),
+                    e)
 
         except InvalidCacheStateError as e:
             problem_sources = [
@@ -207,12 +212,14 @@ class Translator(object):
                 problem_sources.append(
                     self._cloud_cache.get_url(self._virtual_path))
 
-            raise InvalidCacheStateError(
+            raise_chained(
+                InvalidCacheStateError,
                 "Cached data was in an invalid state; "
                 "this should be impossible but could have resulted from "
                 "either a bug or a change to the cached files.  You "
-                "should be able to repair the problem by removing %s."
-                "\nDetails: %s" % (' and '.join(problem_sources), e))
+                "should be able to repair the problem by removing %s." % (
+                    ' and '.join(problem_sources)),
+                e)
 
         result = Result(
             query=self._query,
@@ -394,9 +401,10 @@ class YamlDictRecord(object):
             try:
                 self._body_dict = yaml.full_load(yaml_str)
             except yaml.error.YAMLError as e:
-                raise YamlRecordParsingError(
-                    "Couldn't parse %s: %s" % (
-                        self.__class__.__name__, str(e)))
+                raise_chained(
+                    YamlRecordParsingError,
+                    "Couldn't parse %s: %s" % self.__class__.__name__,
+                    e)
             self._yaml_str = yaml_str
 
     def to_yaml(self):
@@ -430,8 +438,10 @@ class ArtifactDescriptor(YamlDictRecord):
             self.entity_name = self.to_dict()['entity']
             self.value_filename = self.to_dict()['filename']
         except KeyError as e:
-            raise YamlRecordParsingError(
-                "YAML for ArtifactDescriptor was missing field: %s" % e)
+            raise_chained(
+                YamlRecordParsingError,
+                "YAML for ArtifactDescriptor was missing field",
+                e)
 
     def is_valid(self):
         cache_schema_version =\

--- a/bionic/util.py
+++ b/bionic/util.py
@@ -10,6 +10,8 @@ from hashlib import sha256
 from binascii import hexlify
 import warnings
 
+import six
+
 from .optdep import import_optional_dependency
 
 
@@ -281,6 +283,25 @@ class ExtensibleLogger(object):
     def exception(self, msg, *args, **kwargs):
         self._custom_log_if_enabled(
             logging.ERROR, msg, *args, exc_info=True, **kwargs)
+
+
+def raise_chained(exc_ctor, message, from_exc):
+    """
+    Raises a chained exception in a Python-2-compatible way.
+
+    Works like six.raise_from(), except:
+
+    1. Requires an exception constructor and a message instead of an
+    already-constructed exception.
+
+    2. In Python 2, adds the text of ``from_exc`` to the raised exception (as
+    opposed to ``raise_from``, which just ignores the second argument).
+    """
+
+    if six.PY2:
+        raise exc_ctor('%s\nCaused by: %s' % (message, from_exc))
+    else:
+        six.raise_from(exc_ctor(message), from_exc)
 
 
 def init_basic_logging(level=logging.INFO):


### PR DESCRIPTION
Using chained exceptions makes many errors easier to debug.  This
introduces a helper that uses chained exceptions in Python 3 and falls
back to something sensible in Python 2.