### PR TITLE
Janek/use attrs more

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -45,7 +45,7 @@ except AttributeError:
     YamlLoader = yaml.Loader
 
 
-class PersistentCache(object):
+class PersistentCache:
     """
     Provides a persistent mapping between Queries (things we could compute) and
     saved Results (computed Queries).  You use it by getting a CacheAccessor
@@ -86,7 +86,7 @@ class PersistentCache(object):
         return CacheAccessor(self, query)
 
 
-class CacheAccessor(object):
+class CacheAccessor:
     """
     Provides a reference to the cache entries for a specific query.  This
     interface is convenient, and it also allows us to maintain some memoized
@@ -385,7 +385,7 @@ InventoryEntry = namedtuple(
 MetadataMatch = namedtuple("MetadataMatch", "metadata_url level")
 
 
-class Inventory(object):
+class Inventory:
     """
     Maintains a persistent mapping from Queries to artifact URLs.  An Inventory
     is backed by a "file system", which could correspond to either a local disk
@@ -554,7 +554,7 @@ class Inventory(object):
         return metadata_url
 
 
-class LocalStore(object):
+class LocalStore:
     """
     Represents the local disk cache.  Provides both an Inventory that manages
     artifact (file) URLs, and a method to generate those URLs (for creating
@@ -595,7 +595,7 @@ class LocalStore(object):
                     )
 
 
-class GcsCloudStore(object):
+class GcsCloudStore:
     """
     Represents the GCS cloud cache.  Provides both an Inventory that manages
     artifact (blob) URLs, and a method to generate those URLs (for creating
@@ -685,7 +685,7 @@ class FakeCloudStore(LocalStore):
         recursive_file_copy(src_path, dst_path)
 
 
-class LocalFilesystem(object):
+class LocalFilesystem:
     """
     Implements a generic "FileSystem" interface for reading/writing small files
     to local disk.
@@ -724,7 +724,7 @@ class LocalFilesystem(object):
         return path_from_url(url).read_bytes()
 
 
-class GcsFilesystem(object):
+class GcsFilesystem:
     """
     Implements a generic "FileSystem" interface for reading/writing small files
     to GCS.
@@ -750,7 +750,7 @@ class GcsFilesystem(object):
         return self._tool.blob_from_url(url).download_as_string()
 
 
-class GcsTool(object):
+class GcsTool:
     """
     A helper object providing utility methods for accessing a GCS.  Maintains
     a GCS client, and a prefix defining a default namespace to read/write on.
@@ -846,7 +846,7 @@ class YamlRecordParsingError(Exception):
     pass
 
 
-class ArtifactMetadataRecord(object):
+class ArtifactMetadataRecord:
     """
     Describes a persisted artifact.  Intended to be stored as a YAML file.
     """
@@ -893,7 +893,7 @@ class ArtifactMetadataRecord(object):
         return f"ArtifactMetadataRecord({self.descriptor!r})"
 
 
-class Provenance(object):
+class Provenance:
     """
     Describes the code and data used to generate (possibly-yet-to-be-computed)
     value.  Provides a set of hashes that can be used to determine if two

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -4,37 +4,39 @@ Contains various data structures used by Bionic's infrastructure.
 
 from collections import namedtuple
 
+import attr
+
 from .util import ImmutableSequence, ImmutableMapping
 
 
-# TODO Consider using the attr library here?
-class TaskKey(namedtuple("TaskKey", "dnode case_key")):
+@attr.s(frozen=True)
+class TaskKey:
     """
     A unique identifier for a Task.
     """
 
-    def __new__(cls, dnode, case_key):
-        return super(TaskKey, cls).__new__(cls, dnode, case_key)
-
-    def __repr__(self):
-        return f"TaskKey({self.dnode!r}, {self.case_key!r})"
+    dnode = attr.ib()
+    case_key = attr.ib()
 
     def __str__(self):
         args_str = ", ".join(f"{name}={value}" for name, value in self.case_key.items())
         return f"{self.dnode.to_entity_name()}({args_str})"
 
 
-class Task(object):
+@attr.s(frozen=True)
+class Task:
     """
     A unit of work.  Can have dependencies, which are referred to via their
     TaskKeys.
     """
 
-    def __init__(self, keys, dep_keys, compute_func, is_simple_lookup=False):
-        self.keys = tuple(keys)
-        self.dep_keys = tuple(dep_keys)
-        self.compute = compute_func
-        self.is_simple_lookup = is_simple_lookup
+    keys = attr.ib(converter=tuple)
+    dep_keys = attr.ib(converter=tuple)
+    compute_func = attr.ib()
+    is_simple_lookup = attr.ib(default=False)
+
+    def compute(self, dep_values):
+        return self.compute_func(dep_values)
 
     def key_for_entity_name(self, name):
         matching_keys = [
@@ -49,48 +51,53 @@ class Task(object):
         return f"Task({self.keys!r}, {self.dep_keys!r})"
 
 
-class Query(object):
+@attr.s(frozen=True)
+class Query:
     """
     Represents a request for a specific entity value.
     """
 
-    def __init__(self, task_key, protocol, provenance):
-        self.task_key = task_key
-        self.dnode = task_key.dnode
-        self.case_key = task_key.case_key
-        self.protocol = protocol
-        self.provenance = provenance
+    task_key = attr.ib()
+    protocol = attr.ib()
+    provenance = attr.ib()
+
+    @property
+    def dnode(self):
+        return self.task_key.dnode
+
+    @property
+    def case_key(self):
+        return self.task_key.case_key
 
     def __repr__(self):
         return f"Query({self.task_key}, {self.provenance!r})"
 
 
-class Result(object):
+@attr.s(frozen=True)
+class Result:
     """
     Represents one value for one entity.
     """
 
-    def __init__(self, query, value, value_hash=None, file_path=None):
-        self.query = query
-        self.value = value
-        # Only present when value should persist.
-        self.file_path = file_path
-        self.value_hash = value_hash
+    query = attr.ib()
+    value = attr.ib()
+    file_path = attr.ib(default=None)
+    value_hash = attr.ib(default=None)
 
     def __repr__(self):
         return f"Result({self.query!r}, {self.value!r})"
 
 
-class ProvenanceDigest(object):
+@attr.s(frozen=True)
+class ProvenanceDigest:
     """
     A collection of values used by Provenance for different chained hashes.
     These hashes depend on the entities and can come from either another
     provenance or the value hash of a result.
     """
 
-    def __init__(self, functional_hash, exact_hash):
-        self.functional_hash = functional_hash
-        self.exact_hash = exact_hash
+    functional_hash = attr.ib()
+    exact_hash = attr.ib()
 
     @classmethod
     def from_provenance(cls, provenance):
@@ -221,22 +228,6 @@ class ResultGroup(ImmutableSequence):
         return f"ResultGroup({list(self)!r})"
 
 
-class CodeVersion(object):
-    """
-    Contains the user-designated version of a piece of code, consisting of a
-    major and a minor version string.  The convention is that changing the
-    major version indicates a functional change, while changing the minor
-    version indicates a nonfunctional change.
-    """
-
-    def __init__(self, major, minor):
-        self.major = str_from_version_value(major)
-        self.minor = str_from_version_value(minor)
-
-    def __repr__(self):
-        return f"CodeVersion({self.major!r}, {self.minor!r})"
-
-
 def str_from_version_value(value):
     if value is None:
         return "0"
@@ -246,6 +237,19 @@ def str_from_version_value(value):
         return value
     else:
         raise ValueError(f"Version values must be str, int, or None: got {value!r}")
+
+
+@attr.s(frozen=True)
+class CodeVersion:
+    """
+    Contains the user-designated version of a piece of code, consisting of a
+    major and a minor version string.  The convention is that changing the
+    major version indicates a functional change, while changing the minor
+    version indicates a nonfunctional change.
+    """
+
+    major = attr.ib(converter=str_from_version_value)
+    minor = attr.ib(converter=str_from_version_value)
 
 
 # A collection of characteristics attempting to uniquely identify a function.

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -22,7 +22,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class EntityDeriver(object):
+class EntityDeriver:
     """
     Derives the values of Entities.
 
@@ -628,7 +628,7 @@ class DescriptorInfo:
         return self.tasks_by_key.values()
 
 
-class TaskState(object):
+class TaskState:
     """
     Represents the state of a task computation.  Keeps track of its position in
     the task graph, whether its values have been computed yet, and additional

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -203,7 +203,7 @@ class FlowState(pyrs.PClass):
         return state
 
 
-class FlowBuilder(object):
+class FlowBuilder:
     """
     A mutable builder for Flows.
 
@@ -856,7 +856,7 @@ class FlowBuilder(object):
         self._set_for_case_key(last_case_key, name, value)
 
 
-class MergeConflict(object):
+class MergeConflict:
     def __init__(self, old_state, new_state, name):
         self.name = name
         self.old_provider = old_state.providers_by_name.get(name)
@@ -893,7 +893,7 @@ class MergeConflict(object):
         self.reason = reason
 
 
-class FlowCase(object):
+class FlowCase:
     """
     A specific case for which entities can have associated values.
 
@@ -910,7 +910,7 @@ class FlowCase(object):
         return self
 
 
-class Flow(object):
+class Flow:
     """
     An immutable workflow object.  You can use get() to compute any entity
     in the workflow, or setting() to create a new workflow with modifications.
@@ -1405,7 +1405,7 @@ class Flow(object):
         return Flow._from_state(builder._state)
 
 
-class ShortcutProxy(object):
+class ShortcutProxy:
     """
     Wraps a method on a Flow object to allow it to be called via an alternative
     style.

--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -46,7 +46,7 @@ def check_is_like_protocol(obj):
             )
 
 
-class BaseProtocol(object):
+class BaseProtocol:
     def validate(self, value):
         pass
 

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -34,7 +34,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class ProviderAttributes(object):
+class ProviderAttributes:
     def __init__(
         self,
         names,
@@ -74,7 +74,7 @@ class ProviderAttributes(object):
         return self._can_memoize
 
 
-class BaseProvider(object):
+class BaseProvider:
     def __init__(self, attrs, is_mutable=False):
         self.attrs = attrs
         self.is_mutable = is_mutable
@@ -731,7 +731,7 @@ class GatherProvider(WrappingProvider):
     def _compute_key_spaces(self, dep_key_spaces_by_dnode):
         return self._KeySpaces(self, dep_key_spaces_by_dnode)
 
-    class _KeySpaces(object):
+    class _KeySpaces:
         def __init__(self, gather_provider, dep_key_spaces_by_dnode):
             # The combined keyspace of all the non-gathered dependencies of the
             # wrapped provider.
@@ -932,7 +932,7 @@ def merge_case_key_lists(case_key_lists):
     return merged_case_keys
 
 
-class HashableWrapper(object):
+class HashableWrapper:
     """
     Wraps an arbitrary object along with a hashable token.
 

--- a/bionic/util.py
+++ b/bionic/util.py
@@ -352,54 +352,6 @@ class ImmutableMapping(ImmutableSequence):
         return f"{self.__class__.__name__}({self.__values_by_key!r})"
 
 
-# TODO I'm not sure if we'll end up needing this or not.
-class ExtensibleLogger(object):
-    def __init__(self, logger):
-        self._logger = logger
-
-    # Subclasses should call this.
-    def base_log(self, level, msg, *args, **kwargs):
-        self._logger.log(level, msg, *args, **kwargs)
-
-    # Subclasses should override this.
-    def custom_log(self, level, msg, *args, **kwargs):
-        self.base_log(level, msg, *args, **kwargs)
-
-    # Internal methods.
-    def _custom_log_if_enabled(self, level, msg, *args, **kwargs):
-        if not self.isEnabledFor(level):
-            return
-        self.custom_log(level, msg, *args, **kwargs)
-
-    # User-facing methods.
-    def isEnabledFor(self, level):
-        return self._logger.isEnabledFor(level)
-
-    def log(self, level, msg, *args, **kwargs):
-        self._custom_log_if_enabled(level, msg, *args, **kwargs)
-
-    def debug(self, msg, *args, **kwargs):
-        self._custom_log_if_enabled(logging.DEBUG, msg, *args, **kwargs)
-
-    def info(self, msg, *args, **kwargs):
-        self._custom_log_if_enabled(logging.INFO, msg, *args, **kwargs)
-
-    def warning(self, msg, *args, **kwargs):
-        self._custom_log_if_enabled(logging.WARNING, msg, *args, **kwargs)
-
-    def warn(self, msg, *args, **kwargs):
-        self.warning(msg, *args, **kwargs)
-
-    def error(self, msg, *args, **kwargs):
-        self._custom_log_if_enabled(logging.ERROR, msg, *args, **kwargs)
-
-    def critical(self, msg, *args, **kwargs):
-        self._custom_log_if_enabled(logging.CRITICAL, msg, *args, **kwargs)
-
-    def exception(self, msg, *args, **kwargs):
-        self._custom_log_if_enabled(logging.ERROR, msg, *args, exc_info=True, **kwargs)
-
-
 class FileCopier(object):
     """
     A wrapper for a Path object, exposing a ``copy`` method that will copy

--- a/bionic/util.py
+++ b/bionic/util.py
@@ -255,7 +255,7 @@ def rewrap_docstring(docstring):
     return "\n".join(paragraphs)
 
 
-class ImmutableSequence(object):
+class ImmutableSequence:
     def __init__(self, items):
         self.__items = tuple(items)
 
@@ -352,7 +352,7 @@ class ImmutableMapping(ImmutableSequence):
         return f"{self.__class__.__name__}({self.__values_by_key!r})"
 
 
-class FileCopier(object):
+class FileCopier:
     """
     A wrapper for a Path object, exposing a ``copy`` method that will copy
     the underlying file to a local or cloud destination.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -83,7 +83,7 @@ def count_calls(func):
     return wrapped
 
 
-class ResettingCounter(object):
+class ResettingCounter:
     """
     A class for manually counting the number of times something happens.
     Used mainly in situations whre ``count_calls`` can't be used.

--- a/tests/test_flow/test_merge.py
+++ b/tests/test_flow/test_merge.py
@@ -10,7 +10,7 @@ from bionic.exception import (
 ALL_KEEP_VALUES = ["error", "old", "new", "combine"]
 
 
-class MergeTester(object):
+class MergeTester:
     """
     A utility class for testing many variations of flow merging.  This class
     is configured by creating several flows, associated them with names using

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -752,7 +752,7 @@ def test_gather_cache_invalidation_with_over_vars(builder):
     assert z.times_called() == 1
 
 
-class Point(object):
+class Point:
     def __init__(self, x, y):
         self.x = x
         self.y = y

--- a/tests/test_flow/test_persistence_fuzz.py
+++ b/tests/test_flow/test_persistence_fuzz.py
@@ -10,7 +10,7 @@ from bionic import interpret
 import bionic as bn
 
 
-class SimpleFlowModel(object):
+class SimpleFlowModel:
     """
     Manages a simple Bionic flow where every entity value is an integer
     computed from the sum of other entity values.  This wrapper class maintains
@@ -179,7 +179,7 @@ class SimpleFlowModel(object):
         )
 
 
-class ModelEntity(object):
+class ModelEntity:
     """
     Represents one entity in the SimpleFlowModel.
     """
@@ -200,7 +200,7 @@ class ModelEntity(object):
         self.all_downstream_names = set()
 
 
-class Fuzzer(object):
+class Fuzzer:
     """
     Randomly constructs and updates a SimpleModelFlow while checking that its
     behavior is as expected.

--- a/tests/test_tokenize.py
+++ b/tests/test_tokenize.py
@@ -24,7 +24,7 @@ def test_ensure_token_length_is_capped():
     assert len(tokenize("a" * 1000)) < 50
 
 
-class Point(object):
+class Point:
     def __init__(self, x, y):
         self.x = x
         self.y = y


### PR DESCRIPTION
This refactors our simple data classes to use the `attrs` library. I also removed an unused class and a bunch of cases where we explicitly inherit from `object`, which is not necessary in Python 3.