### PR TITLE
Janek/assisted versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ before_install:
   - sudo apt-get install graphviz
   - pip install --upgrade .[dev]
 script:
-  - pytest
+  - pytest --slow
   - flake8
 

--- a/bionic/bytecode.py
+++ b/bionic/bytecode.py
@@ -1,0 +1,62 @@
+import sys
+import re
+
+from six import StringIO
+
+
+def bytecode_from_func(func):
+    # I'm not sure if this module works in non-CPython versions of Python, so
+    # we'll import it only when this function is called.
+    import dis
+
+    # There doesn't seem to be any way, at least in Python 2, to get function
+    # bytecode as a string; you have redirect stdout and capture it.  However,
+    # in Python 3.4+, you can pass a file argument to dis.dis.  Once we drop
+    # support for Python 2, we should switch to that.
+    saved_stdout = sys.stdout
+    buf = StringIO()
+    try:
+        sys.stdout = buf
+        dis.dis(func)
+    finally:
+        sys.stdout = saved_stdout
+    return buf.getvalue()
+
+
+CODE_OBJECT_PATTERN = re.compile('<code.*>')
+
+
+def canonicalize_bytecode(bytecode_str):
+    canon_strs_by_long_str = {}
+
+    modified_lines = []
+    for line in bytecode_str.splitlines():
+        if not line.strip():
+            continue
+
+        if line.startswith('Disassembly'):
+            pass
+        elif not line.startswith('    '):
+            line = line.split(None, 1)[1]
+        else:
+            line = line.lstrip()
+
+        match = CODE_OBJECT_PATTERN.search(line)
+        if match is not None:
+            long_str = match.group(0)
+
+            if long_str in canon_strs_by_long_str:
+                canon_str = canon_strs_by_long_str[long_str]
+            else:
+                canon_str = '<code ref #%s>' % (len(canon_strs_by_long_str))
+                canon_strs_by_long_str[long_str] = canon_str
+
+            line = line.replace(long_str, canon_str)
+
+        modified_lines.append(line)
+
+    return '\n'.join(modified_lines)
+
+
+def canonical_bytecode_bytes_from_func(func):
+    return canonicalize_bytecode(bytecode_from_func(func)).encode('utf8')

--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -34,6 +34,7 @@ try:
     # yaml.full_load.  This is less important since we dump much more than we
     # load.
     YamlDumper = yaml.CDumper
+    YamlLoader = yaml.CLoader
 except AttributeError:
     import os
     running_under_readthedocs = os.environ.get('READTHEDOCS') == 'True'
@@ -44,6 +45,7 @@ except AttributeError:
             "This may reduce performance on large flows. "
             "Installing LibYAML should resolve this.")
     YamlDumper = yaml.Dumper
+    YamlLoader = yaml.Loader
 
 VALUE_FILENAME_STEM = 'value.'
 DESCRIPTOR_FILENAME = 'descriptor.yaml'
@@ -402,7 +404,7 @@ class YamlDictRecord(object):
             )
         else:
             try:
-                self._body_dict = yaml.full_load(yaml_str)
+                self._body_dict = yaml.load(yaml_str, Loader=YamlLoader)
             except yaml.error.YAMLError as e:
                 raise_chained(
                     YamlRecordParsingError,

--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -1,6 +1,7 @@
 """
-Contains the PersistentCache class, which handles persistent local caching.
-This including artifact naming, invalidation, and saving/loading.
+This module provides local and cloud storage of computed values.  The main
+point of entry is the PersistentCache, which encapsulates this functionality.
+
 
 """
 
@@ -8,21 +9,23 @@ from __future__ import absolute_import
 from __future__ import division
 
 from builtins import object
+from collections import namedtuple
+from hashlib import sha256
 import shutil
 import subprocess
 import tempfile
-import textwrap
 import yaml
 import warnings
+from uuid import uuid4
 
 import six
-from pathlib2 import Path, PurePosixPath
+from pathlib2 import Path
 
 from bionic.exception import UnsupportedSerializedValueError
 from .datatypes import Result
 from .util import (
-    check_exactly_one_present, hash_to_hex, get_gcs_client_without_warnings,
-    raise_chained)
+    get_gcs_client_without_warnings, ensure_parent_dir_exists, raise_chained)
+from .tokenization import tokenize
 
 import logging
 logger = logging.getLogger(__name__)
@@ -47,330 +50,740 @@ except AttributeError:
     YamlDumper = yaml.Dumper
     YamlLoader = yaml.Loader
 
-VALUE_FILENAME_STEM = 'value.'
-DESCRIPTOR_FILENAME = 'descriptor.yaml'
-
 
 class PersistentCache(object):
     """
     Provides a persistent mapping between Queries (things we could compute) and
-    Results (computed Queries).
+    saved Results (computed Queries).  You use it by getting a CacheAccessor
+    for your specific query, and then performing load/save operations on the
+    accessor.
+
+    When looking up a Query, the cache searches for a saved artifact with a
+    matching Query.  The Query may not match exactly: each Query contains a
+    Provenance, which represents all the code and data used to compute a value,
+    and two Provenances can match at different levels of precision, from a
+    "functional" match to an "exact" one.  A functional match is sufficient to
+    treat two artifacts as interchangeable; the finer levels of matching are
+    only used by the "assisted versioning" system, which tries to detect
+    situations where a function's bytecode has changed but its version hasn't.
+
+    The cache has two tiers: a "local" tier on disk, which is cheap to access,
+    and an optional "cloud" tier backed by GCS, which is more expensive to
+    access (but globally accessible).  For load operations, the cache returns
+    the cheapest artifact that functionally matches the Query.  For save
+    operations, the cache records an exact entry in both tiers.
+
+    The cache actually has two distinct responsibilities: (a) translating
+    between in-memory Python objects and serialized files or blobs, and (b)
+    maintaining an "inventory" of these files and blobs.  Currently it makes
+    sense to group these responsibilities together at each tier, where the
+    local inventory tracks the local files and the cloud inventory tracks the
+    cloud blobs.  Each of these tiers is handled by a "store" class.  However,
+    in the future we may have other types of persistent artifacts (like
+    database tables) which don't have their own inventory type.  In this case
+    we might want to split these responsibilities out.
     """
 
-    def __init__(self, tmp_working_dir_str, local_cache, cloud_cache):
-        self._tmp_working_dir_str = tmp_working_dir_str
-        self._local_cache = local_cache
-        self._cloud_cache = cloud_cache
+    def __init__(self, local_store, cloud_store):
+        self._local_store = local_store
+        self._cloud_store = cloud_store
 
-    def save(self, result):
-        translator = self.translator_for_query(result.query)
-        translator.save_result_in_local_if_needed(result)
-        translator.copy_local_to_cloud_if_needed()
-
-    def load(self, query):
-        translator = self.translator_for_query(query)
-
-        if translator.has_data_in_local():
-            result = translator.load_result_from_local()
-            # We don't copy to the cloud until we've successfully loaded from
-            # local -- just in case the local data is corrupt.
-            translator.copy_local_to_cloud_if_needed()
-            return result
-
-        elif translator.has_data_in_cloud():
-            translator.copy_cloud_to_local()
-            return translator.load_result_from_local(
-                data_originated_in_cloud=True)
-
-        else:
-            return None
-
-    def translator_for_query(self, query):
-        return Translator(self, query)
+    def get_accessor(self, query):
+        return CacheAccessor(self, query)
 
 
-class Translator(object):
+class CacheAccessor(object):
     """
-    Translates the value of a query among three representations:
-    - in memory, as a Python object
-    - on the local filesystem
-    - in Google Cloud Storage
+    Provides a reference to the cache entries for a specific query.  This
+    interface is convenient, and it also allows us to maintain some memoized
+    state for each query, saving redundant lookups.
     """
+
+    VALUE_FILENAME_STEM = 'value.'
 
     def __init__(self, parent_cache, query):
-        self._tmp_working_dir_str = parent_cache._tmp_working_dir_str
-        self._local_cache = parent_cache._local_cache
-        self._cloud_cache = parent_cache._cloud_cache
-        self._query = query
+        self.query = query
 
-        artifact_dir_str = query.provenance.hashed_value
-        self._virtual_path = Path(query.entity_name) / artifact_dir_str
+        self._local = parent_cache._local_store
+        self._cloud = parent_cache._cloud_store
 
-    def save_result_in_local_if_needed(self, result):
-        working_dir = self._create_tmp_dir()
+        # These values are memoized to avoid roundtrips.
+        self._stored_local_entry = None
+        self._stored_cloud_entry = None
 
-        try:
-            self._save_result_to_dir(result, working_dir)
-
-            if not self.has_data_in_local():
-                self._local_cache.move_in(self._virtual_path, working_dir)
-
-        finally:
-            self._remove_dir(working_dir)
-
-    def copy_local_to_cloud_if_needed(self):
-        if self._cloud_cache is None:
-            return
-        if self._cloud_cache.has_dir(self._virtual_path):
-            return
-
-        logger.info(
-            'Uploading   %s to cloud file cache ...',
-            self._query.task_key)
-        local_dir = self._local_cache.get_real_path(self._virtual_path)
-        self._cloud_cache.copy_in(self._virtual_path, local_dir)
-
-    def copy_cloud_to_local(self):
-        working_dir = self._create_tmp_dir()
+    def can_load(self):
+        """
+        Indicates whether there are any cached artifacts for this query.
+        """
 
         try:
