### PR TITLE
Enable and disable caching globally

### DIFF
--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1261,6 +1261,8 @@ def create_default_flow_state():
 
     builder.assign('core__persistent_cache__global_dir', 'bndata')
     builder.assign('core__versioning_mode', 'manual')
+    builder.assign('core__persistent_cache__enabled', True)
+    builder.assign('core__memory_cache__enabled', True)
 
     @builder
     @decorators.immediate

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -314,6 +314,11 @@ we can disable persistent caching altogether:
     def message(subject):
         return 'Hello {subject}.'.format(subject=subject)
 
+Persistent caching can also be disabled for the whole flow:
+
+.. code-block:: python
+
+    builder.set('core__persistent_cache__enabled', False)
 
 Disabling In-Memory Caching
 ............................
@@ -330,6 +335,11 @@ cases, we can disable in-memory caching:
     def message(subject):
         return 'Hello {subject}.'.format(subject=subject)
 
+In-memory caching can also be disabled for the whole flow:
+
+.. code-block:: python
+
+    builder.set('core__memory_cache__enabled', False)
 
 Location of the Cache Directory
 ...............................


### PR DESCRIPTION
Add `core__persistent_cache__enabled` and `core__memory_cache__enabled` flags to globally enable/disable persistent and in-memory caching for a flow.