### PR TITLE
Import PIL.Image directly

### DIFF
--- a/bionic/dagviz.py
+++ b/bionic/dagviz.py
@@ -11,7 +11,7 @@ from .optdep import import_optional_dependency
 module_purpose = 'rendering the flow DAG'
 hsluv = import_optional_dependency('hsluv', purpose=module_purpose)
 pydot = import_optional_dependency('pydot', purpose=module_purpose)
-PIL = import_optional_dependency('PIL', purpose=module_purpose)
+Image = import_optional_dependency('PIL.Image', purpose=module_purpose)
 
 
 def hpluv_color_dict(keys, saturation, lightness):
@@ -90,4 +90,4 @@ def image_from_dot(dot):
     '''
     Given a pydot graph object, renders it into a Pillow Image.
     '''
-    return PIL.Image.open(BytesIO(dot.create_png()))
+    return Image.open(BytesIO(dot.create_png()))

--- a/bionic/optdep.py
+++ b/bionic/optdep.py
@@ -24,7 +24,7 @@ def first_token_from_package_desc(desc):
 # aliases we use.
 alias_lists_by_package = {
     'google-cloud-storage': ['google.cloud.storage'],
-    'Pillow': ['PIL', 'PIL.Image'],
+    'Pillow': ['PIL.Image'],
     'dask[dataframe]': ['dask.dataframe']
 }
 

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -675,9 +675,8 @@ class PyplotProvider(WrappingProvider):
     def __init__(self, wrapped_provider, name='pyplot', savefig_kwargs=None):
         super(PyplotProvider, self).__init__(wrapped_provider)
 
-        PIL = import_optional_dependency(
-            'PIL', purpose='the @pyplot decorator')
-        self._Image = PIL.Image
+        self._Image = import_optional_dependency(
+            'PIL.Image', purpose='the @pyplot decorator')
 
         self._pyplot_name = name
 


### PR DESCRIPTION
There were some parts of the code where we were importing `PIL` and then
accessing `PIL.Image`, which only works if you've previously imported
`PIL.Image` directly.  Everything tended to work because of the order in
which things were imported, but it was possible to get things to happen
in the wrong order, which would throw a confusing exception.