### PR TITLE
Clean up and isolate GCS tests

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -50,12 +50,18 @@ like this:
 
 Travis should automatically run these for you when you submit a PR.
 
-Pytest will skip the Google Cloud Storage tests unless you set an environment
-variable telling it which bucket to use:
+Pytest will skip the Google Cloud Storage tests unless you pass a command line
+option telling it which bucket to use:
 
 .. code-block:: bash
 
-    BIONIC_TEST_GCS_BUCKET=my-bucket pytest
+    pytest --bucket=gs://MYBUCKET
+
+It will also skip some other slow tests unless you specifically include them:
+
+.. code-block:: bash
+
+    pytest --slow
 
 Updating the Documentation
 --------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,10 @@
 import pytest
 
+import getpass
+import random
+
+from .helpers import gsutil_path_exists, gsutil_wipe_path
+
 import bionic as bn
 
 
@@ -13,23 +18,64 @@ def builder(tmp_path):
     return builder
 
 
-# These three functions add a --slow command line option to enable slow tests.
-# Seems involved, but it's the approach recommended in the pytest docs.
 def pytest_addoption(parser):
     parser.addoption(
         '--slow', action='store_true', default=False, help='run slow tests'
+    )
+    parser.addoption(
+        '--bucket', action='store', help='URL to GCS bucket to use for tests'
     )
 
 
 def pytest_configure(config):
     config.addinivalue_line('markers', 'slow: mark test as slow to run')
+    config.addinivalue_line(
+        'markers', 'needs_gcs: mark test as requiring GCS to run')
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption('--slow'):
-        # If the option is present, don't skip slow tests.
-        return
-    skip_slow = pytest.mark.skip(reason='only runs when --slow is set')
-    for item in items:
-        if 'slow' in item.keywords:
-            item.add_marker(skip_slow)
+    if not config.getoption('--slow'):
+        skip_slow = pytest.mark.skip(reason='only runs when --slow is set')
+        for item in items:
+            if 'slow' in item.keywords:
+                item.add_marker(skip_slow)
+
+    if not config.getoption('--bucket'):
+        skip_gcs = pytest.mark.skip(reason='only runs when --bucket is set')
+        for item in items:
+            if 'needs_gcs' in item.keywords:
+                item.add_marker(skip_gcs)
+
+
+@pytest.fixture(scope='session')
+def gcs_url_stem(request):
+    url = request.config.getoption('--bucket')
+    assert url.startswith('gs://')
+    return url
+
+
+@pytest.fixture(scope='session')
+def session_tmp_gcs_url_prefix(gcs_url_stem):
+    """
+    Sets up and tears down a temporary "directory" on GCS to be shared by all
+    of our tests.
+    """
+
+    random_hex_str = '%016x' % random.randint(0, 2 ** 64)
+    path_str = f'{getpass.getuser()}/BNTESTDATA/{random_hex_str}'
+
+    gs_url = gcs_url_stem + '/' + path_str + '/'
+    # This emits a stderr warning because the URL doesn't exist.  That's
+    # annoying but I wasn't able to find a straightforward way to avoid it.
+    assert not gsutil_path_exists(gs_url)
+
+    yield gs_url
+
+    gsutil_wipe_path(gs_url)
+
+
+@pytest.fixture(scope='function')
+def tmp_gcs_url_prefix(session_tmp_gcs_url_prefix, request):
+    """A temporary "directory" on GCS for a single test."""
+
+    return session_tmp_gcs_url_prefix + request.node.name + '/'

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,21 +1,14 @@
-import pytest
-
 from io import BytesIO
-import os
 from textwrap import dedent
 import re
+import subprocess
+import shutil
 
 import pandas as pd
 from pandas import testing as pdt
 from decorator import decorate
 
 import bionic as bn
-
-GCS_TEST_BUCKET = os.environ.get('BIONIC_GCS_TEST_BUCKET', None)
-skip_unless_gcs = pytest.mark.skipif(
-    GCS_TEST_BUCKET is None,
-    reason='the BIONIC_GCS_TEST_BUCKET env variable was not set'
-)
 
 
 # TODO This name is cumbersome; maybe one of these shorter names?
@@ -241,3 +234,17 @@ def longest_regex_prefix_match(regex, string, flags=0):
     match = re.search(regex[:max_succ_ix], string, flags=flags)
     assert match is not None
     return match
+
+
+def gsutil_wipe_path(url):
+    assert 'BNTESTDATA' in url
+    subprocess.check_call(['gsutil', '-q', '-m', 'rm', '-rf', url])
+
+
+def gsutil_path_exists(url):
+    return subprocess.call(['gsutil', 'ls', url]) == 0
+
+
+def local_wipe_path(path_str):
+    assert 'BNTESTDATA' in path_str
+    shutil.rmtree(path_str)

