### PR TITLE
Update documentation for multi-val export

### DIFF
--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -961,7 +961,8 @@ class Flow(object):
     # TODO Maybe this wants to be two different functions?
     def export(self, name, file_path=None, dir_path=None):
         """
-        Provides access to the persisted file corresponding to an entity.
+        Provides access to the persisted file corresponding to an entity.  Note:
+        this method is deprecated and the same functionality is available through Flow#get.
 
         Can be called in three ways:
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,3 +9,4 @@ These are the APIs provided by Bionic.
     flow
     decorators
     protocols
+    util

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -1,0 +1,19 @@
+====================
+Utilities
+====================
+
+FileCopier
+------------
+When called with the ``mode='FileCopier'`` argument,
+:meth:`Flow.get <bionic.Flow.get>` can return a
+:class:`FileCopier <bionic.util.FileCopier>` instance.  This is simply a
+utility class that exposes a
+:meth:`copy <bionic.util.FileCopier.copy>` method, enabling the
+user to copy files around without knowing any internal details about where
+Bionic stores them.
+
+FileCopier API
+---------------
+
+.. autoclass:: bionic.util.FileCopier
+    :members:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -415,13 +415,20 @@ explictly specify a serialization strategy for an entity by attaching a
 
 .. _Protocol: api/protocols.rst
 
-Exporting Persisted Files
-.........................
+Retrieving Persisted Files
+..........................
+In some cases, you'll want to directly access the persisted file(s) for an
+entity rather than its in-memory representation.  (For example, if you're
+writing a paper or report, you may want to access the files containing the
+plots.) This can be achieved with the ``mode`` argument to
+:meth:`Flow.get <bionic.Flow.get>` method.  For example:
 
-In some cases, you'll want to directly access the persisted file for an entity,
-rather than its in-memory representation.  (For example, if you're writing a
-paper or report, you may want to access the files containing the plots.) This
-can be accomplished using the :meth:`Flow.export <bionic.Flow.export>` method.
+.. code-block:: python
+
+    flow = builder.build().setting('subject', 'Alice')
+    flow.get('subject', mode='path')
+
+This would return a ``Path`` object for the ``subject`` entity.
 
 Multiplicity
 ------------


### PR DESCRIPTION
Also updates Flow#export's docstring to say it's deprecated.