### PR TITLE
Janek/allow multiple docstrings

### DIFF
--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -1,6 +1,6 @@
 from .flow import Flow, FlowBuilder  # noqa: F401
 from .decorators import (  # noqa: F401
-    version, output, outputs, docstrings, gather, persist, memoize, pyplot,
+    version, output, outputs, docs, gather, persist, memoize, pyplot,
     immediate
 )
 

--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -1,6 +1,7 @@
 from .flow import Flow, FlowBuilder  # noqa: F401
 from .decorators import (  # noqa: F401
-    version, output, outputs, gather, persist, memoize, pyplot, immediate
+    version, output, outputs, docstrings, gather, persist, memoize, pyplot,
+    immediate
 )
 
 from . import protocol  # noqa: F401

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -156,6 +156,28 @@ def outputs(*names):
     return provider_wrapper(NameSplittingProvider, names)
 
 
+def docstrings(*docstrings):
+    """
+    Assigns docstrings to the entities defined by the decorated function.
+    Typically used in conjuction with ``@outputs`` for functions that return
+    multiple entity values.  (In the more common case where your function
+    returns a single entity value, you can just use a regular Python
+    docstring.)
+
+    Parameters
+    ----------
+
+    docstrings: Sequence of strings
+        Documentation strings for each of the defined entities.
+
+    Returns
+    -------
+    Function:
+        A decorator which can be applied to an entity function.
+    """
+
+    return provider_wrapper(AttrUpdateProvider, 'docstrings', docstrings)
+
 # TODO I'd like to put a @protocols decorator here that exposes the
 # MultiProtocolUpdateProvider class, but that would collide with the
 # protocols.py module.  Let's do this in a later PR.

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -156,18 +156,18 @@ def outputs(*names):
     return provider_wrapper(NameSplittingProvider, names)
 
 
-def docstrings(*docstrings):
+def docs(*docs):
     """
-    Assigns docstrings to the entities defined by the decorated function.
-    Typically used in conjuction with ``@outputs`` for functions that return
-    multiple entity values.  (In the more common case where your function
-    returns a single entity value, you can just use a regular Python
+    Assigns documentation strings to the entities defined by the decorated
+    function. Typically used in conjuction with ``@outputs`` for functions
+    that return multiple entity values. (In the more common case where your
+    function returns a single entity value, you can just use a regular Python
     docstring.)
 
     Parameters
     ----------
 
-    docstrings: Sequence of strings
+    docs: Sequence of strings
         Documentation strings for each of the defined entities.
 
     Returns
@@ -176,7 +176,7 @@ def docstrings(*docstrings):
         A decorator which can be applied to an entity function.
     """
 
-    return provider_wrapper(AttrUpdateProvider, 'docstrings', docstrings)
+    return provider_wrapper(AttrUpdateProvider, 'docs', docs)
 
 # TODO I'd like to put a @protocols decorator here that exposes the
 # MultiProtocolUpdateProvider class, but that would collide with the

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1370,16 +1370,21 @@ class ShortcutProxy(object):
 
         partial.__name__ = name
 
+        # Set a useful docstring for this function.
+        # First, the prefix explains what the function actually does.
         doc_prefix =\
             self._docstring_prefix_template.format(name=name)
+
+        # If the related entity has any documentation, we include that
+        # afterwards.
         entity_doc = self._flow.entity_doc(name)
         if entity_doc is None:
             main_docstring = doc_prefix + "."
         else:
             clean_entity_doc = dedent(entity_doc).strip()
             main_docstring = f"{doc_prefix}:\n{clean_entity_doc}"
-        method_name = self._wrapped_method.__name__
 
+        method_name = self._wrapped_method.__name__
         partial.__doc__ = (
             f"{main_docstring}"
             "\n\n"

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1303,6 +1303,9 @@ class ShortcutProxy(object):
         self._flow = wrapped_method.__self__
         assert isinstance(self._flow, Flow)
 
+        self.__name__ = wrapped_method.__name__
+        # TODO This doesn't seem to affect the output of `help` or Jupyter's
+        # autocomplete; we should figure out a better way to do this.
         self.__doc__ = self._wrapped_method.__doc__
 
     def __call__(self, *args, **kwargs):

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -30,10 +30,10 @@ class ProviderAttributes(object):
             self, names,
             protocols=None, code_version=None, orig_flow_name=None,
             should_persist=None, should_memoize=None, is_default_value=None,
-            docstrings=None):
+            docs=None):
         self.names = names
         self.protocols = protocols
