### PR TITLE
Janek/path protocol

### DIFF
--- a/bionic/protocol.py
+++ b/bionic/protocol.py
@@ -1,4 +1,5 @@
 from . import protocols
+from .provider import is_func_or_provider
 from .util import oneline
 
 # These are callable with or without arguments.  See BaseProtocol.__call__ for
@@ -50,6 +51,12 @@ def frame(func_or_provider=None, file_format=None, check_dtypes=None):
         if file_format is not None or check_dtypes is not None:
             raise ValueError(
                 "frame can't be called with both a function and keywords")
+        if not is_func_or_provider(func_or_provider):
+            raise ValueError(oneline('''
+                frame must be used either (a) directly as a decorator or
+                (b) with keyword arguments;
+                it can't take positional arguments.
+                '''))
         return protocols.ParquetDataFrameProtocol()(func_or_provider)
 
     # Otherwise, we have arguments and should return a decorator.

--- a/bionic/protocol.py
+++ b/bionic/protocol.py
@@ -10,6 +10,7 @@ dask = protocols.DaskProtocol()  # noqa: F401
 image = protocols.ImageProtocol()  # noqa: F401
 numpy = protocols.NumPyProtocol()  # noqa: F401
 yaml = protocols.YamlProtocol()  # noqa: F401
+path = protocols.PathProtocol()  # noqa: F401
 
 
 def frame(func_or_provider=None, file_format=None, check_dtypes=None):

--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -23,7 +23,8 @@ from pyarrow import parquet, Table
 import pandas as pd
 
 from .exception import UnsupportedSerializedValueError
-from .provider import provider_wrapper, ProtocolUpdateProvider
+from .provider import (
+    provider_wrapper, ProtocolUpdateProvider, is_func_or_provider)
 from .optdep import import_optional_dependency
 from .util import read_hashable_bytes_from_file_or_dir, oneline
 from . import tokenization
@@ -117,6 +118,12 @@ class BaseProtocol(object):
             if len(kwargs) > 0:
                 raise ValueError(
                     f"{self} can't be called with both a function and keywords")
+            if not is_func_or_provider(func_or_provider):
+                raise ValueError(oneline(f'''
+                    {self} must be used either (a) directly as a decorator or
+                    (b) with keyword arguments;
+                    it can't take positional arguments.
+                    '''))
 
             wrapper = provider_wrapper(ProtocolUpdateProvider, self)
             return wrapper(func_or_provider)

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -868,6 +868,10 @@ def is_provider(obj):
     return all(hasattr(obj, method_name) for method_name in PROVIDER_METHODS)
 
 
+def is_func_or_provider(obj):
+    return callable(obj) or is_provider(obj)
+
+
 def as_provider(func_or_provider):
     if is_provider(func_or_provider):
         provider = func_or_provider

--- a/bionic/util.py
+++ b/bionic/util.py
@@ -8,6 +8,7 @@ from hashlib import sha256
 from binascii import hexlify
 import subprocess
 import warnings
+import shutil
 
 from .optdep import import_optional_dependency, oneline
 
@@ -53,6 +54,18 @@ def groups_dict(values, keyfunc):
     for value in values:
         valuelists_by_key[keyfunc(value)].append(value)
     return dict(valuelists_by_key)
+
+
+def single_element(iterable):
+    "Takes an iterable with a single element and returns that element."
+    items = list(iterable)
+    if len(items) != 1:
+        raise ValueError(oneline(f'''
+            Expected a sequence with exactly one item;
+            got {len(items)} items.'''))
+    return items[0]
+
+    return next(iter(iterable))
 
 
 def hash_to_hex(bytestring, n_bytes=None):
@@ -157,6 +170,26 @@ def read_hashable_bytes_from_file_or_dir(path):
 
 def ensure_parent_dir_exists(path):
     path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def recursively_copy_path(src_path, dst_path):
+    if not src_path.exists():
+        raise ValueError(f"Path does not exist: {src_path}")
+
+    if src_path.is_file():
+        shutil.copyfile(str(src_path), str(dst_path))
+    else:
+        shutil.copytree(str(src_path), str(dst_path))
+
+
+def recursively_delete_path(path):
+    if not path.exists():
+        raise ValueError(f"Path does not exist: {path}")
+
+    if path.is_file():
+        path.unlink()
+    else:
+        shutil.rmtree(path)
 
 
 class ImmutableSequence(object):


### PR DESCRIPTION
This introduces a protocol for pathlib Paths referring to local files,
which allows entities to create files directly and have them be managed
by Bionic's tiered caching.

In the future I'd like to have a more elegant way of working with files,
but that requires a lot more infrastructure work.