### PR TITLE
Remove use of Flow.export in tests

### DIFF
--- a/tests/test_flow/test_protocols.py
+++ b/tests/test_flow/test_protocols.py
@@ -383,7 +383,7 @@ def test_yaml_protocol_dump_kwargs(builder, tmpdir):
     flow = builder.build()
     expected = "- red\n- blue\n"
 
-    assert flow.export('alist').read_text() == expected
+    assert flow.get('alist', mode='path').read_text() == expected
 
 
 def test_yaml_protocol_dict(builder):


### PR DESCRIPTION
This method is deprecated and generates a warning -- I switched it to use `get` instead.