-            logger.info(
-                'Downloading %s from cloud file cache ...',
-                self._query.task_key)
-            self._cloud_cache.copy_out(self._virtual_path, working_dir)
-            self._local_cache.move_in(self._virtual_path, working_dir)
+            return self._get_nearest_entry_with_artifact() is not None
+        except InternalCacheStateError as e:
+            self._raise_state_error_with_explanation(e)
 
-        finally:
-            self._remove_dir(working_dir)
+    def load_provenance(self):
+        """
+        Returns the provenance of the nearest cached artifact for this query,
+        if one exists.
+        """
 
-    def has_data_in_local(self):
-        return self._local_cache.has_dir(self._virtual_path)
+        try:
+            entry = self._get_nearest_entry_with_artifact()
+            if entry is None:
+                return None
+            return entry.provenance
+        except InternalCacheStateError as e:
+            self._raise_state_error_with_explanation(e)
 
-    def has_data_in_cloud(self):
-        return self._cloud_cache is not None and\
-            self._cloud_cache.has_dir(self._virtual_path)
+    def load_result(self):
+        """
+        Returns a Result for the nearest cached artifact for this query, if one
+        exists.
+        """
 
-    def load_result_from_local(self, data_originated_in_cloud=False):
-        local_dir = self._local_cache.get_real_path(self._virtual_path)
-        return self._load_result_from_dir(local_dir)
+        try:
+            entry = self._get_nearest_entry_with_artifact()
 
-    def _create_tmp_dir(self):
-        Path(self._tmp_working_dir_str).mkdir(parents=True, exist_ok=True)
-        return Path(tempfile.mkdtemp(dir=self._tmp_working_dir_str))
+            if entry is None:
+                return None
 
-    def _remove_dir(self, dir_path):
-        shutil.rmtree(str(dir_path), ignore_errors=True)
+            if entry.tier == 'local':
+                file_path = path_from_url(entry.artifact_url)
 
-    def _save_result_to_dir(self, result, working_dir):
-        value = result.value
-        extension = self._query.protocol.file_extension_for_value(value)
-        value_filename = VALUE_FILENAME_STEM + extension
-        value_path = working_dir / value_filename
+            elif entry.tier == 'cloud':
+                blob_url = entry.artifact_url
+                file_path = self._file_from_blob(blob_url)
 
-        self._query.protocol.write(value, value_path)
+            else:
+                raise AssertionError("Unrecognized tier: " + entry.tier)
 
