### PR TITLE
Default to `bbox_inches="tight"` when saving plots

### DIFF
--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -205,7 +205,7 @@ def gather(over, also=None, into='gather_df'):
         primary_names=over, secondary_names=also, gathered_dep_name=into)
 
 
-def pyplot(name=None):
+def pyplot(name=None, savefig_kwargs=None):
     """
     Provides a Matplotlib pyplot module to the decorated entity function.
 
@@ -219,6 +219,11 @@ def pyplot(name=None):
     ----------
     name: String, optional (default "pyplot")
         The argument name of the module provided to the decorated function.
+    savefig_kwargs: Dict, optional
+        Additional arguments to pass to `matplotlib.pytplot.savefig` when
+        converting the plot to an image.  By default, passes ``format=png`` and
+        ``bbox_inches="tight"``; any arguments passed in this dict will
+        override the default values.
 
     Returns
     -------
@@ -234,7 +239,7 @@ def pyplot(name=None):
 
     if name is None:
         name = DEFAULT_NAME
-    return provider_wrapper(PyplotProvider, name)
+    return provider_wrapper(PyplotProvider, name, savefig_kwargs)
 
 
 immediate = persist(False)

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -672,7 +672,7 @@ class GatherProvider(WrappingProvider):
 #    process.
 # 3. Try to make Bionic's matplotlib initialization identical to Jupyter's.
 class PyplotProvider(WrappingProvider):
-    def __init__(self, wrapped_provider, name='pyplot'):
+    def __init__(self, wrapped_provider, name='pyplot', savefig_kwargs=None):
         super(PyplotProvider, self).__init__(wrapped_provider)
 
         PIL = import_optional_dependency(
@@ -680,6 +680,13 @@ class PyplotProvider(WrappingProvider):
         self._Image = PIL.Image
 
         self._pyplot_name = name
+
+        self._savefig_kwargs = {
+            'format': 'png',
+            'bbox_inches': 'tight',
+        }
+        if savefig_kwargs is not None:
+            self._savefig_kwargs.update(savefig_kwargs)
 
         inner_dep_names = wrapped_provider.get_dependency_names()
         if self._pyplot_name not in inner_dep_names:
@@ -754,7 +761,7 @@ class PyplotProvider(WrappingProvider):
 
                 # Save the plot into a buffer.
                 bio = BytesIO()
-                plt.savefig(bio, format='png')
+                plt.savefig(bio, **self._savefig_kwargs)
                 plt.close()
                 # Reset the buffer's position so that when we read from it, we
                 # read from the beginning.


### PR DESCRIPTION
This is now configurable via a `savefigs_kwargs` argument to `@pyplot`.

I was modifying some of the examples and I found that when you make the plots fancier, the image is sometimes poorly cropped.  I've usually found this setting to produce good output, but it can always be disabled with the new argument.