### PR TITLE
Remove custom Matplotlib initialization

### DIFF
--- a/bionic/extras.py
+++ b/bionic/extras.py
@@ -22,7 +22,7 @@ def combine(*dep_lists):
 extras = OrderedDict()
 
 extras['image'] = ['Pillow']
-extras['matplotlib'] = combine(['matplotlib'], extras['image'])
+extras['matplotlib'] = combine(['matplotlib>=3.1'], extras['image'])
 extras['viz'] = combine(['hsluv', 'networkx', 'pydot'], extras['image'])
 
 extras['standard'] = combine(extras['matplotlib'], extras['viz'])

--- a/bionic/optdep.py
+++ b/bionic/optdep.py
@@ -28,12 +28,12 @@ def first_token_from_package_desc(desc):
     if first_mismatch is None:
         return desc
 
-    if desc[first_mismatch.pos] not in ' <>=':
+    if desc[first_mismatch.start()] not in ' <>=':
         raise AssertionError(oneline(f'''
             Package descriptor {desc!r} contained
-            unexpected character {desc[first_mismatch.pos]!r}'''))
+            unexpected character {desc[first_mismatch.start()]!r}'''))
 
-    return desc[:first_mismatch.pos]
+    return desc[:first_mismatch.start()]
 
 
 # For packages that we don't import by the exact package name, these are

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -18,7 +18,7 @@ import pandas as pd
 from .datatypes import (
     Task, TaskKey, CaseKey, CaseKeySpace, CodeDescriptor, CodeVersion)
 from .bytecode import canonical_bytecode_bytes_from_func
-from .util import groups_dict, init_matplotlib, hash_to_hex, oneline
+from .util import groups_dict, hash_to_hex, oneline
 from .optdep import import_optional_dependency
 
 import logging
@@ -730,7 +730,7 @@ class PyplotProvider(WrappingProvider):
             outer_dep_keys.pop(pyplot_dep_ix)
 
             def wrapped_compute_func(dep_values):
-                init_matplotlib()
+                import_optional_dependency('matplotlib', purpose='plotting')
                 from matplotlib import pyplot as plt
 
                 outer_dep_values = dep_values

--- a/bionic/util.py
+++ b/bionic/util.py
@@ -350,20 +350,3 @@ def init_basic_logging(level=logging.INFO):
         format='%(asctime)s %(levelname)s %(name)16s: %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S',
     )
-
-
-def init_matplotlib():
-    '''
-    Attempts to safely set up an appropriate matplotlib backend.  (The default
-    backend on OS X will crash on Python 2 if you aren't using the system
-    Python.)
-
-    This only has an effect if you call it before matplotlib.pyplot is
-    imported.
-    '''
-    matplotlib = import_optional_dependency('matplotlib', purpose='plotting')
-
-    if matplotlib.get_backend() == 'MacOSX':
-        matplotlib.use('TkAgg', warn=False)
-    else:
-        matplotlib.use('Agg', warn=False)


### PR DESCRIPTION
This removes the special matplotlib init code, which is no longer required for recent versions of Matplotlib and introduces an unnecessary dependency on Tcl/Tk.  Matplotlib now has a minimum version of 3.1.

I also fixed a bug in the optional dependency loading triggered by the new minimum version.