### PR TITLE
Handle older caching filename convention

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -301,9 +301,18 @@ class CacheAccessor(object):
 
     def _value_from_file(self, file_path):
         value_filename = file_path.name
-        extension = value_filename[len(self.value_filename_stem):]
+
+        # Older versions of Bionic named all of these files 'value.EXTENSION'.
+        # Once we've updated the CACHE_SCHEMA_VERSION to be greater than 3, we
+        # can remove this special case.
+        old_value_filename_stem = 'value.'
+        if value_filename.startswith(old_value_filename_stem):
+            extension = value_filename[len(old_value_filename_stem):]
+        else:
+            extension = value_filename[len(self.value_filename_stem):]
         try:
             return self.query.protocol.read(file_path, extension)
+
         except UnsupportedSerializedValueError:
             raise
         except Exception as e:

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -774,3 +774,43 @@ def test_disable_memory_caching(builder):
 
         flow = builder.build()
         assert flow.get('y') == 1
+
+
+def test_can_still_read_old_filename_convention(builder):
+    call_counter = ResettingCounter()
+
+    @builder
+    def one():
+        call_counter.mark()
+        return 1
+
+    # Compute and save our value using the current caching system.
+    assert builder.build().get('one') == 1
+    assert builder.build().get('one') == 1
+    assert call_counter.times_called() == 1
+
+    # Now we'll modify the cached files to match the naming convention we used
+    # in Bionic versions 0.5.6 and older.
+    new_style_filename = 'one.pkl'
+    old_style_filename = 'value.pkl'
+
+    # Update the artifact itself.
+    artifact_path = builder.build().get('one', mode='path')
+    assert artifact_path.name == new_style_filename
+    renamed_artifact_path = artifact_path.parent / old_style_filename
+    artifact_path.rename(renamed_artifact_path)
+
+    # Update the descriptor file pointing to it.
+    entity_inventory_path = artifact_path.parents[3] / 'inventory' / 'one'
+    assert entity_inventory_path.is_dir()
+    desc_paths = list(entity_inventory_path.glob('**/*.yaml'))
+    assert len(desc_paths) == 1
+    desc_path, = desc_paths
+    desc_yaml = desc_path.read_text()
+    assert new_style_filename in desc_yaml
+    desc_yaml = desc_yaml.replace(new_style_filename, old_style_filename)
+    desc_path.write_text(desc_yaml)
+
+    # Test that we can still load the cached value.
+    assert builder.build().get('one') == 1
+    assert call_counter.times_called() == 0


### PR DESCRIPTION
In Bionic 0.5.7 we mistakenly updated the naming convention for cached
files in a non-backwards-compatible way.  (We switched from naming all
files `value.EXTENSION` to naming them `ENTITY_NAME.EXTENSION`.)  That
means anyone using the new code will be unable to load files saved with
the old version.

This commit updates the loading code to handle both the old and new
extension, which should fix this problem.