### PR TITLE
add volatile decorator

### DIFF
--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -1,7 +1,7 @@
 from .flow import Flow, FlowBuilder  # noqa: F401
 from .decorators import (  # noqa: F401
     version, output, outputs, docs, gather, persist, memoize, pyplot,
-    immediate
+    immediate, changes_per_run
 )
 
 from . import protocol  # noqa: F401

--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -899,7 +899,8 @@ class Provenance(object):
     @classmethod
     def from_computation(
             cls, code_fingerprint, case_key, dep_provenance_digests_by_task_key,
-            treat_bytecode_as_functional):
+            treat_bytecode_as_functional, can_functionally_change_per_run,
+            flow_instance_uuid):
         dep_task_key_provenance_digest_pairs = sorted(
             dep_provenance_digests_by_task_key.items())
 
@@ -919,6 +920,12 @@ class Provenance(object):
             functional_code_dict['bytecode_hash'] = bytecode_hash
         else:
             nonfunctional_code_dict['bytecode_hash'] = bytecode_hash
+
+        # The function's output changes with each run; to reflect that,
+        # we add the flow uuid to the hash so that it will be different
+        # each time.
+        if can_functionally_change_per_run:
+            functional_code_dict['flow_instance_uuid'] = flow_instance_uuid
 
         full_code_dict = dict(
             functional=functional_code_dict,

--- a/bionic/exception.py
+++ b/bionic/exception.py
@@ -33,3 +33,7 @@ class EntitySerializationError(Exception):
 
 class EntityComputationError(Exception):
     pass
+
+
+class AttributeValidationError(Exception):
+    pass

--- a/docs/api/decorators.rst
+++ b/docs/api/decorators.rst
@@ -69,6 +69,7 @@ E.g.:
 Built-In Decorators
 -------------------
 
+.. autofunction:: bionic.changes_per_run
 .. autofunction:: bionic.docs
 .. autofunction:: bionic.gather
 .. autofunction:: bionic.immediate


### PR DESCRIPTION
The decorator recomputes the entity between different flows and triggers cache invalidation on downstream entities.

Closes #27 