+            value = self._value_from_file(file_path)
+
+            return Result(
+                query=self.query,
+                value=value,
+                file_path=file_path,
+            )
+        except InternalCacheStateError as e:
+            self._raise_state_error_with_explanation(e)
+
+    def save_result(self, result):
+        """
+        Saves a Result in each cache layer that doens't already have an exact
+        match.
+        """
+
+        try:
+            self._save_or_reregister_result(result)
+        except InternalCacheStateError as e:
+            self._raise_state_error_with_explanation(e)
+
+    def update_provenance(self):
+        """
+        Adds an entry to each cache layer that doesn't already have an exact
+        match for this query.  There must be already be at least one cached
+        functional match -- i.e., ``can_load()`` must already return True.
+        """
+
+        try:
+            self._save_or_reregister_result(None)
+        except InternalCacheStateError as e:
+            self._raise_state_error_with_explanation(e)
+
+    def _save_or_reregister_result(self, result):
+        local_entry = self._get_local_entry()
+        cloud_entry = self._get_cloud_entry()
+        self._clear_stored_entries()
+
+        if result is not None:
+            value = result.value
+            file_path = result.file_path
+        else:
+            value = None
+            file_path = None
+
+        blob_url = None
+
+        if file_path is None:
+            if local_entry.has_artifact:
+                file_path = path_from_url(local_entry.artifact_url)
+            elif value is not None:
+                file_path = self._file_from_value(value)
+            else:
+                if cloud_entry is None or not cloud_entry.has_artifact:
+                    raise AssertionError(
+                        "Attempted to register a descriptor with "
+                        "no result argument and no previously saved values; "
+                        "this suggests we called update_provenance() without "
+                        "previously finding a cached value, which shouldn't "
+                        "happen.")
+                blob_url = cloud_entry.artifact_url
+                file_path = self._file_from_blob(blob_url)
+
+        if not local_entry.exactly_matches_query:
+            file_url = url_from_path(file_path)
+            self._local.inventory.register_url(self.query, file_url)
+
+        if self._cloud:
+            assert cloud_entry is not None
+            if not cloud_entry.exactly_matches_query:
+                if blob_url is None:
+                    if cloud_entry.has_artifact:
+                        blob_url = cloud_entry.artifact_url
+                    else:
+                        blob_url = self._blob_from_file(file_path)
+                self._cloud.inventory.register_url(self.query, blob_url)
+
+    def _get_nearest_entry_with_artifact(self):
+        """
+        Returns the "nearest" -- i.e., most local -- cache entry for this
+        query.
+        """
+
+        local_entry = self._get_local_entry()
+        if local_entry.has_artifact:
+            return local_entry
+
+        cloud_entry = self._get_cloud_entry()
+        if cloud_entry is not None and cloud_entry.has_artifact:
+            return cloud_entry
+
+        return None
+
+    def _get_local_entry(self):
+        if self._stored_local_entry is None:
+            self._stored_local_entry = self._local.inventory.find_entry(
+                self.query)
+        return self._stored_local_entry
+
+    def _get_cloud_entry(self):
+        if self._stored_cloud_entry is None:
+            if self._cloud is None:
+                return None
+            self._stored_cloud_entry = self._cloud.inventory.find_entry(
+                self.query)
+        return self._stored_cloud_entry
+
+    def _clear_stored_entries(self):
+        self._stored_local_entry = None
+        self._stored_cloud_entry = None
+
+    def _file_from_blob(self, blob_url):
+        dir_path = self._local.generate_unique_dir_path(self.query)
+        filename = blob_url.split('/')[-1]
+        file_path = dir_path / filename
+
+        ensure_parent_dir_exists(file_path)
+
+        logger.info('Downloading %s from GCS ...', self.query.task_key)
+        try:
+            self._cloud.download(file_path, blob_url)
+        except Exception as e:
+            raise InternalCacheStateError.from_failure(
+                'artifact blob', blob_url, e)
+
+        return file_path
+
+    def _blob_from_file(self, file_path):
+        url_prefix = self._cloud.generate_unique_url_prefix(self.query)
+        blob_url = url_prefix + '/' + file_path.name
+
+        logger.info('Uploading %s to GCS ...', self.query.task_key)
+        try:
+            self._cloud.upload(file_path, blob_url)
+        except Exception as e:
+            raise InternalCacheStateError.from_failure(
+                'artifact file', file_path, e)
+
+        return blob_url
+
+    def _file_from_value(self, value):
+        dir_path = self._local.generate_unique_dir_path(self.query)
+
+        extension = self.query.protocol.file_extension_for_value(value)
+        value_filename = self.VALUE_FILENAME_STEM + extension
+        value_path = dir_path / value_filename
+
+        ensure_parent_dir_exists(value_path)
+        self.query.protocol.write(value, value_path)
+
+        return value_path
+
+    def _value_from_file(self, file_path):
+        value_filename = file_path.name
+        extension = value_filename[len(self.VALUE_FILENAME_STEM):]
+        try:
+            return self.query.protocol.read(file_path, extension)
+        except UnsupportedSerializedValueError:
+            raise
+        except Exception as e:
+            raise InternalCacheStateError.from_failure(
+                'artifact file', file_path, e)
+
+    def _raise_state_error_with_explanation(self, source_exc):
+        stores = [self._local]
+        if self._cloud:
+            stores.append(self._cloud)
+        inventory_root_urls = ' and '.join(
+            store.inventory.root_url for store in stores),
+
+        raise_chained(
+            InvalidCacheStateError,
+            "Cached data may be in an invalid state; "
+            "this should be impossible but "
+            "could have resulted from either a bug or "
+            "a change to the cached files.  "
+            "You should be able to repair the problem by "
+            "removing all cached files under %s." % inventory_root_urls,
+            source_exc)
+
+
+# TODO In Python 3 we can store these comments as docstrings.
+# Represents a saved artifact tracked by an Inventory; returned by Inventory
+# to CacheAccessor.
+InventoryEntry = namedtuple(
+    'InventoryEntry',
+    'tier has_artifact artifact_url provenance exactly_matches_query')
+
+# Represents a match between a query and a saved artifact.  `level` is a string
+# describing the match level, ranging from "functional" to "exact".
+DescriptorMatch = namedtuple('DescriptorMatch', 'descriptor_url level')
+
+
+class Inventory(object):
+    """
+    Maintains a persistent mapping from Queries to artifact URLs.  An Inventory
+    is backed by a "file system", which could correspond to either a local disk
+    or a cloud storage service.  This file system is used to store
+    "descriptors", each of which describes a Query and an artifact URL that
+    satisfies it.  Descriptors are stored using a hierarchical naming scheme
+    whose levels correspond to the different levels of Provenance matching.
+    """
+
+    def __init__(self, name, tier, filesystem):
+        self.name = name
+        self.tier = tier
+        self._fs = filesystem
+        self.root_url = filesystem.root_url
+
+    def register_url(self, query, url):
+        """
+        Records a descriptor indicating that the provided Query is satisfied
+        by the provided URL.
+        """
+
+        logger.debug(
+            'In     %s inventory for %r, saving artifact URL %s ...',
+            self.tier, query, url)
+
+        if self._fs.exists(self._exact_descriptor_url_for_query(query)):
+            # This shouldn't happen, because the CacheAccessor shouldn't write
+            # to this inventory if we already have an exact match.
+            logger.warn(
+                'In %s cache, attempted to create duplicate entry mapping %r '
+                'to %s', self.tier, query, url)
+            return
+        descriptor_url = self._create_and_write_descriptor(query, url)
+
+        logger.debug(
+            '... in %s inventory for %r, created descriptor at %s',
+            self.tier, query, descriptor_url)
+
+    def find_entry(self, query):
+        """
+        Returns an InventoryEntry describing the closest match to the provided
+        Query.
+        """
+
+        logger.debug(
+            'In     %s inventory for %r, searching ...', self.tier, query)
+
+        match = self._find_best_match(query)
+        if not match:
+            logger.debug(
+                '... in %s inventory for %r, found no match', self.tier, query)
+
+            return InventoryEntry(
+                tier=self.tier,
+                has_artifact=False,
+                artifact_url=None,
+                provenance=None,
+                exactly_matches_query=False,
+            )
+
+        logger.debug(
+            '... in %s inventory for %r, found %s match at %s',
+            self.tier, query, match.level, match.descriptor_url)
+
+        descriptor = self._load_descriptor_from_url(match.descriptor_url)
+
+        return InventoryEntry(
+            tier=self.tier,
+            has_artifact=True,
+            artifact_url=descriptor.artifact_url,
+            provenance=descriptor.provenance,
+            exactly_matches_query=(match.level == 'exact'),
+        )
+
+    def _find_best_match(self, query):
+        equivalent_url_prefix =\
+            self._equivalent_descriptor_url_prefix_for_query(query)
+        possible_urls = self._fs.search(equivalent_url_prefix)
+        equivalent_urls = [
+            url for url in possible_urls
+            if url.endswith('.yaml')
+        ]
+        if len(equivalent_urls) == 0:
+            return None
+
+        exact_url = self._exact_descriptor_url_for_query(query)
+        if exact_url in equivalent_urls:
+            return DescriptorMatch(
+                descriptor_url=exact_url,
+                level='exact',
+            )
+
+        samecode_url_prefix =\
+            self._samecode_descriptor_url_prefix_for_query(query)
+        samecode_urls = [
+            url for url in equivalent_urls
+            if url.startswith(samecode_url_prefix)
+        ]
+        if len(samecode_urls) > 0:
+            return DescriptorMatch(
+                descriptor_url=samecode_urls[0],
+                level='samecode',
+            )
+
+        nominal_url_prefix =\
+            self._nominal_descriptor_url_prefix_for_query(query)
+        nominal_urls = [
+            url for url in equivalent_urls
+            if url.startswith(nominal_url_prefix)
+        ]
+        if len(nominal_urls) > 0:
+            return DescriptorMatch(
+                descriptor_url=nominal_urls[0],
+                level='nominal',
+            )
+
+        return DescriptorMatch(
+            descriptor_url=equivalent_urls[0],
+            level='equivalent',
+        )
+
+    def _equivalent_descriptor_url_prefix_for_query(self, query):
+        return (
+            self._fs.root_url + '/' + query.entity_name + '/' +
+            query.provenance.functional_hash
+        )
+
+    def _nominal_descriptor_url_prefix_for_query(self, query):
+        minor_version_token = tokenize(query.provenance.code_version_minor)
+        return (
+            self._equivalent_descriptor_url_prefix_for_query(query) + '/' +
+            'mv_' + minor_version_token
+        )
+
+    def _samecode_descriptor_url_prefix_for_query(self, query):
+        return (
+            self._nominal_descriptor_url_prefix_for_query(query) + '/' +
+            'bc_' + query.provenance.bytecode_hash
+        )
+
+    def _exact_descriptor_url_for_query(self, query):
+        filename = ('descriptor_%s.yaml' % query.provenance.exact_hash)
+        return (
+            self._nominal_descriptor_url_prefix_for_query(query) + '/' +
+            filename
+        )
+
+    def _load_descriptor_from_url(self, url):
+        try:
+            descriptor_yaml = self._fs.read_bytes(url).decode('utf8')
+            return ArtifactDescriptor.from_yaml(descriptor_yaml)
+        except Exception as e:
+            raise InternalCacheStateError.from_failure(
+                'descriptor', url, e)
+
+    def _create_and_write_descriptor(self, query, artifact_url):
         descriptor = ArtifactDescriptor.from_content(
-            entity_name=self._query.entity_name,
-            value_filename=value_filename,
-            provenance=self._query.provenance,
-        )
-        descriptor_path = working_dir / DESCRIPTOR_FILENAME
-        descriptor_path.write_text(descriptor.to_yaml())
-
-    def _load_result_from_dir(
-            self, working_dir, data_originated_in_cloud=False):
-        try:
-            descriptor_path = working_dir / DESCRIPTOR_FILENAME
-            if not descriptor_path.is_file():
-                raise InvalidCacheStateError(
-                    "Couldn't find descriptor file: %s" %
-                    DESCRIPTOR_FILENAME)
-
-            descriptor_yaml = descriptor_path.read_text()
-            try:
-                descriptor = ArtifactDescriptor.from_yaml(descriptor_yaml)
-            except YamlRecordParsingError as e:
-                raise_chained(
-                    InvalidCacheStateError,
-                    "Couldn't parse descriptor file",
-                    e)
-
-            value_filename = descriptor.value_filename
-            value_path = working_dir / value_filename
-            extension = value_path.name[len(VALUE_FILENAME_STEM):]
-
-            try:
-                value = self._query.protocol.read(value_path, extension)
-            except UnsupportedSerializedValueError:
-                raise
-            except Exception as e:
-                raise_chained(
-                    InvalidCacheStateError,
-                    "Unable to load value %s due to %s" % (
-                        self._query.task_key, e.__class__.__name__),
-                    e)
-
-        except InvalidCacheStateError as e:
-            problem_sources = [
-                str(self._local_cache.get_real_path(self._virtual_path))]
-            if data_originated_in_cloud:
-                problem_sources.append(
-                    self._cloud_cache.get_url(self._virtual_path))
-
-            raise_chained(
-                InvalidCacheStateError,
-                "Cached data was in an invalid state; "
-                "this should be impossible but could have resulted from "
-                "either a bug or a change to the cached files.  You "
-                "should be able to repair the problem by removing %s." % (
-                    ' and '.join(problem_sources)),
-                e)
-
-        result = Result(
-            query=self._query,
-            value=value,
-            local_cache_path=value_path,
+            entity_name=query.entity_name,
+            artifact_url=artifact_url,
+            provenance=query.provenance,
         )
 
-        return result
+        descriptor_url = self._exact_descriptor_url_for_query(query)
+
+        self._fs.write_bytes(
+            descriptor.to_yaml().encode('utf8'), descriptor_url)
+
+        return descriptor_url
 
 
-class LocalFileCache(object):
+class LocalStore(object):
     """
-    Replicates files to another location on the local filesystem.
-    """
-
-    def __init__(self, root_path):
-        self.root_path = root_path
-
-    def has_dir(self, virtual_path):
-        """Checks whether a directory is present in the cache."""
-        dir_path = self.root_path / virtual_path
-        return dir_path.is_dir()
-
-    def move_in(self, virtual_path, src_path):
-        """
-        Moves a directory into the cache filesystem.
-        """
-
-        dst_path = self.root_path / virtual_path
-        if dst_path.is_file():
-            dst_path.unlink()
-        dst_path.mkdir(parents=True, exist_ok=True)
-
-        src_path.rename(dst_path)
-
-    def get_real_path(self, virtual_path):
-        """Returns the real path corresponding to the provided virtual path."""
-        return self.root_path / virtual_path
-
-
-def normalize_path(path):
-    """
-    Convert a Path to a slash-separated string, suitable for use in cloud
-    object names.  (We don't just use ``str(path)`` because our paths might
-    look different if we ever run on Windows.)
-    """
-    return str(PurePosixPath(path))
-
-
-class GcsFileCache(object):
-    """
-    Replicates files to and from Google Cloud Storage.
+    Represents the local disk cache.  Provides both an Inventory that manages
+    artifact (file) URLs, and a method to generate those URLs (for creating
+    new files).
     """
 
