### PR TITLE
Added memoize decorator to allow in-memory caching to be disabled

### DIFF
--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from .flow import Flow, FlowBuilder  # noqa: F401
 from .decorators import (  # noqa: F401
-    version, output, outputs, gather, persist, pyplot, immediate
+    version, output, outputs, gather, persist, memoize, pyplot, immediate
 )
 
 from . import protocol  # noqa: F401

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -86,6 +86,28 @@ def persist(enabled):
     return provider_wrapper(AttrUpdateProvider, 'should_persist', enabled)
 
 
+def memoize(enabled):
+    """
+    Indicates whether computed values should be cached memoized
+
+    Parameters
+    ----------
+
+    enabled: Boolean
+        Whether this entity's values should be memoized
+
+    Returns
+    -------
+    Function:
+        A decorator which can be applied to an entity function.
+    """
+
+    if not isinstance(enabled, bool):
+        raise ValueError("Argument must be a boolean; got %r" % enabled)
+
+    return provider_wrapper(AttrUpdateProvider, 'should_memoize', enabled)
+
+
 def output(name):
     """
     Renames an entity.  The entity function must have a single value.

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -88,7 +88,7 @@ def persist(enabled):
 
 def memoize(enabled):
     """
-    Indicates whether computed values should be cached memoized
+    Indicates whether computed values should be cached in memory.
 
     Parameters
     ----------

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -515,7 +515,6 @@ class EntityDeriver(object):
 
             results_by_name[query.entity_name] = result
 
-        # TODO check if persist is False and memoize is False
         if provider.attrs.should_memoize:
             task_state.results_by_name = results_by_name
 

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -696,6 +696,11 @@ class FlowBuilder(object):
             provider = decorators.persist(True)(provider)
         if provider.attrs.should_memoize is None:
             provider = decorators.memoize(True)(provider)
+        if not (provider.attrs.should_persist or provider.attrs.should_memoize):
+            raise ValueError (
+                "Attempted to set both persist and memoize to False. "
+                "Must store computed entity for downstream computation. "
+        )
 
         state = self._state
 

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -694,6 +694,8 @@ class FlowBuilder(object):
             provider = DEFAULT_PROTOCOL(provider)
         if provider.attrs.should_persist is None:
             provider = decorators.persist(True)(provider)
+        if provider.attrs.should_memoize is None:
+            provider = decorators.memoize(True)(provider)
 
         state = self._state
 

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -699,7 +699,8 @@ class FlowBuilder(object):
         if not (provider.attrs.should_persist or provider.attrs.should_memoize):
             raise ValueError(
                 "Attempted to set both persist and memoize to False. "
-                "Must store computed entity for downstream computation. "
+                "At least one form of storage must be enabled for entities: %r "
+                % (func_or_provider.attrs.names)
             )
 
         state = self._state

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -697,10 +697,10 @@ class FlowBuilder(object):
         if provider.attrs.should_memoize is None:
             provider = decorators.memoize(True)(provider)
         if not (provider.attrs.should_persist or provider.attrs.should_memoize):
-            raise ValueError (
+            raise ValueError(
                 "Attempted to set both persist and memoize to False. "
                 "Must store computed entity for downstream computation. "
-        )
+            )
 
         state = self._state
 

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -33,12 +33,13 @@ class ProviderAttributes(object):
     def __init__(
             self, names,
             protocols=None, code_version=None, orig_flow_name=None,
-            should_persist=None, is_default_value=None):
+            should_persist=None, should_memoize=None, is_default_value=None):
         self.names = names
         self.protocols = protocols
         self.code_version = code_version
         self.orig_flow_name = orig_flow_name
         self.should_persist = should_persist
+        self.should_memoize = should_memoize
         self.is_default_value = is_default_value
 
 
@@ -264,7 +265,10 @@ class ValueProvider(BaseProvider):
     def __init__(self, name, protocol):
         super(ValueProvider, self).__init__(
             attrs=ProviderAttributes(
-                names=[name], protocols=[protocol], should_persist=False),
+                names=[name],
+                protocols=[protocol],
+                should_persist=False,
+                should_memoize=True),
             is_mutable=True,
         )
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -314,6 +314,23 @@ we can disable persistent caching altogether:
     def message(subject):
         return 'Hello {subject}.'.format(subject=subject)
 
+
+Disabling In-Memory Caching
+............................
+
+In other cases, it might be useful to not keep an entity in memory, but store
+it on disk and load it only when needed for downstream computation. This might
+be useful when it is too expensive to keep all entities in memory. In these
+cases, we can disable in-memory caching:
+
+.. code-block:: python
+
+    @builder
+    @bionic.memoize(False)
+    def message(subject):
+        return 'Hello {subject}.'.format(subject=subject)
+
+
 Location of the Cache Directory
 ...............................
 

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -772,4 +772,6 @@ def test_disable_memory_caching(builder):
         @bn.memoize(False)
         def y():
             return 1
-        assert builder.build().get('y')
+
+        flow = builder.build()
+        assert flow.get('y') == 1

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -765,8 +765,7 @@ def test_disable_memory_caching(builder):
     assert flow.get('x') == 1
     assert x_protocol.times_read_called == 2
 
-
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError):
         @builder
         @x_protocol
         @bn.persist(False)

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -764,3 +764,13 @@ def test_disable_memory_caching(builder):
     assert flow.get('x') == 1
     assert flow.get('x') == 1
     assert x_protocol.times_read_called == 2
+
+
+    with pytest.raises(ValueError) as e:
+        @builder
+        @x_protocol
+        @bn.persist(False)
+        @bn.memoize(False)
+        def y():
+            return 1
+        assert builder.build().get('y')


### PR DESCRIPTION
Addressing issue #26
This code will allow users to specify whether they want to keep an entity in-memory after computing it. This should allow flows with larger values to be executed.

- Added tests for this decorator in test_persistence