### PR TITLE
Reformat docstrings before rendering as tooltips

### DIFF
--- a/bionic/dagviz.py
+++ b/bionic/dagviz.py
@@ -24,7 +24,7 @@ class FlowImage:
         Replicates the PIL APIs for save and show, for both PIL-supported and SVG formats.
         """
         self._pil_image = Image.open(BytesIO(pydot_graph.create_png()))
-        self._xml_text = pydot_graph.create_svg()
+        self._xml_bytes = pydot_graph.create_svg()
 
     def save(self, fp, format=None, **params):
         """
@@ -41,10 +41,10 @@ class FlowImage:
         )
         if use_svg:
             if is_file_object:
-                fp.write(self._xml_text)
+                fp.write(self._xml_bytes)
             else:
                 with open(fp, "wb") as file:
-                    file.write(self._xml_text)
+                    file.write(self._xml_bytes)
         else:
             self._pil_image.save(fp, format, **params)
 
@@ -54,7 +54,7 @@ class FlowImage:
 
     def _repr_svg_(self):
         """Rich display image as SVG in IPython notebook or Qt console."""
-        return str(self._xml_text)
+        return self._xml_bytes.decode("utf8")
 
 
 def hpluv_color_dict(keys, saturation, lightness):

--- a/bionic/dagviz.py
+++ b/bionic/dagviz.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from io import BytesIO, IOBase
 
 from .optdep import import_optional_dependency
+from .util import rewrap_docstring
 
 module_purpose = "rendering the flow DAG"
 hsluv = import_optional_dependency("hsluv", purpose=module_purpose)
@@ -71,13 +72,19 @@ def hpluv_color_dict(keys, saturation, lightness):
     return dict(zip(keys, color_strs))
 
 
-def dot_from_graph(graph, vertical=False, curvy_lines=False):
+def dot_from_graph(graph, vertical=False, curvy_lines=False, name=None):
     """
     Given a NetworkX directed acyclic graph, returns a Pydot object which can
     be visualized using GraphViz.
     """
 
+    if name is None:
+        graph_name = ""
+    else:
+        graph_name = name
+
     dot = pydot.Dot(
+        graph_name=graph_name,
         graph_type="digraph",
         splines="spline" if curvy_lines else "line",
         outputorder="edgesfirst",
@@ -109,15 +116,16 @@ def dot_from_graph(graph, vertical=False, curvy_lines=False):
 
         for node in sorted_nodes:
             entity_name = graph.nodes[node]["entity_name"]
-            entity_tooltip = doc_from_node(node)
+            entity_doc = doc_from_node(node)
             dot_node = pydot.Node(
                 name_from_node(node),
                 style="filled",
                 fillcolor=color_strs_by_entity_name[entity_name],
                 shape="box",
             )
-            if entity_tooltip:
-                dot_node.set("tooltip", entity_tooltip)
+            if entity_doc:
+                tooltip = rewrap_docstring(entity_doc)
+                dot_node.set("tooltip", tooltip)
             subdot.add_node(dot_node)
 
         dot.add_subgraph(subdot)

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1230,7 +1230,9 @@ class Flow(object):
         from . import dagviz
 
         graph = self._deriver.export_dag(include_core)
-        dot = dagviz.dot_from_graph(graph, vertical, curvy_lines)
+        dot = dagviz.dot_from_graph(
+            graph=graph, vertical=vertical, curvy_lines=curvy_lines, name=self.name,
+        )
         return dagviz.FlowImage(dot)
 
     # TODO Should we offer an in-place version of this?  It's contrary to the

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -109,6 +109,127 @@ def test_oneline():
     )
 
 
+def test_clean_docstring():
+    from bionic.util import rewrap_docstring
+
+    assert rewrap_docstring("") == ""
+    assert rewrap_docstring("test") == "test"
+    assert rewrap_docstring("test one two") == "test one two"
+    assert rewrap_docstring("test\none\ntwo") == "test one two"
+    assert rewrap_docstring("test 1. 2.") == "test 1. 2."
+    assert rewrap_docstring("test\n\none\ntwo") == "test\none two"
+
+    doc = """
+    test
+    """
+    assert rewrap_docstring(doc) == "test"
+
+    doc = """
+    test one
+    two
+    """
+    assert rewrap_docstring(doc) == "test one two"
+
+    doc = """
+    test one
+        two
+    """
+    assert rewrap_docstring(doc) == "test one two"
+
+    doc = """
+    test one
+
+    two
+    """
+    assert rewrap_docstring(doc) == "test one\ntwo"
+
+    doc = """
+    test
+    - one
+    - two
+    """
+    assert rewrap_docstring(doc) == "test\n- one\n- two"
+
+    doc = """
+    test
+    + one
+    + two
+    """
+    assert rewrap_docstring(doc) == "test\n+ one\n+ two"
+
+    doc = """
+    test
+    * one
+    * two
+    """
+    assert rewrap_docstring(doc) == "test\n* one\n* two"
+
+    doc = """
+    test
+    1. one
+    2. two
+    """
+    assert rewrap_docstring(doc) == "test\n1. one\n2. two"
+
+    doc = """
+    test
+    1) one
+    2) two
+    """
+    assert rewrap_docstring(doc) == "test\n1) one\n2) two"
+
+    doc = """
+    test
+    10) one
+    20) two
+    """
+    assert rewrap_docstring(doc) == "test\n10) one\n20) two"
+
+    doc = """
+    test
+    a) one
+    b) two
+    """
+    assert rewrap_docstring(doc) == "test\na) one\nb) two"
+
+    doc = """
+    test
+    1.0
+    """
+    assert rewrap_docstring(doc) == "test 1.0"
+
+    doc = """
+    test (one
+    two)
+    """
+    assert rewrap_docstring(doc) == "test (one two)"
+
+    doc = """
+    test
+    - one
+    - two
+
+    - three
+    - four
+    """
+    assert rewrap_docstring(doc) == "test\n- one\n- two\n\n- three\n- four"
+
+    doc = """
+    test
+    - one
+    two
+    """
+    assert rewrap_docstring(doc) == "test\n- one two"
+
+    doc = """
+    test
+    - one
+
+    two
+    """
+    assert rewrap_docstring(doc) == "test\n- one\ntwo"
+
+
 # These functions are not in util.py but it's convenient to test them here too.
 def test_longest_regex_prefix():
     from .helpers import longest_regex_prefix_match


### PR DESCRIPTION
Raw docstrings don't look great as tooltips because of their line
breaks, so I added a simple algorithm that attempts to rewrap each
docstring before displaying it as a tooltip.