-    DIR_MARKER_NAME = '__dir_marker__'
-    DIR_MARKER_CONTENTS = textwrap.dedent('''
-    The presence of this file indicates that the containing directory
-    has been completely and successfully written.
-    ''')
+    def __init__(self, root_path_str):
+        root_path = Path(root_path_str).absolute()
+        self._artifact_root_path = root_path / 'artifacts'
+
+        inventory_root_path = root_path / 'inventory'
+        self.inventory = Inventory(
+            'local disk', 'local', LocalFilesystem(inventory_root_path))
+
+    def generate_unique_dir_path(self, query):
+        n_attempts = 0
+        while True:
+            # TODO This path can be anything as long as it's unique, so we
+            # could make it more human-readable.
+            path = self._artifact_root_path / query.entity_name / str(uuid4())
+
+            if not path.exists():
+                return path
+            else:
+                n_attempts += 1
+                if n_attempts > 3:
+                    raise AssertionError(
+                        "Repeatedly failed to randomly generate a novel "
+                        "directory name; %r already exists" % str(path))
+
+
+class GcsCloudStore(object):
+    """
+    Represents the GCS cloud cache.  Provides both an Inventory that manages
+    artifact (blob) URLs, and a method to generate those URLs (for creating
+    those blobs).
+    """
 
     def __init__(self, url):
-        URL_PREFIX = 'gs://'
-        if not url.startswith(URL_PREFIX):
-            raise ValueError('url must start with "%s"' % URL_PREFIX)
-        url_parts = url[len(URL_PREFIX):].split('/', 1)
-        if len(url_parts) == 1:
-            bucket_name, = url_parts
-            object_prefix = ''
+        self._tool = GcsTool(url)
+
+        self.inventory = Inventory(
+            'GCS', 'cloud', GcsFilesystem(self._tool, '/inventory'))
+        self._artifact_root_url_prefix = url + '/artifacts'
+
+    def generate_unique_url_prefix(self, query):
+        n_attempts = 0
+        while True:
+            # TODO This path can be anything as long as it's unique, so we
+            # could make it more human-readable.
+            url_prefix = '/'.join([
+                str(self._artifact_root_url_prefix),
+                query.entity_name,
+                str(uuid4()),
+            ])
+
+            matching_blobs = self._tool.blobs_matching_url_prefix(url_prefix)
+            if len(list(matching_blobs)) == 0:
+                return url_prefix
+            else:
+                n_attempts += 1
+                if n_attempts > 3:
+                    raise AssertionError(
+                        "Repeatedly failed to randomly generate a novel "
+                        "blob name; %s already exists" % (
+                            self._artifact_root_url_prefix))
+
+    def upload(self, path, url):
+        # TODO For large individual files, we may still want to use gsutil.
+        if path.is_dir():
+            self._tool.gsutil_cp(str(path), url)
         else:
-            bucket_name, object_prefix = url_parts
+            assert path.is_file()
+            self._tool.blob_from_url(url).upload_from_filename(str(path))
+
+    def download(self, path, url):
+        blob = self._tool.blob_from_url(url)
+        # TODO For large individual files, we may still want to use gsutil.
+        if not blob.exists():
+            # `gsutil cp -r gs://A/B X/Y` doesn't work when B contains
+            # multiple files and Y doesn't exist yet.  However, if B == Y, we
+            # can run `gsutil cp -r gs://A/B X`, which will create Y for us.
+            assert path.name == blob.name.rsplit('/', 1)[1]
+            self._tool.gsutil_cp(url, str(path.parent))
+        else:
+            blob.download_to_filename(str(path))
+
+
+class FakeCloudStore(LocalStore):
+    """
+    A mock version of the GcsCloudStore that's actually backed by local files.
+    Useful for running tests without setting up a GCS connection, which is
+    slow and requires some configuration.
+    """
+
+    def __init__(self, root_path_str):
+        super(FakeCloudStore, self).__init__(root_path_str)
+
+    def generate_unique_url_prefix(self, query):
+        return url_from_path(self.generate_unique_dir_path(query))
+
+    def upload(self, path, url):
+        src_path = path
+        dst_path = path_from_url(url)
+
+        recursive_file_copy(src_path, dst_path)
+
+    def download(self, path, url):
+        src_path = path_from_url(url)
+        dst_path = path
+
+        recursive_file_copy(src_path, dst_path)
+
+
+class LocalFilesystem(object):
+    """
+    Implements a generic "FileSystem" interface for reading/writing small files
+    to local disk.
+    """
+
+    def __init__(self, inventory_dir):
+        self.root_url = url_from_path(inventory_dir)
+
+    def exists(self, url):
+        return path_from_url(url).exists()
+
+    def search(self, url_prefix):
+        path_prefix = path_from_url(url_prefix)
+        if not path_prefix.is_dir():
+            return []
+
+        return [
+            url_from_path(path_prefix / sub_path)
+            for sub_path in path_prefix.glob('**/*')
+        ]
+
+    def write_bytes(self, content_bytes, url):
+        path = path_from_url(url)
+        ensure_parent_dir_exists(path)
+        working_dir = Path(tempfile.mkdtemp(dir=str(path.parent)))
+        try:
+            working_path = working_dir / 'tmp_file'
+            working_path.write_bytes(content_bytes)
+
+            working_path.rename(path)
+
+        finally:
+            shutil.rmtree(str(working_dir))
+
+    def read_bytes(self, url):
+        return path_from_url(url).read_bytes()
+
+
+class GcsFilesystem(object):
+    """
+    Implements a generic "FileSystem" interface for reading/writing small files
+    to GCS.
+    """
+
+    def __init__(self, gcs_tool, object_prefix_extension):
+        self._tool = gcs_tool
+        self.root_url = self._tool.url + object_prefix_extension
+
+    def exists(self, url):
+        return self._tool.blob_from_url(url).exists()
+
+    def search(self, url_prefix):
+        return [
+            self._tool.url_from_object_name(blob.name)
+            for blob in self._tool.blobs_matching_url_prefix(url_prefix)
+        ]
+
+    def write_bytes(self, content_bytes, url):
+        self._tool.blob_from_url(url).upload_from_string(content_bytes)
+
+    def read_bytes(self, url):
+        return self._tool.blob_from_url(url).download_as_string()
+
+
+class GcsTool(object):
+    """
+    A helper object providing utility methods for accessing a GCS.  Maintains
+    a GCS client, and a prefix defining a default namespace to read/write on.
+    """
+
+    _GS_URL_PREFIX = 'gs://'
+
+    def __init__(self, url):
+        if url.endswith('/'):
+            url = url[:-1]
+        self.url = url
+        bucket_name, object_prefix =\
+            self._bucket_and_object_names_from_url(url)
 
         logger.info('Initializing GCS client ...')
-        client = get_gcs_client_without_warnings()
-
-        self._bucket = client.get_bucket(bucket_name)
-        if not object_prefix.endswith('/'):
-            object_prefix = object_prefix + '/'
+        self._client = get_gcs_client_without_warnings()
+        self._bucket = self._client.get_bucket(bucket_name)
         self._object_prefix = object_prefix
 
-    def has_dir(self, virtual_path):
-        """Checks whether a directory is present in the cache."""
-        return self._marker_blob(virtual_path).exists()
+    def blob_from_url(self, url):
+        object_name = self._validated_object_name_from_url(url)
+        return self._bucket.blob(object_name)
 
-    def copy_in(self, virtual_path, src_path):
-        """
-        Copies the contents of a directory to GCS.
+    def url_from_object_name(self, object_name):
+        return self._GS_URL_PREFIX + self._bucket.name + '/' + object_name
 
-        This uses gsutils rsync, but also adds a special marker blob to
-        indicate that a sync has been successfully completed.  (Otherwise,
-        if the rsync termined in the middle of an upload, there would be no
-        way to tell that the uploaded objects were incomplete.)
-        """
+    def blobs_matching_url_prefix(self, url_prefix):
+        obj_prefix = self._validated_object_name_from_url(url_prefix)
+        return self._bucket.list_blobs(prefix=obj_prefix)
 
-        if (src_path / self.DIR_MARKER_NAME).exists():
-            raise ValueError(
-                "Found a file with the special name %r; we can't cache this" %
-                self.DIR_MARKER_NAME)
-
-        self._gsutil_rsync(
-            src_url=str(src_path),
-            dst_url=self.get_url(virtual_path),
-        )
-
-        self._marker_blob(virtual_path).upload_from_string(
-            self.DIR_MARKER_CONTENTS)
-
-    def copy_out(self, virtual_path, dst_path):
-        """Copies a cached directory into a local file directory."""
-        dst_path.mkdir(parents=True, exist_ok=True)
-        self._gsutil_rsync(
-            src_url=self.get_url(virtual_path),
-            dst_url=str(dst_path),
-        )
-
-    def get_url(self, virtual_path):
-        """Returns a ``gs://` URL corresponding to a virtual path."""
-        return 'gs://%s/%s' % (
-            self._bucket.name,
-            normalize_path(self._object_prefix + str(virtual_path) + '/'))
-
-    def _gsutil_rsync(self, src_url, dst_url):
+    def gsutil_cp(self, src_url, dst_url):
         args = [
             'gsutil',
             '-q',  # Don't log anything but errors.
             '-m',  # Transfer files in paralle.
-            'rsync',
-            '-d',  # Delete any items in the dst dir that aren't in the src dir.
-            '-R',  # Recursively sync sub-directories.
+            'cp',
+            '-r',  # Recursively sync sub-directories.
             src_url, dst_url
         ]
         logger.debug('Running command: %s' % ' '.join(args))
         subprocess.check_call(args)
         logger.debug('Finished running gsutil')
 