-        self.docstrings = docstrings
+        self.docs = docs
         self.code_version = code_version
         self.orig_flow_name = orig_flow_name
         self.should_persist = should_persist
@@ -98,13 +98,13 @@ class BaseProvider(object):
                 providing only {tuple(self.attrs.names)!r}'''))
         return self.attrs.protocols[name_ix]
 
-    def docstring_for_name(self, name):
+    def doc_for_name(self, name):
         name_ix = self.attrs.names.index(name)
         if name_ix < 0:
             raise ValueError(oneline(f'''
                 Attempted to look up name {name!r} from provider
                 providing only {tuple(self.attrs.names)!r}'''))
-        return self.attrs.docstrings[name_ix]
+        return self.attrs.docs[name_ix]
 
     def __repr__(self):
         return f'{self.__class__.__name__}{tuple(self.attrs.names)!r}'
@@ -261,12 +261,12 @@ class NameSplittingProvider(WrappingProvider):
 
 
 class ValueProvider(BaseProvider):
-    def __init__(self, name, protocol, docstring):
+    def __init__(self, name, protocol, doc):
         super(ValueProvider, self).__init__(
             attrs=ProviderAttributes(
                 names=[name],
                 protocols=[protocol],
-                docstrings=[docstring],
+                docs=[doc],
                 should_persist=False,
                 should_memoize=True,
             ),
@@ -275,12 +275,12 @@ class ValueProvider(BaseProvider):
 
         self.name = name
         self.protocol = protocol
-        self.docstring = docstring
+        self.doc = doc
 
         self.clear_cases()
 
     def copy(self):
-        provider = ValueProvider(self.name, self.protocol, self.docstring)
+        provider = ValueProvider(self.name, self.protocol, self.doc)
         provider.key_space = self.key_space
         provider._has_any_values = self._has_any_values
         provider._values_by_case_key = self._values_by_case_key.copy()
@@ -370,7 +370,7 @@ class FunctionProvider(BaseProvider):
         name = func.__name__
         super(FunctionProvider, self).__init__(attrs=ProviderAttributes(
             names=[name],
-            docstrings=(None if func.__doc__ is None else [func.__doc__]),
+            docs=(None if func.__doc__ is None else [func.__doc__]),
         ))
 
         self._func = func

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -145,6 +145,47 @@ interpreted and converted to an entity (or entities).  In the `future
 <future.rst#user-defined-decorators>`__, it will be possible for users to write
 their own decorators as well.
 
+Documenting Entities
+.........................
+
+Each Bionic entity can optionally have a documentation string associated with
+it.  Entities defined by functions can use the regular Python docstring
+syntax:
+
+.. code-block:: python
+
+    @builder
+    def message(greeting, subject):
+        """A nice thing to say to someone."""
+        return f'{greeting} {subject}!'
+
+If the function defines multiple entities, the :meth:`decorators.docstrings`
+decorator can be used to specify documentation for each one:
+
+.. code-block:: python
+
+    @builder
+    @bn.outputs('first_name', 'last_name')
+    @bn.docstrings('The first name.', 'The last name.')
+    def split_name(full_name):
+        first_name, last_name = full_name.split()
+        return first_name, last_name
+
+For entities with fixed values, an optional ``docstring`` argument is available:
+
+.. code-block:: python
+
+    builder.assign('greeting', 'Hello', docstring="A nice way to start a message.")
+    builder.declare('subject', docstring="The person we're talking to.")
+
+These documentation strings are helpful for people reading your code, and are
+sometimes visible to the users of your flow.  For example, Python's built-in
+``help`` method can be used to view an entity's documentation:
+
+.. code-block:: python
+
+    help(flow.get.message)
+
 Configuration with Internal Entities
 ....................................
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -159,24 +159,24 @@ syntax:
         """A nice thing to say to someone."""
         return f'{greeting} {subject}!'
 
-If the function defines multiple entities, the :meth:`decorators.docstrings`
+If the function defines multiple entities, the :meth:`decorators.docs`
 decorator can be used to specify documentation for each one:
 
 .. code-block:: python
 
     @builder
     @bn.outputs('first_name', 'last_name')
-    @bn.docstrings('The first name.', 'The last name.')
+    @bn.docs('The first name.', 'The last name.')
     def split_name(full_name):
         first_name, last_name = full_name.split()
         return first_name, last_name
 
-For entities with fixed values, an optional ``docstring`` argument is available:
+For entities with fixed values, an optional ``doc`` argument is available:
 
 .. code-block:: python
 
-    builder.assign('greeting', 'Hello', docstring="A nice way to start a message.")
-    builder.declare('subject', docstring="The person we're talking to.")
+    builder.assign('greeting', 'Hello', doc="A nice way to start a message.")
+    builder.declare('subject', doc="The person we're talking to.")
 
 These documentation strings are helpful for people reading your code, and are
 sometimes visible to the users of your flow.  For example, Python's built-in

--- a/example/ml_workflow.py
+++ b/example/ml_workflow.py
@@ -15,15 +15,26 @@ import bionic as bn
 builder = bn.FlowBuilder('ml_workflow')
 
 # Define some basic parameters.
-builder.assign('random_seed', 0)
-builder.assign('test_split_fraction', 0.3)
-builder.assign('hyperparams_dict', {'C': 1})
-builder.assign('feature_inclusion_regex', '.*')
+builder.assign(
+    'random_seed', 0,
+    docstring='Arbitrary seed for all random decisions in the flow.')
+builder.assign(
+    'test_split_fraction', 0.3,
+    docstring='Fraction of data to include in test set.')
+builder.assign(
+    'hyperparams_dict', {'C': 1},
+    docstring='Hyperparameters to use when training the model.')
+builder.assign(
+    'feature_inclusion_regex', '.*',
+    docstring="Regular expression specifying which feature names to include.")
 
 
 # Load the raw data.
 @builder
 def raw_frame():
+    """
+    The raw data, including all features and a `target` column of labels.
+    """
     dataset = datasets.load_breast_cancer()
     df = pd.DataFrame(
         data=dataset.data,
@@ -36,6 +47,7 @@ def raw_frame():
 # Select a subset of the columns to use as features.
 @builder
 def features_frame(raw_frame, feature_inclusion_regex):
+    """Labeled data with a selected subset of the feature columns."""
     included_feature_cols = [
         col for col in raw_frame.columns.drop('target')
         if re.match(feature_inclusion_regex, col)
@@ -48,6 +60,10 @@ def features_frame(raw_frame, feature_inclusion_regex):
 # The `@outputs` decorator tells Bionic to define two new entities from this
 # function (which returns a tuple of two values).
 @bn.outputs('train_frame', 'test_frame')
+@bn.docstrings(
+    "Subset of feature data rows, used for model training.",
+    "Subset of feature data rows, used for model testing.",
+)
 def split_raw_frame(features_frame, test_split_fraction, random_seed):
     return model_selection.train_test_split(
         features_frame,
@@ -59,6 +75,7 @@ def split_raw_frame(features_frame, test_split_fraction, random_seed):
 # Fit a logistic regression model on the training data.
 @builder
 def model(train_frame, random_seed, hyperparams_dict):
+    """A binary classifier sklearn model."""
     m = linear_model.LogisticRegression(
         solver='liblinear', random_state=random_seed,
         **hyperparams_dict)
@@ -69,6 +86,12 @@ def model(train_frame, random_seed, hyperparams_dict):
 # Evaluate the model's precision and recall over a range of threshold values.
 @builder
 def precision_recall_frame(model, test_frame):
+    """
+    A dataframe with three columns:
+    - `threshold`: a probability threshold for the model
+    - `precision`: the test set precision resulting from that threshold
+    - `recall`: the test set recall resulting from that threshold
+    """
     predictions = model.predict_proba(test_frame.drop('target', axis=1))[:, 1]
     precisions, recalls, thresholds = metrics.precision_recall_curve(
         test_frame['target'], predictions)
@@ -95,6 +118,10 @@ def precision_recall_frame(model, test_frame):
     also='precision_recall_frame',
     into='gathered_frame')
 def all_hyperparams_pr_plot(gathered_frame, plt):
+    """
+    A plot of precision against recall.  Includes one curve for each set of
+    hyperparameters.
+    """
     _, ax = plt.subplots(figsize=(4, 3))
     for row in gathered_frame.itertuples():
         label = ', '.join(

--- a/example/ml_workflow.py
+++ b/example/ml_workflow.py
@@ -17,16 +17,16 @@ builder = bn.FlowBuilder('ml_workflow')
 # Define some basic parameters.
 builder.assign(
     'random_seed', 0,
-    docstring='Arbitrary seed for all random decisions in the flow.')
+    doc='Arbitrary seed for all random decisions in the flow.')
 builder.assign(
     'test_split_fraction', 0.3,
-    docstring='Fraction of data to include in test set.')
+    doc='Fraction of data to include in test set.')
 builder.assign(
     'hyperparams_dict', {'C': 1},
-    docstring='Hyperparameters to use when training the model.')
+    doc='Hyperparameters to use when training the model.')
 builder.assign(
     'feature_inclusion_regex', '.*',
-    docstring="Regular expression specifying which feature names to include.")
+    doc="Regular expression specifying which feature names to include.")
 
 
 # Load the raw data.
@@ -60,7 +60,7 @@ def features_frame(raw_frame, feature_inclusion_regex):
 # The `@outputs` decorator tells Bionic to define two new entities from this
 # function (which returns a tuple of two values).
 @bn.outputs('train_frame', 'test_frame')
-@bn.docstrings(
+@bn.docs(
     "Subset of feature data rows, used for model training.",
     "Subset of feature data rows, used for model testing.",
 )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,7 @@ import pytest
 from io import BytesIO
 import os
 from textwrap import dedent
+import re
 
 import pandas as pd
 from pandas import testing as pdt
@@ -114,3 +115,129 @@ class RoundingProtocol(bn.protocols.BaseProtocol):
 
     def read(self, path, extension):
         return float(path.read_bytes())
+
+
+def assert_re_matches(regex, string, flags=0):
+    '''
+    Equivalent to `assert re.match(regex, string, flags)` but with a nicer
+    error message that shows how how much of the regex and string matched.
+    '''
+
+    # Check if the full regex matches.
+    match = longest_regex_prefix_match(regex, string, flags)
+    matched_str = match.group(0)
+    matched_rgx = match.re.pattern
+    if len(matched_rgx) == len(regex):
+        return
+
+    # Otherwise, identify the parts that didn't match.
+    assert string.startswith(matched_str)
+    assert regex.startswith(matched_rgx)
+    unmatched_str = string[len(matched_str):]
+    unmatched_rgx = regex[len(matched_rgx):]
+
+    # We'll display the results in two columns: first the matching parts, then
+    # the non-matching parts.
+    def fmt(s):
+        s = repr(s)
+        if len(s) > 20:
+            s = s[:8] + '<...>' + s[-7:]
+        return s
+
+    matched_parts = [
+        fmt(matched_rgx),
+        fmt(matched_str),
+        '(match)'
+    ]
+    unmatched_parts = [
+        fmt(unmatched_rgx),
+        fmt(unmatched_str),
+        '(MISMATCH)'
+    ]
+
+    # Align each column so its elements each have the same width.
+    max_matched_len = max(len(s) for s in matched_parts)
+    matched_parts = [s.rjust(max_matched_len) for s in matched_parts]
+    max_unmatched_len = max(len(s) for s in unmatched_parts)
+    unmatched_parts = [s.ljust(max_unmatched_len) for s in unmatched_parts]
+
+    raise AssertionError(
+        f"assert re.match({regex!r}, {string!r})\n"
+        f"   regex: {matched_parts[0]} + {unmatched_parts[0]}\n"
+        f"  string: {matched_parts[1]} + {unmatched_parts[1]}\n"
+        f"          {matched_parts[2]}   {unmatched_parts[2]}"
+    )
+
+
+def longest_regex_prefix_match(regex, string, flags=0):
+    '''
+    Returns the longest prefix of `regex` that matches `string`. (Note this
+    uses re.match, which means the regex needs to match the beginning of the
+    string, but not the entire string. This also means that the empty prefix
+    will always match, so this function will always return a value.)
+    '''
+
+    # If the full regex matches, then we'll just return that.
+    match = re.match(regex, string, flags=flags)
+    if match:
+        return match
+
+    assert len(regex) > 0
+
+    # Otherwise, we'll find the longest matching prefix using binary search.
+    # We know a lower bound to get a match (the empty regex always matches)
+    # and an upper bound for failure (the full regex didn't match).
+    max_succ_ix = 0
+    min_fail_ix = len(regex)
+
+    while max_succ_ix + 1 < min_fail_ix:
+        # We'll test the prefix that ends at this index.
+        mid_ix = (max_succ_ix + min_fail_ix + 1) // 2
+
+        # We don't know if this prefix actually forms a valid regex -- it may be
+        # cut off in the middle of an escape code or parenthetical.
+        # If this exact index doesn't work, we'll find the nearest working index
+        # (if any) to either side.
+        found_valid_pattern = False
+
+        # Test the current index, and walk to the right until we find a working
+        # index.
+        hi_ix = mid_ix
+        while hi_ix < min_fail_ix:
+            try:
+                pattern = re.compile(regex[:hi_ix], flags=flags)
+                match = pattern.match(string)
+                if match:
+                    max_succ_ix = hi_ix
+                else:
+                    min_fail_ix = hi_ix
+                found_valid_pattern = True
+                break
+            except re.error:
+                hi_ix += 1
+
+        # If the original index didn't work, we'll also walk to the left until
+        # we find a working index.
+        if hi_ix != mid_ix:
+            lo_ix = mid_ix - 1
+            while lo_ix > max_succ_ix:
+                try:
+                    pattern = re.compile(regex[:lo_ix], flags=flags)
+                    match = pattern.match(string)
+                    if match:
+                        max_succ_ix = lo_ix
+                    else:
+                        min_fail_ix = lo_ix
+                    break
+                    found_valid_pattern = True
+                except re.error:
+                    lo_ix -= 1
+
+        # If we didn't find any valid regexs between our bounds, then we're done
+        # searching.
+        if not found_valid_pattern:
+            break
+
+    match = re.search(regex[:max_succ_ix], string, flags=flags)
+    assert match is not None
+    return match

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -623,10 +623,10 @@ def test_unhashable_index_values(builder):
     assert index_items == [[1, 2], [2, 3]]
 
 
-def test_entity_docstring(builder):
+def test_entity_doc(builder):
     builder.declare('x')
-    builder.declare('y', docstring="y doc")
-    builder.assign('z', value=3, docstring="z doc")
+    builder.declare('y', doc="y doc")
+    builder.assign('z', value=3, doc="z doc")
 
     @builder
     def f():
@@ -640,15 +640,15 @@ def test_entity_docstring(builder):
     flow = builder.build()
 
     # Test getting ValueProvider's docstring.
-    assert flow.entity_docstring(name='x') is None
-    assert flow.entity_docstring(name='y') == "y doc"
-    assert flow.entity_docstring(name='z') == "z doc"
+    assert flow.entity_doc(name='x') is None
+    assert flow.entity_doc(name='y') == "y doc"
+    assert flow.entity_doc(name='z') == "z doc"
 
     # Test getting FunctionProvider's docstring.
-    assert flow.entity_docstring(name='f') == "test docstring"
-    assert flow.entity_docstring(name='g') is None
+    assert flow.entity_doc(name='f') == "test docstring"
+    assert flow.entity_doc(name='g') is None
 
-    # Test that help() can access entity docstring.
+    # Test that help() can access entity docs.
     def help_str(obj):
         """
         Return the output of help() as a string (rather than printing to
@@ -667,3 +667,14 @@ def test_entity_docstring(builder):
         r"(?s).*"
         r"This function is equivalent to ``get\('g', \*args, \*\*kwargs\)``.*",
         help_str(flow.get.g))
+
+
+def test_entity_doc_legacy_api(builder):
+    with pytest.warns(Warning):
+        builder.assign('x', 1, docstring="x doc")
+    with pytest.warns(Warning):
+        builder.declare('y', docstring="y doc")
+    flow = builder.build()
+    with pytest.warns(Warning):
+        assert flow.entity_docstring('x') == "x doc"
+    assert flow.entity_doc('y') == "y doc"

--- a/tests/test_flow/test_multi_out.py
+++ b/tests/test_flow/test_multi_out.py
@@ -1,0 +1,98 @@
+import pytest
+
+import bionic as bn
+
+
+def test_no_docstring(builder):
+    @builder
+    @bn.outputs('a', 'b')
+    def f():
+        return 1, 2
+
+    flow = builder.build()
+    assert flow.entity_docstring('a') is None
+    assert flow.entity_docstring('b') is None
+
+
+def test_multi_docstrings(builder):
+    @builder
+    @bn.outputs('a', 'b')
+    @bn.docstrings('a doc', 'b doc')
+    def f():
+        return 1, 2
+
+    flow = builder.build()
+    assert flow.entity_docstring('a') == 'a doc'
+    assert flow.entity_docstring('b') == 'b doc'
+
+
+def test_multi_docstrings_decorated_first(builder):
+    @builder
+    @bn.docstrings('a doc', 'b doc')
+    @bn.outputs('a', 'b')
+    def f():
+        return 1, 2
+
+    flow = builder.build()
+    assert flow.entity_docstring('a') == 'a doc'
+    assert flow.entity_docstring('b') == 'b doc'
+
+
+def test_too_many_docstrings(builder):
+    with pytest.raises(ValueError):
+        @builder
+        @bn.docstrings('a doc', 'b doc')
+        def f():
+            return 1, 2
+
+
+def test_too_few_docstrings(builder):
+    with pytest.warns(Warning):
+        @builder
+        @bn.outputs('a', 'b')
+        def f():
+            "a and b doc"
+            return 1, 2
+
+    flow = builder.build()
+    assert flow.entity_docstring('a') == 'a and b doc'
+    assert flow.entity_docstring('b') == 'a and b doc'
+
+
+def test_multi_default_protocols(builder):
+    @builder
+    @bn.outputs('a', 'b')
+    def f():
+        return 1, 2
+
+    flow = builder.build()
+    assert flow.entity_protocol('a') == bn.flow.DEFAULT_PROTOCOL
+    assert flow.entity_protocol('b') == bn.flow.DEFAULT_PROTOCOL
+
+
+def test_multi_custom_protocols(builder):
+    protocol = bn.protocol.dillable()
+
+    @builder
+    @bn.outputs('a', 'b')
+    @protocol
+    def f():
+        return 1, 2
+
+    flow = builder.build()
+    assert flow.entity_protocol('a') == protocol
+    assert flow.entity_protocol('b') == protocol
+
+
+def test_multi_custom_protocols_decorated_first(builder):
+    protocol = bn.protocol.dillable()
+
+    @builder
+    @protocol
+    @bn.outputs('a', 'b')
+    def f():
+        return 1, 2
+
+    flow = builder.build()
+    assert flow.entity_protocol('a') == protocol
+    assert flow.entity_protocol('b') == protocol

--- a/tests/test_flow/test_multi_out.py
+++ b/tests/test_flow/test_multi_out.py
@@ -3,50 +3,50 @@ import pytest
 import bionic as bn
 
 
-def test_no_docstring(builder):
+def test_no_doc(builder):
     @builder
     @bn.outputs('a', 'b')
     def f():
         return 1, 2
 
     flow = builder.build()
-    assert flow.entity_docstring('a') is None
-    assert flow.entity_docstring('b') is None
+    assert flow.entity_doc('a') is None
+    assert flow.entity_doc('b') is None
 
 
-def test_multi_docstrings(builder):
+def test_multi_docs(builder):
     @builder
     @bn.outputs('a', 'b')
-    @bn.docstrings('a doc', 'b doc')
+    @bn.docs('a doc', 'b doc')
     def f():
         return 1, 2
 
     flow = builder.build()
-    assert flow.entity_docstring('a') == 'a doc'
-    assert flow.entity_docstring('b') == 'b doc'
+    assert flow.entity_doc('a') == 'a doc'
+    assert flow.entity_doc('b') == 'b doc'
 
 
-def test_multi_docstrings_decorated_first(builder):
+def test_multi_docs_decorated_first(builder):
     @builder
-    @bn.docstrings('a doc', 'b doc')
+    @bn.docs('a doc', 'b doc')
     @bn.outputs('a', 'b')
     def f():
         return 1, 2
 
     flow = builder.build()
-    assert flow.entity_docstring('a') == 'a doc'
-    assert flow.entity_docstring('b') == 'b doc'
+    assert flow.entity_doc('a') == 'a doc'
+    assert flow.entity_doc('b') == 'b doc'
 
 
-def test_too_many_docstrings(builder):
+def test_too_many_docs(builder):
     with pytest.raises(ValueError):
         @builder
-        @bn.docstrings('a doc', 'b doc')
+        @bn.docs('a doc', 'b doc')
         def f():
             return 1, 2
 
 
-def test_too_few_docstrings(builder):
+def test_too_few_docs(builder):
     with pytest.warns(Warning):
         @builder
         @bn.outputs('a', 'b')
@@ -55,8 +55,8 @@ def test_too_few_docstrings(builder):
             return 1, 2
 
     flow = builder.build()
-    assert flow.entity_docstring('a') == 'a and b doc'
-    assert flow.entity_docstring('b') == 'a and b doc'
+    assert flow.entity_doc('a') == 'a and b doc'
+    assert flow.entity_doc('b') == 'a and b doc'
 
 
 def test_multi_default_protocols(builder):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -96,3 +96,60 @@ def test_oneline():
 
        three
        ''') == 'one two three'