--- a/tests/test_flow/test_copy.py
+++ b/tests/test_flow/test_copy.py
@@ -6,9 +6,7 @@ from subprocess import check_call
 
 import dask.dataframe as dd
 
-from ..helpers import (
-    skip_unless_gcs, GCS_TEST_BUCKET, df_from_csv_str,
-    equal_frame_and_index_content)
+from ..helpers import df_from_csv_str, equal_frame_and_index_content
 
 import bionic as bn
 
@@ -74,25 +72,22 @@ def test_copy_file_to_local_file_using_str(flow, tmp_path):
     assert pickle.loads(file_path.read_bytes()) == 5
 
 
-# TODO Add separate setup and teardown steps (similar to test_persistence_gcs)
-@skip_unless_gcs
-def test_copy_file_to_gcs_dir(flow, tmp_path):
-    flow.get('f', mode='FileCopier').copy(destination='gs://' + GCS_TEST_BUCKET)
-    cloud_path = Path(GCS_TEST_BUCKET) / 'f.pkl'
+@pytest.mark.needs_gcs
+def test_copy_file_to_gcs_dir(flow, tmp_path, tmp_gcs_url_prefix):
+    flow.get('f', mode='FileCopier').copy(destination=tmp_gcs_url_prefix)
+    cloud_url = tmp_gcs_url_prefix + 'f.pkl'
     local_path = tmp_path / 'f.pkl'
-    check_call(f'gsutil -m cp gs://{cloud_path} {local_path}', shell=True)
+    check_call(f'gsutil -m cp {cloud_url} {local_path}', shell=True)
     assert pickle.loads(local_path.read_bytes()) == 5
-    check_call(f'gsutil -m rm gs://{cloud_path}', shell=True)
 
 
-@skip_unless_gcs
-def test_copy_file_to_gcs_file(flow, tmp_path):
-    cloud_path = str(Path(GCS_TEST_BUCKET) / 'f.pkl')
-    flow.get('f', mode='FileCopier').copy(destination='gs://' + cloud_path)
+@pytest.mark.needs_gcs
+def test_copy_file_to_gcs_file(flow, tmp_path, tmp_gcs_url_prefix):
+    cloud_url = tmp_gcs_url_prefix + 'f.pkl'
+    flow.get('f', mode='FileCopier').copy(destination=cloud_url)
     local_path = tmp_path / 'f.pkl'
-    check_call(f'gsutil -m cp gs://{cloud_path} {local_path}', shell=True)
+    check_call(f'gsutil -m cp {cloud_url} {local_path}', shell=True)
     assert pickle.loads(local_path.read_bytes()) == 5
-    check_call(f'gsutil -m rm gs://{cloud_path}', shell=True)
 
 
 def test_copy_dask_to_dir(tmp_path, expected_dask_df, dask_flow):
@@ -106,15 +101,16 @@ def test_copy_dask_to_dir(tmp_path, expected_dask_df, dask_flow):
     assert equal_frame_and_index_content(actual.compute(), expected_dask_df.compute())
 
 
-@skip_unless_gcs
-def test_copy_dask_to_gcs_dir(tmp_path, expected_dask_df, dask_flow):
-    cloud_path = str(Path(GCS_TEST_BUCKET) / 'output')
-    dask_flow.get('dask_df', mode='FileCopier').copy(destination='gs://' + cloud_path)
+@pytest.mark.needs_gcs
+def test_copy_dask_to_gcs_dir(
+        tmp_path, tmp_gcs_url_prefix, expected_dask_df, dask_flow):
+    cloud_url = tmp_gcs_url_prefix + 'output'
 
-    check_call(f'gsutil -m cp -r gs://{cloud_path} {tmp_path}', shell=True)
+    dask_flow.get('dask_df', mode='FileCopier').copy(destination=cloud_url)
+
+    check_call(f'gsutil -m cp -r {cloud_url} {tmp_path}', shell=True)
     actual = dd.read_parquet(tmp_path / 'output')
     assert equal_frame_and_index_content(actual.compute(), expected_dask_df.compute())
-    check_call(f'gsutil -m rm -r gs://{cloud_path}', shell=True)
 
 
 def test_get_multi_value_entity(builder):


### PR DESCRIPTION
* GCS tests are now configured with a `--bucket` command line argument
rather than with an environment variable. This seemed more consistent with
other test options like `--slow`.

* Some tests were not using a clean setup and teardown when writing to
GCS, so they would leave stray objects lying around if the test happened
to fail. This should be fixed now.