-    def _marker_blob(self, virtual_path):
-        return self._bucket.blob(
-            self._object_prefix +
-            normalize_path(virtual_path / self.DIR_MARKER_NAME)
-        )
+    def _validated_object_name_from_url(self, url):
+        bucket_name, object_name = self._bucket_and_object_names_from_url(url)
+        assert bucket_name == self._bucket.name
+        assert object_name.startswith(self._object_prefix)
+        return object_name
+
+    def _bucket_and_object_names_from_url(self, url):
+        if not url.startswith(self._GS_URL_PREFIX):
+            raise ValueError('url must start with "%s"' % self._GS_URL_PREFIX)
+        url_parts = url[len(self._GS_URL_PREFIX):].split('/', 1)
+        if len(url_parts) == 1:
+            bucket_name, = url_parts
+            object_prefix = ''
+        else:
+            bucket_name, object_prefix = url_parts
+
+        return bucket_name, object_prefix
+
+
+class InternalCacheStateError(Exception):
+    """
+    Indicates a problem with the integrity of our cached data.  Before this is
+    surfaced to a user, it should be converted to an InvalidCacheStateError.
+    """
+
+    @classmethod
+    def from_failure(cls, artifact_type, location, exc):
+        return cls(
+            "Unable to read %s %r in cache: %s" % (
+                artifact_type, location, exc))
 
 
 class InvalidCacheStateError(Exception):
-    pass
+    """
+    Indicates that the cache state may have been corrupted.
+    """
 
 
-CACHE_SCHEMA_VERSION = 2
+CACHE_SCHEMA_VERSION = 3
 
 if six.PY2:
     PYTHON_MAJOR_VERSION = 2
@@ -380,114 +793,243 @@ else:
     raise AssertionError("Can't figure out what Python version we're using")
 
 
-class YamlDictRecord(object):
-    """
-    A base class for classes wrapping a simple dictionary that can easily
-    be converted to/from YAML.
-    """
-
-    @classmethod
-    def from_yaml(cls, yaml_str):
-        return cls(yaml_str=yaml_str)
-
-    def __init__(self, body_dict=None, yaml_str=None):
-        check_exactly_one_present(body_dict=body_dict, yaml_str=yaml_str)
-
-        if body_dict is not None:
-            self._body_dict = body_dict
-            self._yaml_str = yaml.dump(
-                body_dict,
-                default_flow_style=False,
-                encoding=None,
-                sort_keys=True,
-                Dumper=YamlDumper,
-            )
-        else:
-            try:
-                self._body_dict = yaml.load(yaml_str, Loader=YamlLoader)
-            except yaml.error.YAMLError as e:
-                raise_chained(
-                    YamlRecordParsingError,
-                    "Couldn't parse %s: %s" % self.__class__.__name__,
-                    e)
-            self._yaml_str = yaml_str
-
-    def to_yaml(self):
-        return self._yaml_str
-
-    def to_dict(self):
-        return self._body_dict
-
-
 class YamlRecordParsingError(Exception):
     pass
 
 
-class ArtifactDescriptor(YamlDictRecord):
+class ArtifactDescriptor(object):
     """
     Describes a persisted artifact.  Intended to be stored as a YAML file.
     """
 
     @classmethod
-    def from_content(cls, entity_name, value_filename, provenance):
+    def from_content(cls, entity_name, artifact_url, provenance):
         return cls(body_dict=dict(
             entity=entity_name,
-            filename=value_filename,
+            artifact_url=artifact_url,
             provenance=provenance.to_dict(),
         ))
 
-    def __init__(self, body_dict=None, yaml_str=None):
-        super(ArtifactDescriptor, self).__init__(body_dict, yaml_str)
-
+    @classmethod
+    def from_yaml(cls, yaml_str):
         try:
-            self.entity_name = self.to_dict()['entity']
-            self.value_filename = self.to_dict()['filename']
-        except KeyError as e:
+            body_dict = yaml.load(yaml_str, Loader=YamlLoader)
+        except yaml.error.YAMLError as e:
             raise_chained(
                 YamlRecordParsingError,
-                "YAML for ArtifactDescriptor was missing field",
+                "Couldn't parse %s" % cls.__name__,
                 e)
+        return cls(body_dict=body_dict)
 
-    def is_valid(self):
-        cache_schema_version =\
-            self.to_dict()['provenance']['cache_schema_version']
-        return cache_schema_version == CACHE_SCHEMA_VERSION
+    def __init__(self, body_dict):
+        try:
+            self._dict = body_dict
+            self.entity_name = self._dict['entity']
+            self.artifact_url = self._dict['artifact_url']
+            self.provenance = Provenance.from_dict(self._dict['provenance'])
+        except KeyError as e:
+            raise YamlRecordParsingError(
+                "YAML for ArtifactDescriptor was missing field: %s" % e)
+
+    def to_yaml(self):
+        return yaml.dump(
+            self._dict,
+            default_flow_style=False,
+            encoding=None,
+            sort_keys=True,
+            Dumper=YamlDumper,
+        )
 
     def __repr__(self):
         return 'ArtifactDescriptor(%s)' % self.entity_name
 
 
-class Provenance(YamlDictRecord):
+class Provenance(object):
     """
-    A compact, unique hash of a (possibly yet-to-be-computed) value.
-    Can be used to determine whether a value needs to be recomputed.
+    Describes the code and data used to generate (possibly-yet-to-be-computed)
+    value.  Provides a set of hashes that can be used to determine if two
+    such values are meaningfully different, without actually examining the
+    values.
+
+    Provenances can "match" at several different levels of precision.
+
+    1. Functional match: all input data is the same, and all functions involved
+    in the computation have matching major versions.  This is the lowest level
+    of matching, but it's a sufficient condition to treat two artifacts as
+    interchangeable.  The only purpose of the higher levels is to allow
+    recursive searches for possible versioning errors, where the user has
+    changed a function's bytecode but failed to update its version.
+
+    2. Nominal match: as above, plus the function that computes this value has
+    a matching minor version.  If two provenances don't nominally match, then
+    they have different versions, which means this particular entity doesn't
+    have a versioning error (although its dependencies might or might not).
+
+    3. "Samecode" match: as above, plus the function that computes this value
+    has matching bytecode.  If two provenances are a nominal match but not
+    a samecode match, that suggests the user may have made a versioning error
+    in this entity.
+
+    4. Exact match: as above, plus all dependencies exactly match.  If two
+    provenances exactly match, then there is no chance of any versioning error
+    anywhere in this entity's dependency tree.
     """
 
     @classmethod
