### PR TITLE
Support PyYAML 3.13

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -842,7 +842,6 @@ class ArtifactDescriptor(object):
             self._dict,
             default_flow_style=False,
             encoding=None,
-            sort_keys=True,
             Dumper=YamlDumper,
         )
 


### PR DESCRIPTION
We were using the `sort_keys` argument to `yaml.dump`, which was
introduced in PyYAML 5.1.  However, Apache Beam requires `PyYAML<4.0`,
which meant it was impossible to use Bionic with Beam.  Thankfully we no
longer care whether keys are sorted, so I've removed this argument.

(The version of Beam on master no longer has this PyYAML requirement,
but the latest releases (2.15.0, 2.16.0-RC1) still do.)