### PR TITLE
Add .pytest_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover


### PR DESCRIPTION
Apparently pytest's cache directory was renamed from `.cache` to
`.pytest_cache`.