-    def from_computation(cls, code_id, case_key, dep_provenances_by_task_key):
-        return cls(body_dict=dict(
+    def from_computation(
+            cls, code_descriptor, case_key, dep_provenances_by_task_key,
+            treat_bytecode_as_functional):
+        dep_task_key_provenance_pairs = sorted(
+            dep_provenances_by_task_key.items())
+
+        functional_code_dict = dict(
+            orig_flow_name=code_descriptor.orig_flow_name,
+            code_version_major=code_descriptor.version.major,
             cache_schema_version=CACHE_SCHEMA_VERSION,
             python_major_version=PYTHON_MAJOR_VERSION,
-            code_id=code_id,
-            case_key=dict(case_key),
-            dependencies=[
-                dict(
-                    entity=task_key.entity_name,
-                    case_key=dict(task_key.case_key),
-                    provenance=provenance.hashed_value,
-                )
-                for task_key, provenance
-                # We need to sort this to make sure our final YAML has
-                # deterministic contents.  (When we write to YAML, dict entries
-                # are automatically sorted by sort_keys, but lists will keep
-                # their original order.)
-                in sorted(dep_provenances_by_task_key.items())
-            ],
+        )
+        nonfunctional_code_dict = dict(
+            code_version_minor=code_descriptor.version.minor,
+        )
+
+        bytecode_hash = code_descriptor.bytecode_hash
+        if treat_bytecode_as_functional:
+            functional_code_dict['bytecode_hash'] = bytecode_hash
+        else:
+            nonfunctional_code_dict['bytecode_hash'] = bytecode_hash
+
+        full_code_dict = dict(
+            functional=functional_code_dict,
+            nonfunctional=nonfunctional_code_dict,
+            bytecode_hash=bytecode_hash,
+        )
+        functional_deps_list = [
+            dict(
+                entity=task_key.entity_name,
+                case_key=dict(task_key.case_key),
+                provenance_hash=provenance.functional_hash,
+            )
+            for task_key, provenance in dep_task_key_provenance_pairs
+        ]
+        exact_deps_list = [
+            dict(
+                entity=task_key.entity_name,
+                case_key=dict(task_key.case_key),
+                provenance_hash=provenance.exact_hash,
+            )
+            for task_key, provenance in dep_task_key_provenance_pairs
+        ]
+
+        exact_deps_hash = hash_simple_obj_to_hex(exact_deps_list)
+        functional_hash = hash_simple_obj_to_hex(dict(
+            code=functional_code_dict,
+            deps=functional_deps_list,
+        ))
+        exact_hash = hash_simple_obj_to_hex(dict(
+            code=full_code_dict,
+            deps=exact_deps_list,
         ))
 
-    def __init__(self, body_dict=None, yaml_str=None):
-        super(Provenance, self).__init__(body_dict, yaml_str)
-        self.hashed_value = hash_to_hex(self.to_yaml().encode('utf-8'))
+        return cls(body_dict=dict(
+            case_key=dict(case_key),
+            code=full_code_dict,
+            functional_deps=functional_deps_list,
+            functional_hash=functional_hash,
+            exact_hash=exact_hash,
+            exact_deps_hash=exact_deps_hash,
+        ))
+
+    @classmethod
+    def from_dict(cls, body_dict):
+        return cls(body_dict=body_dict)
+
+    def __init__(self, body_dict=None):
+        self._dict = body_dict
+
+        d = self._dict
+
+        self.functional_hash = d['functional_hash']
+        self.exact_hash = d['exact_hash']
+        self.exact_deps_hash = d['exact_deps_hash']
+        self.code_version_major = d['code']['functional']['code_version_major']
+        self.code_version_minor =\
+            d['code']['nonfunctional']['code_version_minor']
+        self.bytecode_hash = d['code']['bytecode_hash']
+
+    def to_dict(self):
+        return self._dict
 
     def __repr__(self):
-        return 'Provenance(%s...)' % self.hashed_value[:8]
+        return 'Provenance[%s/%s.%s/%s]' % (
+            self.functional_hash[:8],
+            self.code_version_major, self.code_version_minor,
+            self.exact_hash[:8])
+
+    def exactly_matches(self, prov):
+        return self.exact_hash == prov.exact_hash
+
+    def dependencies_exactly_match(self, prov):
+        return self.exact_deps_hash == prov.exact_deps_hash
+
+
+# Helpers for managing files.
+FILE_URL_PREFIX = 'file://'
+
+
+def path_from_url(url):
+    assert url.startswith(FILE_URL_PREFIX), url
+    return Path(url[len(FILE_URL_PREFIX):])
+
+
+def url_from_path(path):
+    return FILE_URL_PREFIX + str(path)
+
+
+def recursive_file_copy(src_path, dst_path):
+    ensure_parent_dir_exists(dst_path)
+    if src_path.is_file():
+        shutil.copy(str(src_path), str(dst_path))
+    else:
+        shutil.copytree(str(src_path), str(dst_path))
+
+
+# Helpers for generating hashes from objects.
+def hash_simple_obj_to_hex(obj):
+    """
+    Generates a hash digest of an object, as a hex string.  The object must
+    be a "simple" type, i.e., of one of the following types: None, text, bytes,
+    int, or a list or dict of simple types.
+    """
+
+    hash_ = sha256()
+    try:
+        update_hash(hash_, obj)
+    except ValueError as e:
+        raise ValueError("%s (full object was %r)" % (e, obj))
+    return hash_.hexdigest()
+
+
+def update_hash(hash_, obj):
+    if obj is None:
+        hash_.update(b'N')
+    elif isinstance(obj, six.text_type):
+        hash_.update(b'S')
+        hash_.update(obj.encode('utf8'))
+    elif isinstance(obj, six.binary_type):
+        hash_.update(b'B')
+        hash_.update(obj.encode('utf8'))
+    elif isinstance(obj, int):
+        hash_.update(b'I')
+        hash_.update(str(obj).encode('utf8'))
+    elif isinstance(obj, list):
+        hash_.update(b'L')
+        for item in obj:
+            update_hash(hash_, item)
+    elif isinstance(obj, dict):
+        hash_.update(b'D')
+        for key, value in obj.items():
+            update_hash(hash_, key)
+            update_hash(hash_, value)
+    else:
+        raise ValueError("Unable to hash object %r of type %r" % (
+            obj, type(obj)))

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -6,6 +6,8 @@ from __future__ import absolute_import
 from builtins import object
 from collections import namedtuple
 
+import six
+
 from .util import ImmutableSequence, ImmutableMapping
 
 
@@ -77,10 +79,10 @@ class Result(object):
     Represents one value for one entity.
     '''
     def __init__(
-            self, query, value, local_cache_path=None):
+            self, query, value, file_path=None):
         self.query = query
         self.value = value
-        self.local_cache_path = local_cache_path
+        self.file_path = file_path
 
     def __repr__(self):
         return 'Result(%r, %r)' % (self.query, self.value)
@@ -202,3 +204,42 @@ class ResultGroup(ImmutableSequence):
 
     def __repr__(self):
         return 'ResultGroup(%r)' % list(self)
+
+
+class CodeVersion(object):
+    '''
+    Contains the user-designated version of a piece of code, consisting of a
+    major and a minor version string.  The convention is that changing the
+    major version indicates a functional change, while changing the minor
+    version indicates a nonfunctional change.
+    '''
+
+    def __init__(self, major, minor):
+        self.major = str_from_version_value(major)
+        self.minor = str_from_version_value(minor)
+
+    def __repr__(self):
+        return 'CodeVersion(%r, %r)' % (self.major, self.minor)
+
+
+def str_from_version_value(value):
+    if value is None:
+        return '0'
+    elif isinstance(value, int):
+        return str(value)
+    elif isinstance(value, six.text_type):
+        return value
+    else:
+        raise ValueError(
+            "Version values must be str, int, or None: got %r" % value)
+
+
+# Describes the code of a function.
+CodeDescriptor = namedtuple(
+    'CodeDescriptor', 'version bytecode_hash orig_flow_name')
+
+
+# Encodes the versioning rules to use when computing entity values.
+VersioningPolicy = namedtuple(
+    'VersioningPolicy',
+    'check_for_bytecode_errors treat_bytecode_as_functional')

--- a/bionic/exception.py
+++ b/bionic/exception.py
@@ -21,3 +21,7 @@ class IncompatibleEntityError(ValueError):
 
 class UnsupportedSerializedValueError(Exception):
     pass
+
+
+class CodeVersioningError(Exception):
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,25 @@ def builder(tmp_path):
     builder.set(
         'core__persistent_cache__flow_dir', str(tmp_path / 'BNTESTDATA'))
     return builder
+
+
+# These three functions add a --slow command line option to enable slow tests.
+# Seems involved, but it's the approach recommended in the pytest docs.
+def pytest_addoption(parser):
+    parser.addoption(
+        '--slow', action='store_true', default=False, help='run slow tests'
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'slow: mark test as slow to run')
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption('--slow'):
+        # If the option is present, don't skip slow tests.
+        return
+    skip_slow = pytest.mark.skip(reason='only runs when --slow is set')
+    for item in items:
+        if 'slow' in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -88,6 +88,24 @@ def count_calls(func):
     return wrapped
 
 
+class ResettingCounter(object):
+    """
+    A class for manually counting the number of times something happens.
+    Used mainly in situations whre ``count_calls`` can't be used.
+    """
+
+    def __init__(self):
+        self._count = 0
+
+    def mark(self):
+        self._count += 1
+
+    def times_called(self):
+        count = self._count
+        self._count = 0
+        return count
+
+
 class RoundingProtocol(bn.protocols.BaseProtocol):
     def get_fixed_file_extension(self):
         return 'round'

--- a/tests/test_flow/test_merge.py
+++ b/tests/test_flow/test_merge.py
@@ -147,6 +147,8 @@ def merge_tester(builder):
         'FixedJoint',
         f.declaring('x').declaring('y').adding_case('x', 7, 'y', 8))
 
+    # TODO This builder doesn't use a temp directory for its cache, so it may
+    # pick up cached data from previous tests.  That's bad!
     f = bn.FlowBuilder('new_flow').build()
     tester.add('M', f)
     tester.add('D', f.declaring('x'))

--- a/tests/test_flow/test_persistence_fuzz.py
+++ b/tests/test_flow/test_persistence_fuzz.py
@@ -1,0 +1,341 @@
+import pytest
+
+from textwrap import dedent
+from random import Random
+
+from bionic.cache import FakeCloudStore
+from bionic.exception import CodeVersioningError
+from bionic import interpret
+import bionic as bn
+
+
+class SimpleFlowModel(object):
+    """
+    Manages a simple Bionic flow where every entity value is an integer
+    computed from the sum of other entity values.  This wrapper class maintains
+    both the Bionic flow and a parallel model that can predict what the Bionic
+    flow should be doing.  This can be used to generate, manipulate, and
+    validate large flows.
+    """
+
+    def __init__(self, builder):
+        self._builder = builder
+
+        self._entities_by_name = {}
+        self._last_called_names = []
+
+    def add_entity(self, dep_names):
+        name = 'e%d' % (len(self._entities_by_name) + 1)
+
+        self._create_entity(name, dep_names)
+        self._define_entity(name)
+
+        return name
+
+    def update_entity(
+            self, name, make_func_change=False, make_nonfunc_change=False,
+            update_major=False, update_minor=False):
+
+        entity = self._entities_by_name[name]
+
+        if make_func_change:
+            entity.func_value += 1
+        if make_nonfunc_change:
+            entity.nonfunc_value += 1
+        if update_major:
+            entity.major_version += 1
+        if update_minor:
+            entity.minor_version += 1
+
+        self._define_entity(name)
+
+    def build_flow(self):
+        return self._builder.build()
+
+    def expected_entity_value(self, name):
+        entity = self._entities_by_name[name]
+        dep_values_total = sum(
+            self.expected_entity_value(dep_name)
+            for dep_name in entity.dep_names
+        )
+        return entity.func_value + dep_values_total
+
+    def entity_names(
+            self, downstream_of=None, upstream_of=None, with_children=None):
+        names = set(self._entities_by_name.keys())
+
+        if upstream_of is not None:
+            bot_names = interpret.str_or_seq_as_list(upstream_of)
+
+            upstream_names = set()
+            for bot_name in bot_names:
+                bot_entity = self._entities_by_name[bot_name]
+                upstream_names |= bot_entity.all_upstream_names
+
+            names = names & upstream_names
+
+        if downstream_of is not None:
+            top_names = interpret.str_or_seq_as_list(downstream_of)
+
+            downstream_names = set()
+            for top_name in top_names:
+                top_entity = self._entities_by_name[top_name]
+                downstream_names |= top_entity.all_downstream_names
+
+            names = names & downstream_names
+
+        if with_children is not None:
+            names_with_children = set(
+                name for name in names
+                if len(self._entities_by_name[name].child_names) > 0
+            )
+            if with_children:
+                names = names_with_children
+            else:
+                names -= names_with_children
+
+        return list(sorted(names))
+
+    def called_entity_names(self):
+        names = list(self._last_called_names)
+        while self._last_called_names:
+            self._last_called_names.pop()
+        return names
+
+    def _create_entity(self, name, dep_names):
+        entity = ModelEntity(name=name, dep_names=dep_names)
+
+        entity.all_upstream_names = {name}
+        for dep_name in dep_names:
+            dep_entity = self._entities_by_name[dep_name]
+            entity.all_upstream_names.update(dep_entity.all_upstream_names)
+            dep_entity.child_names.append(name)
+        entity.all_downstream_names = {name}
+
+        self._entities_by_name[name] = entity
+        for anc_name in entity.all_upstream_names:
+            anc_entity = self._entities_by_name[anc_name]
+            anc_entity.all_downstream_names.add(name)
+
+    def _define_entity(self, name):
+        entity = self._entities_by_name[name]
+
+        vars_dict = {
+            'bn': bn,
+            'builder': self._builder,
+            'record_call': self._last_called_names.append,
+            'noop_func': lambda x: None,
+        }
+
+        exec(
+            dedent('''
+            @builder
+            @bn.version(major={major}, minor={minor})
+            def {name}({dep_names_str}):
+                noop_func({nonfunc_value})
+                record_call("{name}")
+                return {return_expr}
+            '''.format(
+                major=entity.major_version,
+                minor=entity.minor_version,
+                name=name,
+                dep_names_str=', '.join(entity.dep_names),
+                nonfunc_value=entity.nonfunc_value,
+                return_expr=' + '.join(
+                    [str(entity.func_value)] +
+                    entity.dep_names
+                ),
+            )),
+            vars_dict,
+        )
+
+
+class ModelEntity(object):
+    """
+    Represents one entity in the SimpleFlowModel.
+    """
+
+    def __init__(self, name, dep_names):
+        self.name = name
+        self.dep_names = dep_names
+
+        self.major_version = 0
+        self.minor_version = 0
+        self.func_value = 0
+        self.nonfunc_value = 0
+
+        self.child_names = []
+        self.all_upstream_names = set()
+        self.all_downstream_names = set()
+
+
+class Fuzzer(object):
+    """
+    Randomly constructs and updates a SimpleModelFlow while checking that its
+    behavior is as expected.
+    """
+
+    def __init__(self, builder, random_seed=0):
+        self.model = SimpleFlowModel(builder)
+        self._versioning_mode = 'manual'
+        self._builder = builder
+        self._random = Random(random_seed)
+
+    def set_versioning_mode(self, mode):
+        self._builder.set('core__versioning_mode', mode)
+        self._versioning_mode = mode
+
+    def add_entities(self, n_entities):
+        for i in range(n_entities):
+            all_names = self.model.entity_names()
+
+            dep_names = []
+            for name in all_names:
+                if self._random_bool():
+                    dep_names.append(name)
+            new_name = self.model.add_entity(dep_names)
+
+            self.model.build_flow().get(new_name)
+            assert self.model.called_entity_names() == [new_name]
+
+    def run(self, n_iterations):
+        for i in range(n_iterations):
+            updated_name = self._random.choice(self.model.entity_names())
+            affected_names = self.model.entity_names(
+                downstream_of=updated_name, with_children=False)
+            make_func_change = self._random_bool()
+            make_nonfunc_change = not make_func_change
+            update_version = self._random_bool()
+
+            self.model.update_entity(
+                updated_name,
+                make_func_change=make_func_change,
+                make_nonfunc_change=make_nonfunc_change,
+                update_major=update_version and make_func_change,
+                update_minor=update_version and make_nonfunc_change,
+            )
+
+            if not update_version:
+                # If we didn't update the version, there's a potential mismatch
+                # between the entity code and Bionic's understanding.  How this
+                # plays out will depend on the versioning mode.
+
+                if self._versioning_mode == 'manual':
+                    # Bionic doesn't know the code has changed, so this entity
+                    # should still be returning the old value.
+                    affected_name = self._random.choice(affected_names)
+                    returned_value = self.model.build_flow().get(affected_name)
+                    expected_value = self.model.expected_entity_value(
+                        affected_name)
+                    if make_func_change:
+                        assert returned_value != expected_value
+                    else:
+                        assert returned_value == expected_value
+
+                    # We should have used the cached value, so no new
+                    # computation should have happened.
+                    assert len(self.model.called_entity_names()) == 0
+
+                    # Now update the version to get the flow back into a
+                    # "correct" state.
+                    self.model.update_entity(
+                        updated_name,
+                        update_major=make_func_change,
+                        update_minor=make_nonfunc_change,
+                    )
+
+                elif self._versioning_mode == 'assist':
+                    # Bionic should detect that we forgot to update the
+                    # version.
+                    affected_name = self._random.choice(affected_names)
+                    with pytest.raises(CodeVersioningError):
+                        self.model.build_flow().get(affected_name)
+
+                    # Now update the version to get the flow back into a
+                    # "correct" state.
+                    self.model.update_entity(
+                        updated_name,
+                        update_major=make_func_change,
+                        update_minor=make_nonfunc_change,
+                    )
+
+                elif self._versioning_mode == 'auto':
+                    # Even if we didn't update the version, Bionic should
+                    # do it for us and the flow should already be in a correct
+                    # state.
+                    pass
+
+                else:
+                    raise AssertionError(
+                        "Unexpected versioning mode: %r" %
+                        self._versioning_mode)
+
+            for affected_name in affected_names:
+                assert (
+                    self.model.build_flow().get(affected_name) ==
+                    self.model.expected_entity_value(affected_name)
+                )
+
+            if make_func_change or self._versioning_mode == 'auto':
+                expected_called_names = self.model.entity_names(
+                    downstream_of=updated_name,
+                    upstream_of=affected_names,
+                )
+                assert (
+                    list(sorted(self.model.called_entity_names())) ==
+                    list(sorted(expected_called_names))
+                )
+            else:
+                assert len(self.model.called_entity_names()) == 0
+
+    def _random_bool(self):
+        return self._random.choice([True, False])
+
+
+@pytest.fixture(scope='function')
+def fuzzer(builder, tmp_path):
+    fake_cloud_store = FakeCloudStore(str(tmp_path / 'BNTESTDATA_FAKE_CLOUD'))
+    builder.set('core__persistent_cache__cloud_store', fake_cloud_store)
+    return Fuzzer(builder)
+
+
+foreach_mode = pytest.mark.parametrize(
+    'versioning_mode', ['manual', 'assist', 'auto'])
+
+
+@foreach_mode
+def test_small_fixed_flow_short_fuzz(fuzzer, versioning_mode):
+    fuzzer.set_versioning_mode(versioning_mode)
+
+    e1 = fuzzer.model.add_entity([])
+    e2 = fuzzer.model.add_entity([])
+    e3 = fuzzer.model.add_entity([e1])
+    e4 = fuzzer.model.add_entity([e1, e2])
+    e5 = fuzzer.model.add_entity([e3, e4])
+
+    assert (
+        fuzzer.model.build_flow().get(e5) ==
+        fuzzer.model.expected_entity_value(e5)
+    )
+    assert (
+        list(sorted(fuzzer.model.called_entity_names())) ==
+        list(sorted(fuzzer.model.entity_names()))
+    )
+
+    fuzzer.run(n_iterations=30)
+
+
+@pytest.mark.slow
+@foreach_mode
+def test_medium_random_flow_long_fuzz(fuzzer, versioning_mode):
+    fuzzer.set_versioning_mode(versioning_mode)
+    fuzzer.add_entities(10)
+    fuzzer.run(n_iterations=100)
+
+
+@pytest.mark.slow
+@foreach_mode
+def test_big_random_flow_medium_fuzz(fuzzer, versioning_mode):
+    fuzzer.set_versioning_mode(versioning_mode)
+    fuzzer.add_entities(20)
+    fuzzer.run(n_iterations=50)

--- a/tests/test_flow/test_persistence_gcs.py
+++ b/tests/test_flow/test_persistence_gcs.py
@@ -4,7 +4,7 @@ the ``BIONIC_GCS_TEST_BUCKET`` environmet variable with the name of a GCS
 bucket you have access to.  Bionic will cache its data to randomly-generated
 prefix in this bucket, and then clean it up after the tests finish.
 
-These tests are pretty slow -- they take about 40 seconds for me.
+These tests are pretty slow -- they take about 60 seconds for me.
 '''
 
 import pytest
@@ -13,7 +13,15 @@ import subprocess
 import getpass
 import shutil
 
-from ..helpers import count_calls, skip_unless_gcs, GCS_TEST_BUCKET
+import six
+import dask.dataframe as dd
+
+from ..helpers import (
+    ResettingCounter, skip_unless_gcs, GCS_TEST_BUCKET, df_from_csv_str,
+    equal_frame_and_index_content)
+from bionic.exception import CodeVersioningError
+
+import bionic as bn
 
 
 # This is detected by pytest and applied to all the tests in this module.
@@ -22,7 +30,7 @@ pytestmark = skip_unless_gcs
 
 def gsutil_wipe_path(url):
     assert 'BNTESTDATA' in url
-    subprocess.check_call(['gsutil', 'rm', '-rf', url])
+    subprocess.check_call(['gsutil', '-q', '-m', 'rm', '-rf', url])
 
 
 def gsutil_path_exists(url):
@@ -45,6 +53,8 @@ def tmp_object_path(bucket_name):
     path_str = '%s/BNTESTDATA/%s' % (getpass.getuser(), random_hex_str)
 
     gs_url = 'gs://%s/%s' % (bucket_name, path_str)
+    # This emits a stderr warning because the URL doesn't exist.  That's
+    # annoying but I wasn't able to find a straightforward way to avoid it.
     assert not gsutil_path_exists(gs_url)
 
     yield path_str
@@ -60,19 +70,30 @@ def gcs_builder(builder, bucket_name, tmp_object_path):
     builder.set('core__persistent_cache__gcs__object_path', tmp_object_path)
     builder.set('core__persistent_cache__gcs__enabled', True)
 
+    builder.set('core__versioning_mode', 'assist')
+
     return builder
 
 
+# This should really be multiple separate tests, but it's expensive to do the
+# setup, teardown, and client initialization, so we'll just do it all in one
+# place.
 def test_gcs_caching(gcs_builder):
+    # Setup.
+
+    call_counter = ResettingCounter()
+
     builder = gcs_builder
 
     builder.assign('x', 2)
     builder.assign('y', 3)
 
     @builder
-    @count_calls
     def xy(x, y):
+        call_counter.mark()
         return x * y
+
+    # Test reading from and writing to GCS cache.
 
     flow = builder.build()
 
@@ -80,28 +101,162 @@ def test_gcs_caching(gcs_builder):
     gcs_cache_url = flow.get('core__persistent_cache__gcs__url')
 
     assert flow.get('xy') == 6
-    assert xy.times_called() == 1
+    assert flow.setting('x', 4).get('xy') == 12
+    assert call_counter.times_called() == 2
 
     flow = builder.build()
 
     assert flow.get('xy') == 6
-    assert xy.times_called() == 0
+    assert flow.setting('x', 4).get('xy') == 12
+    assert call_counter.times_called() == 0
 
     gsutil_wipe_path(gcs_cache_url)
     flow = builder.build()
 
     assert flow.get('xy') == 6
-    assert xy.times_called() == 0
+    assert flow.setting('x', 4).get('xy') == 12
+    assert call_counter.times_called() == 0
 
     local_wipe_path(local_cache_path_str)
     flow = builder.build()
 
     assert flow.get('xy') == 6
-    assert xy.times_called() == 0
+    assert flow.setting('x', 4).get('xy') == 12
+    assert call_counter.times_called() == 0
 
     gsutil_wipe_path(gcs_cache_url)
     local_wipe_path(local_cache_path_str)
     flow = builder.build()
 
     assert flow.get('xy') == 6
-    assert xy.times_called() == 1
+    assert flow.setting('x', 4).get('xy') == 12
+    assert call_counter.times_called() == 2
+
+    # Test versioning.
+    @builder  # noqa: F811
+    def xy(x, y):
+        call_counter.mark()
+        return y * x
+
+    flow = builder.build()
+    with pytest.raises(CodeVersioningError):
+        flow.get('xy')
+
+    local_wipe_path(local_cache_path_str)
+    flow = builder.build()
+    with pytest.raises(CodeVersioningError):
+        flow.get('xy')
+
+    @builder  # noqa: F811
+    @bn.version(minor=1)
+    def xy(x, y):
+        call_counter.mark()
+        return y * x
+
+    flow = builder.build()
+
+    assert flow.get('xy') == 6
+    assert flow.setting('x', 4).get('xy') == 12
+    assert call_counter.times_called() == 0
+
+    local_wipe_path(local_cache_path_str)
+    flow = builder.build()
+
+    assert flow.get('xy') == 6
+    assert flow.setting('x', 4).get('xy') == 12
+    assert call_counter.times_called() == 0
+
+    @builder  # noqa: F811
+    @bn.version(major=1)
+    def xy(x, y):
+        call_counter.mark()
+        return x ** y
+
+    flow = builder.build()
+
+    assert flow.get('xy') == 8
+    assert flow.setting('x', 4).get('xy') == 64
+    assert call_counter.times_called() == 2
+
+    local_wipe_path(local_cache_path_str)
+    flow = builder.build()
+
+    assert flow.get('xy') == 8
+    assert flow.setting('x', 4).get('xy') == 64
+    assert call_counter.times_called() == 0
+
+    # Test indirect versioning.
+    @builder
+    def xy_plus(xy):
+        return xy + 1
+
+    flow = builder.build()
+
+    assert flow.get('xy_plus') == 9
+    assert call_counter.times_called() == 0
+
+    @builder  # noqa: F811
+    @bn.version(major=1)
+    def xy(x, y):
+        call_counter.mark()
+        return int(float(x)) ** y
+
+    flow = builder.build()
+    with pytest.raises(CodeVersioningError):
+        flow.get('xy_plus')
+
+    @builder  # noqa: F811
+    @bn.version(major=1, minor=1)
+    def xy(x, y):
+        call_counter.mark()
+        return int(float(y)) ** x
+
+    flow = builder.build()
+
+    assert flow.get('xy_plus') == 9
+    assert call_counter.times_called() == 0
+
+    @builder  # noqa: F811
+    @bn.version(major=2)
+    def xy(x, y):
+        call_counter.mark()
+        return y ** x
+
+    flow = builder.build()
+
+    assert flow.get('xy_plus') == 10
+    assert call_counter.times_called() == 1
+
+    # Dask only works in Python 3.
+    if six.PY3:
+        # Test multi-file serialization.
+        dask_df = dd.from_pandas(
+            df_from_csv_str(
+                '''
+                color,number
+                red,1
+                blue,2
+                green,3
+                '''),
+            npartitions=1)
+
+        @builder
+        @bn.protocol.dask
+        def df():
+            call_counter.mark()
+            return dask_df
+
+        flow = builder.build()
+
+        assert equal_frame_and_index_content(
+            flow.get('df').compute(), dask_df.compute())
+        assert equal_frame_and_index_content(
+            flow.get('df').compute(), dask_df.compute())
+        assert call_counter.times_called() == 1
+
+        local_wipe_path(local_cache_path_str)
+        flow = builder.build()
+
+        assert equal_frame_and_index_content(
+            flow.get('df').compute(), dask_df.compute())
+        assert call_counter.times_called() == 0


### PR DESCRIPTION
This introduces two new versioning modes: "assist" and "auto".

Assist: Use each function's bytecode to attempt to detect when the user
has forgotten to update the function's version -- if so, throw an
exception.

Auto: Implicitly update each function's version when its bytecode
changes.

These modes are opt-in; they need to be explicitly enabled.  This is
partly because they introduce a large amount of new complexity to the
code base, so we may want to roll them back if they're not helpful and
reliable.