### PR TITLE
Show entity docstrings as SVG tooltips

### DIFF
--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -35,6 +35,7 @@ class EntityDeriver(object):
         self._is_ready_for_bootstrap_resolution = False
         self._task_lists_by_entity_name = None
         self._task_states_by_key = None
+        self._doc_by_entity_name = {}
 
         # This state allows us to do full resolution for external callers.
         self._is_ready_for_full_resolution = False
@@ -104,6 +105,7 @@ class EntityDeriver(object):
                     entity_name=entity_name,
                     case_key=task_key.case_key,
                     task_ix=task_ix,
+                    doc=self._doc_by_entity_name.get(entity_name),
                 )
 
                 for child_state in state.children:
@@ -192,7 +194,6 @@ class EntityDeriver(object):
     def _populate_entity_info(self, entity_name):
         if entity_name in self._task_lists_by_entity_name:
             return
-
         provider = self._flow_state.get_provider(entity_name)
 
         dep_names = provider.get_dependency_names()
@@ -218,6 +219,8 @@ class EntityDeriver(object):
         self._task_lists_by_entity_name[entity_name] = provider.get_tasks(
             dep_key_spaces_by_name,
             dep_task_key_lists_by_name)
+
+        self._doc_by_entity_name[entity_name] = provider.doc_for_name(entity_name)
 
     def _bootstrap_singleton(self, entity_name):
         result_group = self._compute_result_group_for_entity_name(

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1169,7 +1169,7 @@ class Flow(object):
 
     def render_dag(self, include_core=False, vertical=False, curvy_lines=False):
         """
-        Returns an image with a visualization of this flow's DAG.
+        Returns a FlowImage with a visualization of this flow's DAG.
 
         Will fail if Graphviz is not installed on the system.
         """
@@ -1178,8 +1178,7 @@ class Flow(object):
 
         graph = self._deriver.export_dag(include_core)
         dot = dagviz.dot_from_graph(graph, vertical, curvy_lines)
-        image = dagviz.image_from_dot(dot)
-        return image
+        return dagviz.FlowImage(dot)
 
     # TODO Should we offer an in-place version of this?  It's contrary to the
     # idea of an immutable API, but it might be more natural for the user, and

--- a/tests/test_dagviz.py
+++ b/tests/test_dagviz.py
@@ -1,0 +1,87 @@
+'''
+Tests for dagviz and FlowImage class.
+'''
+
+import pytest
+from xml.etree import ElementTree as ET
+import pydot
+import networkx as nx
+import bionic
+import bionic.dagviz as dagviz
+from PIL import Image
+
+
+@pytest.fixture
+def flow():
+    """Create FlowImage fixture for testing"""
+    builder = bionic.FlowBuilder('hello_world')
+    builder.assign('greeting', 'hello world', doc='a friendly greeting')
+    return builder.build()
+
+
+@pytest.fixture
+def flow_image(flow):
+    return flow.render_dag()
+
+
+def get_pydot_attributes(index, dot):
+    """Helper function to get attributes from pydot graph given index"""
+    return dot.get_subgraphs()[index].get_nodes()[0].get_attributes()
+
+
+def test_save_flowimage_file_path(tmp_path, flow_image):
+    """When a file path is given as input, and type is supported by PIL
+    check that output image format is preserved."""
+    filepath = tmp_path / "test.png"
+    flow_image.save(filepath)
+    output = Image.open(filepath)
+    assert output.format == 'PNG'
+
+
+def test_save_flowimage_file_path_svg(tmp_path, flow_image):
+    """When a file path is given as input and svg as the format"""
+    filepath = tmp_path / "test.svg"
+    flow_image.save(filepath)
+    output_text = (tmp_path / "test.svg").read_text()
+    try:
+        ET.fromstring(output_text)
+    except ET.ParseError:
+        pytest.fail("output from saving SVG to file object not well formed XML {}"
+                    .format(output_text))
+
+
+def test_save_flowimage_file_object(tmp_path, flow_image):
+    """When a file object is given as input, use PIL interface to save"""
+    with open(tmp_path / "test.png", 'wb') as file_object:
+        flow_image.save(file_object, format='png')
+    output = Image.open(tmp_path/"test.png")
+    assert output.format == 'PNG'
+
+
+def test_save_flowimage_file_object_svg(tmp_path, flow_image):
+    """When a file object is given as input and file is svg, use builtin interface to save"""
+    with open(tmp_path / "test.svg", 'wb') as file_object:
+        flow_image.save(file_object, format='svg')
+    output_text = (tmp_path / "test.svg").read_text()
+    try:
+        ET.fromstring(output_text)
+    except ET.ParseError:
+        pytest.fail("output from saving SVG to file object not well formed XML {}"
+                    .format(output_text))
+
+
+def test_doc_propagated_to_tooltip(flow):
+    """Check that docs are propagated to tooltips"""
+    G = flow._deriver.export_dag(False)
+    dot = dagviz.dot_from_graph(G)
+    assert isinstance(dot, pydot.Dot)
+    assert get_pydot_attributes(0, dot)['tooltip'] == 'a friendly greeting'
+
+
+def test_missing_doc_empty_tooltip():
+    """When doc is missing, tooltip is missing"""
+    G = nx.DiGraph()
+    G.add_node(0, name='foo', task_ix=0, entity_name='buzz')
+    dot = dagviz.dot_from_graph(G)
+    # assert tooltip is missing
+    assert not hasattr(get_pydot_attributes(0, dot), 'tooltip')


### PR DESCRIPTION
Addresses #56 : Allow FlowImage to be rendered as SVG and show entity docstrings as SVG tooltips. Continue to support PIL image types and PIL.show(). Save as SVG (to be viewed by system viewer) or display in IPython notebooks (Jupyter).

Testing:
* Ran `example/ml_workflow.py` and visualized DAG as both SVG and PNG.
* See Pytests