+
+
+# These functions are not in util.py but it's convenient to test them here too.
+def test_longest_regex_prefix():
+    from .helpers import longest_regex_prefix_match
+
+    def longest_prefix(regex, string):
+        return longest_regex_prefix_match(regex, string).re.pattern
+
+    assert longest_prefix('test', 'test') == 'test'
+    assert longest_prefix('test', 'te') == 'te'
+    assert longest_prefix('test', 'text') == 'te'
+    assert longest_prefix('test', 'testtest') == 'test'
+    assert longest_prefix('zest', 'test') == ''
+    assert longest_prefix('(test)', 'test') == '(test)'
+    assert longest_prefix('(test)', 'text') == ''
+    assert longest_prefix('(test)test', 'testtest') == '(test)test'
+    assert longest_prefix('(test)test', 'testtext') == '(test)te'
+    assert longest_prefix('x\n\n\nx', 'x\n\n\nx') == 'x\n\n\nx'
+    assert longest_prefix('x\n\n\nx', 'x\n\n\ny') == 'x\n\n\n'
+    assert longest_prefix('x\n\n\nx', 'x\n\ny') == 'x\n\n'
+    assert longest_prefix('x\n\n\nx', 'y\n\n\nx') == ''
+    assert longest_prefix('test.*test', 'testtest') == 'test.*test'
+    assert longest_prefix('test.*test', 'testxxtest') == 'test.*test'
+    assert longest_prefix('test.*test', 'testxxzest') == 'test.*t'
+    assert longest_prefix('test.*test', 'testxxz') == 'test.*'
+    assert longest_prefix('test.*test', 'texttest') == 'te'
+
+
+def test_assert_re_matches():
+    from .helpers import assert_re_matches
+
+    def assert_re_nomatch(regex, string):
+        with pytest.raises(AssertionError):
+            assert_re_matches(regex, string)
+
+    assert_re_matches('test', 'test')
+    assert_re_matches('test', 'testxxx')
+    assert_re_nomatch('test', 'tesd')
+
+    assert_re_matches('test$', 'test')
+    assert_re_nomatch('test$', 'testx')
+
+    assert_re_matches('.*test', 'test')
+    assert_re_matches('.*test', 'xxtest')
+    assert_re_matches('.*test', 'testxx')
+    assert_re_nomatch('.*test', 'tesd')
+
+    assert_re_matches('(test)', 'test')
+    assert_re_matches('(test)', 'testx')
+    assert_re_nomatch('(test)', 'tesd')
+
+    assert_re_matches('test.*test', 'testtest')
+    assert_re_matches('test.*test', 'testxxtest')
+    assert_re_nomatch('test.*test', 'test\ntest')
+
+    assert_re_matches('(?s)test.*test', 'test\ntest')


### PR DESCRIPTION
This adds support for multiple docstrings (when using multi-output functions) and also makes the docstrings of `flow.get.ENTITY_NAME` and `flow.setting.ENTITY_NAME` a little nicer.

Finally, now that I've tried using docstrings in the `ml_workflow` example, I'm tempted to change the signature from

    builder.assign(
        'test_split_fraction', 0.3,
        docstring='Fraction of data to include in test set.')

to

    builder.assign(
        'test_split_fraction', 0.3,
        doc='Fraction of data to include in test set.')

in order to leave more space for the actual string.  @bclayman @cathyatsquare what do you think?