### PR TITLE
Update docs to support ZSH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 - '3.7'
 before_install:
 - sudo apt-get install graphviz
-- pip install --upgrade --upgrade-strategy eager .[dev]
+- pip install --upgrade --upgrade-strategy eager '.[dev]'
 # This prints out all installed package versions, which may help for debugging
 # build failures.
 - pip freeze

--- a/bionic/optdep.py
+++ b/bionic/optdep.py
@@ -102,7 +102,7 @@ def import_optional_dependency(name, purpose=None, raise_on_missing=True):
 
             raise ImportError(oneline(f'''
                 Unable to import package {name!r}, which is {description};
-                you can use ``pip install bionic[{extra_name}]``
+                you can use ``pip install 'bionic[{extra_name}]'``
                 to resolve this'''))
 
         else:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -428,7 +428,7 @@ entity computation a bit slower.
 
 In order to use GCS caching, you must have the `gsutil`_ tool installed, and
 you must have GCP credentials configured.  You should also use ``pip install
-bionic[gcp]`` to install the required Python libraries.
+'bionic[gcp]'`` to install the required Python libraries.
 
 .. _gsutil: https://cloud.google.com/storage/docs/gsutil
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -26,7 +26,7 @@ of the repo:
 
 .. code-block:: bash
 
-    pip install -e .[dev]
+    pip install -e '.[dev]'
 
 If you want to build the documentation, you also need to install `pandoc
 <https://pandoc.org/>`_, which is used to convert notebook files into Sphinx

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -9,7 +9,7 @@ Bionic can be installed using ``pip``:
 
 .. code-block:: bash
 
-    pip install bionic[standard]
+    pip install 'bionic[standard]'
 
 The ``bionic[standard]`` package includes the core framework as well as the
 most commonly-used dependencies.  There are several other subpackages offering
@@ -56,32 +56,32 @@ as well as `graph visualization`_.
 
 The full set of subpackages is as follows:
 
-========== ================================== =================================
-Subpackage  Installation Command              Enables
-========== ================================== =================================
-dev        ``pip install bionic[dev]``        every feature; testing; building
-                                              documentation
----------- ---------------------------------- ---------------------------------
-dask       ``pip install bionic[dask]``       the ``@dask`` decorator
----------- ---------------------------------- ---------------------------------
-dill       ``pip install bionic[dill]``       the ``@dillable`` decorator
----------- ---------------------------------- ---------------------------------
-examples   ``pip install bionic[examples]``   the tutorial example code
----------- ---------------------------------- ---------------------------------
-full       ``pip install bionic[full]``       every non-development feature
----------- ---------------------------------- ---------------------------------
-gcp        ``pip install bionic[gcp]``        caching to GCS
----------- ---------------------------------- ---------------------------------
-image      ``pip install bionic[image]``      automatic de/serialization of
-                                              ``PIL.Image`` objects
----------- ---------------------------------- ---------------------------------
-matplotlib ``pip install bionic[matplotlib]`` the ``@pyplot`` decorator
----------- ---------------------------------- ---------------------------------
-standard   ``pip install bionic[standard]``   graph visualization; ``Image``
-                                              handling; ``@pyplot``
----------- ---------------------------------- ---------------------------------
-viz        ``pip install bionic[viz]``        graph visualization
-========== ================================== =================================
+========== ==================================== ================================
+Subpackage  Installation Command                Enables
+========== ==================================== ================================
+dev        ``pip install 'bionic[dev]'``        every feature; testing; building
+                                                documentation
+---------- ------------------------------------ --------------------------------
+dask       ``pip install 'bionic[dask]'``       the ``@dask`` decorator
+---------- ------------------------------------ --------------------------------
+dill       ``pip install 'bionic[dill]'``       the ``@dillable`` decorator
+---------- ------------------------------------ --------------------------------
+examples   ``pip install 'bionic[examples]'``   the tutorial example code
+---------- ------------------------------------ --------------------------------
+full       ``pip install 'bionic[full]'``       every non-development feature
+---------- ------------------------------------ --------------------------------
+gcp        ``pip install 'bionic[gcp]'``        caching to GCS
+---------- ------------------------------------ --------------------------------
+image      ``pip install 'bionic[image]'``      automatic de/serialization of
+                                                ``PIL.Image`` objects
+---------- ------------------------------------ --------------------------------
+matplotlib ``pip install 'bionic[matplotlib]'`` the ``@pyplot`` decorator
+---------- ------------------------------------ --------------------------------
+standard   ``pip install 'bionic[standard]'``   graph visualization; ``Image``
+                                                handling; ``@pyplot``
+---------- ------------------------------------ --------------------------------
+viz        ``pip install 'bionic[viz]'``        graph visualization
+========== ==================================== ================================
 
 Tutorials
 ---------

--- a/docs/tutorials/ml_workflow.ipynb
+++ b/docs/tutorials/ml_workflow.ipynb
@@ -23,7 +23,7 @@
     "We'll consider a typical (but simplified) machine learning flow.\n",
     "\n",
     "*(The code for this example is available in the Bionic repo at\n",
-    "example/ml_workflow.py.  Run* ``pip install bionic[examples]``\n",
+    "example/ml_workflow.py.  Run* ``pip install 'bionic[examples]'``\n",
     "*to ensure you have the required dependencies.)*\n",
     "\n",
     ".. literalinclude:: ../../example/ml_workflow.py\n",

--- a/tests/test_optdep.py
+++ b/tests/test_optdep.py
@@ -7,7 +7,7 @@ from bionic.optdep import (
 def test_import_missing_dependency():
     with pytest.raises(
             ImportError,
-            match='.*%s.*PURPOSE.*pip install bionic\\[%s\\].*' % (
+            match=".*%s.*PURPOSE.*pip install 'bionic\\[%s\\]'.*" % (
                 TEST_PACKAGE_NAME, TEST_EXTRA_NAME)):
         import_optional_dependency(TEST_PACKAGE_NAME, purpose='PURPOSE')
 


### PR DESCRIPTION
Replaced all instances of

    pip install bionic[SOMETHING]

with

    pip install 'bionic[SOMETHING]'

The former doesn't work on Zsh, since that shell assigns a special
meaning to square brackets. Having to add the quotes is kind of
annoying, but now Zsh is the default shell on new Macbooks and it
generates a cryptic error if you don't add the quotes, so it seems
worthwhile to try to help newcomers avoid this.