### PR TITLE
Removed unneeded log statement

### DIFF
--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -268,11 +268,7 @@ class EntityDeriver(object):
             state = ready_task_states.pop()
 
             # If this task is already complete, we don't need to do any work.
-            # But if this is the first time we've seen this task, we should
-            # should log a message.
             if state.is_complete:
-                for task_key in state.task.keys:
-                    task_key_logger.log_accessed_from_memory(task_key)
                 continue
 
             # If blocked, let's mark it and try to derive its dependencies.


### PR DESCRIPTION
I removed an "Accessed ... from in-memory cache" statement; it's no
longer necessary, because we now log the same thing anytime we access the
results of any task state.