### PR TITLE
Ignore .venv dir when running flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length=100
-exclude = docs
+exclude = docs,.venv
 
 [tool:pytest]
 filterwarnings=ignore::DeprecationWarning


### PR DESCRIPTION
Otherwise flake8 will hang trying to lint every python file in your
virtual environment.