### PR TITLE
Support unserializable entities for parallel processing

### DIFF
--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -344,7 +344,7 @@ class EntityDeriver:
                 state.complete(task_key_logger)
             else:
                 # NOTE 1: Logging support for multiple processes not done yet.
-                new_state_for_subprocess = state.new_state_for_completion({})
+                new_state_for_subprocess = state.strip_state_for_subprocess()
                 ex = self._bootstrap.process_executor.submit(
                     new_state_for_subprocess.complete, task_key_logger
                 )

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -344,9 +344,6 @@ class EntityDeriver:
                 state.complete(task_key_logger)
             else:
                 # NOTE 1: Logging support for multiple processes not done yet.
-                # NOTE 2: The entire task state is passed along to the executor except the
-                # memoized results. This means that the entire parent task state structure
-                # is also passed along which can can be unneeded.
                 new_state_for_subprocess = state.new_state_for_completion({})
                 ex = self._bootstrap.process_executor.submit(
                     new_state_for_subprocess.complete, task_key_logger

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -344,14 +344,12 @@ class EntityDeriver:
                 state.complete(task_key_logger)
             else:
                 # NOTE 1: Logging support for multiple processes not done yet.
-                # NOTE 2: Non-persisted entities are not computed inside the executor yet.
-                # Right now the tests pass because all non-persisted entities are serializable
-                # but that won't always be the case.
-                # NOTE 3: The entire task state is passed along to the executor. This means that
-                # all the memoized results as well as the entire parent task state structure
-                # alongside their memoized results are also passed along which are unneeded.
+                # NOTE 2: The entire task state is passed along to the executor except the
+                # memoized results. This means that the entire parent task state structure
+                # is also passed along which can can be unneeded.
+                new_state_for_subprocess = state.new_state_for_completion({})
                 ex = self._bootstrap.process_executor.submit(
-                    state.complete, task_key_logger
+                    new_state_for_subprocess.complete, task_key_logger
                 )
                 ex.result()
                 state.sync_after_subprocess_completion()

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -646,7 +646,7 @@ def test_unhashable_index_values(builder):
     assert index_items == [[1, 2], [2, 3]]
 
 
-def test_unpickable_non_persisted_entity(builder):
+def test_unpicklable_non_persisted_entity(builder):
     @builder
     @bn.persist(False)
     def unpicklable_lock():

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -5,6 +5,7 @@ import io
 import pickle
 from pathlib import Path
 import contextlib
+import threading
 
 import pandas as pd
 
@@ -643,6 +644,21 @@ def test_unhashable_index_values(builder):
 
     index_items = [wrapper.get() for wrapper, in sums_series.index]
     assert index_items == [[1, 2], [2, 3]]
+
+
+def test_unpickable_non_persisted_entity(builder):
+    @builder
+    @bn.persist(False)
+    def unpicklable_lock():
+        return threading.Lock()
+
+    @builder
+    def uses_lock(unpicklable_lock):
+        unpicklable_lock.acquire()
+        unpicklable_lock.release()
+        return True
+
+    assert builder.build().get("uses_lock")
 
 
 @pytest.mark.no_parallel

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -21,6 +21,7 @@ class ReadCountingProtocol(bn.protocols.PicklableProtocol):
 # It would be nice to move the builder setup into fixtures, but since we need
 # to access the bound functions as well (to check the number of times they were
 # called), it's easiest to just have one long test.
+@pytest.mark.no_parallel
 def test_caching_and_invalidation(builder, make_counter):
     # Set up the builder with singleton values.
 
@@ -851,6 +852,7 @@ def test_disable_memory_caching(builder):
         assert flow.get("y") == 1
 
 
+@pytest.mark.no_parallel
 def test_changes_per_run_and_not_persist(builder, make_counter):
     builder.assign("x", 5)
 
@@ -916,6 +918,7 @@ def test_changes_per_run_and_not_persist(builder, make_counter):
     assert x_plus_four_counter.times_called() == 0
 
 
+@pytest.mark.no_parallel
 def test_changes_per_run_and_persist(builder, make_counter):
     builder.assign("x", 5)
 


### PR DESCRIPTION
Stop sending any memoized results through IPC. Instead, use the
persisted cache for persistable entities and compute non-persisted
entities inside the subprocess.

The major benefit of this change is that Bionic can now support
using unserializable entities inside subprocess instead of throwing
an error during pickling the entity. It also reduces the IPC overhead
as reading persisted entities will use the Bionic Protocols which
are often tailored to the entities rather than using inefficient
cloud pickling for IPC.

This also changes the definition of complete for a task message.
Instead of being able to always retrieve the cached values, a completed
task state can also compute the value from its deps without having to
set up any task states.