### PR TITLE
Mention 'old' and 'new' args in `merge` docstring

### DIFF
--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -491,8 +491,8 @@ class FlowBuilder(object):
             How to handle conflicting entity names.  Options:
 
             * 'error': throw an ``AlreadyDefinedEntityError``
-            * 'self': use the definition from this builder
-            * 'arg': use the definition from ``flow``
+            * 'self' or 'old': use the definition from this builder
+            * 'arg' or 'new': use the definition from ``flow``
 
         allow_name_match: boolean (default: False)
             Allows the incoming flow to have the same name as this builder.


### PR DESCRIPTION
I also considered replacing the names in `test_merge`, but I think the
code reads a little nicer with the original names.

cc @juanmahvelez WDYT?