### PR TITLE
Janek/improve messaging for user code errors

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -15,7 +15,8 @@ from uuid import uuid4
 from pathlib import Path
 from urllib.parse import urlparse
 
-from bionic.exception import UnsupportedSerializedValueError
+from bionic.exception import (
+    EntitySerializationError, UnsupportedSerializedValueError)
 from .datatypes import Result
 from .util import (
     get_gcs_client_without_warnings, ensure_parent_dir_exists, oneline)
@@ -317,7 +318,14 @@ class CacheAccessor(object):
         value_path = dir_path / value_filename
 
         ensure_parent_dir_exists(value_path)
-        self.query.protocol.write(value, value_path)
+        try:
+            self.query.protocol.write(value, value_path)
+        except Exception as e:
+            raise EntitySerializationError(oneline(
+                f'''
+                Value of entity {self.query.entity_name!r}
+                could not be serialized to disk
+                ''')) from e
 
         return value_path
 

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -297,7 +297,6 @@ class EntityDeriver(object):
         assert not task_state.is_complete
 
         # First, set up provenance.
-        assert task_state.provenance is None
         if not self._is_ready_for_full_resolution:
             # If we're still in the bootstrap resolution phase, we don't have
             # any versioning policy, so we don't attempt anything fancy.
@@ -327,7 +326,6 @@ class EntityDeriver(object):
         )
 
         # Then set up queries.
-        assert task_state.queries is None
         task_state.queries = [
             Query(
                 task_key=task_key,
@@ -338,7 +336,6 @@ class EntityDeriver(object):
         ]
 
         # Lastly, set up cache accessors.
-        assert task_state.cache_accessors is None
         if task_state.provider.attrs.should_persist:
             if not self._is_ready_for_full_resolution:
                 name = task_state.task.keys[0].entity_name

--- a/bionic/exception.py
+++ b/bionic/exception.py
@@ -25,3 +25,11 @@ class UnsupportedSerializedValueError(Exception):
 
 class CodeVersioningError(Exception):
     pass
+
+
+class EntitySerializationError(Exception):
+    pass
+
+
+class EntityComputationError(Exception):
+    pass

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from .datatypes import (
     Task, TaskKey, CaseKey, CaseKeySpace, CodeFingerprint, CodeVersion)
+from .exception import EntityComputationError
 from .bytecode import canonical_bytecode_bytes_from_func
 from .util import groups_dict, hash_to_hex, oneline
 from .optdep import import_optional_dependency
@@ -419,7 +420,19 @@ class FunctionProvider(BaseProvider):
         ]
 
     def _apply(self, dep_values):
-        value = self._func(*dep_values)
+        try:
+            value = self._func(*dep_values)
+        except Exception as e:
+            entity_description = (
+                f'entity {self.attrs.names[0]!r}'
+                if len(self.attrs.names) == 1 else
+                f'entities {self.attrs.names!r}'
+            )
+            raise EntityComputationError(oneline(
+                f'''
+                An exception was thrown while computing the value of
+                {entity_description}
+                ''')) from e
         return [value]
 
     def __repr__(self):

--- a/tests/test_flow/test_protocols.py
+++ b/tests/test_flow/test_protocols.py
@@ -15,7 +15,8 @@ from ..helpers import (
 
 import bionic as bn
 from bionic.util import recursively_delete_path
-from bionic.exception import UnsupportedSerializedValueError
+from bionic.exception import (
+    UnsupportedSerializedValueError, EntitySerializationError)
 from bionic.protocols import CombinedProtocol, PicklableProtocol
 
 
@@ -166,7 +167,7 @@ def test_dataframe_with_categoricals_fails(builder):
     def df():
         return df_value
 
-    with pytest.raises(ValueError):
+    with pytest.raises(EntitySerializationError):
         builder.build().get('df')
 
 
@@ -197,7 +198,7 @@ def test_dataframe_with_duplicate_columns_fails(builder):
     def df():
         return df_value
 
-    with pytest.raises(ValueError):
+    with pytest.raises(EntitySerializationError):
         builder.build().get('df')
 
 


### PR DESCRIPTION
Addresses #92

When we fail to compute or serialize an entity value, this adds a
clearer exception that indicates what the problem was and which
entity was the cause.

Also fixes a bug causing a crash when we try to compute a failing entity twice.