### PR TITLE
Added memoize decorator to allow in-memory caching to be disabled

### DIFF
--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from .flow import Flow, FlowBuilder  # noqa: F401
 from .decorators import (  # noqa: F401
-    version, output, outputs, gather, persist, pyplot, immediate
+    version, output, outputs, gather, persist, memoize, pyplot, immediate
 )
 
 from . import protocol  # noqa: F401

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -86,6 +86,28 @@ def persist(enabled):
     return provider_wrapper(AttrUpdateProvider, 'should_persist', enabled)
 
 
+def memoize(enabled):
+    """
+    Indicates whether computed values should be cached memoized
+
+    Parameters
+    ----------
+
+    enabled: Boolean
+        Whether this entity's values should be memoized
+
+    Returns
+    -------
+    Function:
+        A decorator which can be applied to an entity function.
+    """
+
+    if not isinstance(enabled, bool):
+        raise ValueError("Argument must be a boolean; got %r" % enabled)
+
+    return provider_wrapper(AttrUpdateProvider, 'should_memoize', enabled)
+
+
 def output(name):
     """
     Renames an entity.  The entity function must have a single value.

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -450,7 +450,6 @@ class EntityDeriver(object):
             }
         task_state.is_complete = True
 
-
     def _get_results_for_complete_task_state(self, task_state):
         assert task_state.is_complete
 
@@ -462,11 +461,9 @@ class EntityDeriver(object):
             result = accessor.load_result()
             self._log(
                 'Loaded      %s from disk cache', result.query.task_key)
-
             results_by_name[result.query.entity_name] = result
 
         return results_by_name
-        
 
     def _compute_task_state(self, task_state):
         assert not task_state.is_blocked()
@@ -517,13 +514,12 @@ class EntityDeriver(object):
                     assert result is not None
 
             results_by_name[query.entity_name] = result
-        
+
         # TODO check if persist is False and memoize is False
         if provider.attrs.should_memoize:
             task_state.results_by_name = results_by_name
-        
-        task_state.is_complete = True
 
+        task_state.is_complete = True
 
     def _log(self, message, *args):
         if self._is_ready_for_full_resolution:
@@ -569,7 +565,6 @@ class TaskState(object):
         self.results_by_name = None
 
         self.is_complete = False
-
 
     def is_blocked(self):
         return not all(parent.is_complete for parent in self.parents)

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -259,7 +259,7 @@ class EntityDeriver(object):
             # If this task is already complete, we don't need to do any work.
             # But if this is this is the first time we've seen this task, we
             # should should log a message .
-            if state.is_complete():
+            if state.is_complete:
                 for task_key in state.task.keys:
                     if task_key not in logged_task_keys:
                         self._log(
@@ -272,12 +272,12 @@ class EntityDeriver(object):
 
             # If we weren't able to load it but it's ready to compute, let's
             # compute it!
-            if not state.is_complete() and not state.is_blocked():
+            if not state.is_complete and not state.is_blocked():
                 self._compute_task_state(state)
 
             # If we successfully loaded or computed it, see if we can unblock
             # its children.
-            if state.is_complete():
+            if state.is_complete:
                 for task_key in state.task.keys:
                     logged_task_keys.add(task_key)
 
@@ -294,11 +294,11 @@ class EntityDeriver(object):
 
         assert len(blocked_task_key_tuples) == 0, blocked_task_key_tuples
         for state in requested_task_states:
-            assert state.is_complete(), state
+            assert state.is_complete, state
 
         return ResultGroup(
             results=[
-                state.results_by_name[entity_name]
+                self._get_results_for_complete_task_state(state)[entity_name]
                 for state in requested_task_states
             ],
             key_space=self._key_spaces_by_entity_name[entity_name],
@@ -443,10 +443,30 @@ class EntityDeriver(object):
 
             results.append(result)
 
-        task_state.results_by_name = {
-            result.query.entity_name: result
-            for result in results
-        }
+        if task_state.provider.attrs.should_memoize:
+            task_state.results_by_name = {
+                result.query.entity_name: result
+                for result in results
+            }
+        task_state.is_complete = True
+
+
+    def _get_results_for_complete_task_state(self, task_state):
+        assert task_state.is_complete
+
+        if task_state.results_by_name:
+            return task_state.results_by_name
+
+        results_by_name = dict()
+        for accessor in task_state.cache_accessors:
+            result = accessor.load_result()
+            self._log(
+                'Loaded      %s from disk cache', result.query.task_key)
+
+            results_by_name[result.query.entity_name] = result
+
+        return results_by_name
+        
 
     def _compute_task_state(self, task_state):
         assert not task_state.is_blocked()
@@ -454,10 +474,11 @@ class EntityDeriver(object):
         task = task_state.task
         dep_keys = task.dep_keys
         dep_results = [
-            self._task_states_by_key[dep_key]
-                .results_by_name[dep_key.entity_name]
+            self._get_results_for_complete_task_state(
+                self._task_states_by_key[dep_key])[dep_key.entity_name]
             for dep_key in dep_keys
         ]
+
         provider = task_state.provider
 
         if not task.is_simple_lookup:
@@ -491,12 +512,18 @@ class EntityDeriver(object):
                 # real value.  That way, if the serialized/deserialized
                 # value is not exactly the same as the original, we still
                 # always return the same value.
-                result = accessor.load_result()
-                assert result is not None
+                if provider.attrs.should_memoize:
+                    result = accessor.load_result()
+                    assert result is not None
 
             results_by_name[query.entity_name] = result
+        
+        # TODO check if persist is False and memoize is False
+        if provider.attrs.should_memoize:
+            task_state.results_by_name = results_by_name
+        
+        task_state.is_complete = True
 
-        task_state.results_by_name = results_by_name
 
     def _log(self, message, *args):
         if self._is_ready_for_full_resolution:
@@ -541,11 +568,11 @@ class TaskState(object):
         # EntityDeriver._compute_task_state().
         self.results_by_name = None
 
-    def is_complete(self):
-        return self.results_by_name is not None
+        self.is_complete = False
+
 
     def is_blocked(self):
-        return not all(parent.is_complete() for parent in self.parents)
+        return not all(parent.is_complete for parent in self.parents)
 
     def __repr__(self):
         return 'TaskState(%r)' % self.task

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -694,6 +694,8 @@ class FlowBuilder(object):
             provider = DEFAULT_PROTOCOL(provider)
         if provider.attrs.should_persist is None:
             provider = decorators.persist(True)(provider)
+        if provider.attrs.should_memoize is None:
+            provider = decorators.memoize(True)(provider)
 
         state = self._state
 

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -33,12 +33,13 @@ class ProviderAttributes(object):
     def __init__(
             self, names,
             protocols=None, code_version=None, orig_flow_name=None,
-            should_persist=None, is_default_value=None):
+            should_persist=None, should_memoize=None, is_default_value=None):
         self.names = names
         self.protocols = protocols
         self.code_version = code_version
         self.orig_flow_name = orig_flow_name
         self.should_persist = should_persist
+        self.should_memoize = should_memoize
         self.is_default_value = is_default_value
 
 
@@ -264,7 +265,10 @@ class ValueProvider(BaseProvider):
     def __init__(self, name, protocol):
         super(ValueProvider, self).__init__(
             attrs=ProviderAttributes(
-                names=[name], protocols=[protocol], should_persist=False),
+                names=[name],
+                protocols=[protocol],
+                should_persist=False,
+                should_memoize=True),
             is_mutable=True,
         )
 

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -9,6 +9,15 @@ from bionic.exception import CodeVersioningError
 import bionic as bn
 
 
+class ReadCountingProtocol(bn.protocols.PicklableProtocol):
+    def __init__(self):
+        self.times_read_called = 0
+        super(ReadCountingProtocol, self).__init__()
+
+    def read(self, path, extension):
+        self.times_read_called += 1
+        return super(ReadCountingProtocol, self).read(path, extension)
+
 # It would be nice to move the builder setup into fixtures, but since we need
 # to access the bound functions as well (to check the number of times they were
 # called), it's easiest to just have one long test.
@@ -607,15 +616,6 @@ def test_all_returned_results_are_deserialized(builder):
 
 
 def test_deps_of_cached_values_not_needed(builder):
-    class ReadCountingProtocol(bn.protocols.PicklableProtocol):
-        def __init__(self):
-            self.times_read_called = 0
-            super(ReadCountingProtocol, self).__init__()
-
-        def read(self, path, extension):
-            self.times_read_called += 1
-            return super(ReadCountingProtocol, self).read(path, extension)
-
     y_protocol = ReadCountingProtocol()
     z_protocol = ReadCountingProtocol()
 
@@ -748,3 +748,18 @@ def test_persisting_none(builder):
     assert builder.build().get('none') is None
     assert builder.build().get('none') is None
     assert none.times_called() == 1
+
+
+def test_disable_memory_caching(builder):
+    x_protocol = ReadCountingProtocol()
+
+    @builder
+    @x_protocol
+    @bn.memoize(False)
+    def x():
+        return 1
+
+    flow = builder.build()
+    assert flow.get('x') == 1
+    assert flow.get('x') == 1
+    assert x_protocol.times_read_called == 2

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -18,6 +18,7 @@ class ReadCountingProtocol(bn.protocols.PicklableProtocol):
         self.times_read_called += 1
         return super(ReadCountingProtocol, self).read(path, extension)
 
+
 # It would be nice to move the builder setup into fixtures, but since we need
 # to access the bound functions as well (to check the number of times they were
 # called), it's easiest to just have one long test.


### PR DESCRIPTION
Addressing issue #26

This code will allow users to specify whether they want to keep an entity in-memory after computing it. This should allow flows with larger values to be executed. 

- Added tests for this memoize decorator in test_persistence