### PR TITLE
Fix failure when persisting None values

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -196,10 +196,10 @@ class CacheAccessor(object):
         self._clear_stored_entries()
 
         if result is not None:
-            value = result.value
+            value_wrapper = NullableWrapper(result.value)
             file_path = result.file_path
         else:
-            value = None
+            value_wrapper = None
             file_path = None
 
         blob_url = None
@@ -207,8 +207,8 @@ class CacheAccessor(object):
         if file_path is None:
             if local_entry.has_artifact:
                 file_path = path_from_url(local_entry.artifact_url)
-            elif value is not None:
-                file_path = self._file_from_value(value)
+            elif value_wrapper is not None:
+                file_path = self._file_from_value(value_wrapper.value)
             else:
                 if cloud_entry is None or not cloud_entry.has_artifact:
                     raise AssertionError(
@@ -339,6 +339,12 @@ class CacheAccessor(object):
 
 
 # TODO In Python 3 we can store these comments as docstrings.
+# A simple wrapper for a value that might be None.  We use this when we want
+# to distinguish between "we have a value which is None" from "we don't have a
+# value".
+NullableWrapper = namedtuple('NullableWrapper', 'value')
+
+
 # Represents a saved artifact tracked by an Inventory; returned by Inventory
 # to CacheAccessor.
 InventoryEntry = namedtuple(

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -737,3 +737,14 @@ def test_complex_input_type(builder):
     assert x_plus_y.times_called() == 1
     assert flow.get('x_plus_y', set) == {5, 9}
     assert x_plus_y.times_called() == 0
+
+
+def test_persisting_none(builder):
+    @builder
+    @count_calls
+    def none():
+        return None
+
+    assert builder.build().get('none') is None
+    assert builder.build().get('none') is None
+    assert none.times_called() == 1


### PR DESCRIPTION
The new caching code was failing whenever we tried to persist a None
value; this commit should fix it.

The caching code was getting confused by the difference between "we have
a value which is None" and "we don't have a value at all".  I took a
quick look for other situations where we use this pattern but couldn't
find any -- most of the Bionic code doesn't care about the content of
what's being persisted.

Thanks @damienrj for finding this!