### PR TITLE
Refactor ValueProvider to provide multiple entities jointly

### DIFF
--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -122,7 +122,7 @@ class FlowState(pyrs.PClass):
         # If there's only one provider, then the grouping is already done.
         if len(providers_set) == 1:
             provider = providers[0]
-            if not set(provider.attrs.names) == set(names):
+            if set(provider.attrs.names) != set(names):
                 if len(names) == 1:
                     message = f"""
                     Can't assign to individual entity {names[0]!r}:
@@ -192,8 +192,7 @@ class FlowState(pyrs.PClass):
         if names != provider.attrs.names:
             values = [values[provider.attrs.names.index(name)] for name in names]
 
-        provider = provider.copy()
-        provider.add_case(case_key, values)
+        provider = provider.add_case(case_key, values)
 
         return self._set_provider(provider).touch()
 

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -23,7 +23,7 @@ from .datatypes import (
     CodeFingerprint,
     CodeVersion,
 )
-from .exception import EntityComputationError
+from .exception import EntityComputationError, IncompatibleEntityError
 from .descriptors.parsing import entity_dnode_from_descriptor
 from .bytecode import canonical_bytecode_bytes_from_func
 from .util import groups_dict, hash_to_hex, oneline
@@ -181,7 +181,7 @@ class ValueProvider(BaseProvider):
 
         if self._has_any_values:
             if case_key.space != self.key_space:
-                raise ValueError(
+                raise IncompatibleEntityError(
                     oneline(
                         f"""
                     Can't add {case_key!r} to entities {self.attrs.names!r}:
@@ -190,7 +190,7 @@ class ValueProvider(BaseProvider):
                 )
 
             if case_key in self._value_tuples_by_case_key:
-                raise ValueError(
+                raise IncompatibleEntityError(
                     oneline(
                         f"""
                     Can't add {case_key!r} to entity {self.attrs.names!r}:

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -162,7 +162,7 @@ def test_add_case(preset_builder):
     builder.add_case("z", 7)
     assert builder.build().get("z", set) == {2, 3, 7}
 
-    with raises(ValueError):
+    with raises(IncompatibleEntityError):
         builder.add_case("f", 7)
 
     with raises(UndefinedEntityError):
@@ -173,18 +173,37 @@ def test_add_case(preset_builder):
     assert builder.build().get("p", set) == {4, 5}
     assert builder.build().get("q", set) == {5, 6}
 
-    with raises(ValueError):
+    with raises(IncompatibleEntityError):
         builder.add_case("p", 7)
-    with raises(ValueError):
+    with raises(IncompatibleEntityError):
         builder.add_case("p", 4, "q", 6)
     builder.declare("r")
-    with raises(ValueError):
+    with raises(IncompatibleEntityError):
         builder.add_case("p", 1, "q", 2, "r", 3)
+    with raises(IncompatibleEntityError):
+        builder.add_case("p", 1, "r", 3)
+    with raises(IncompatibleEntityError):
+        builder.add_case("x", 1, "y", 2)
 
     with raises(IncompatibleEntityError):
         builder.add_case("y_plus", 2)
     with raises(IncompatibleEntityError):
         builder.add_case("y_plus", 2, "y_plus_plus", 3)
+
+
+def test_add_case_out_of_order(builder):
+    builder.declare("p")
+    builder.declare("q")
+    builder.declare("r")
+
+    builder.add_case("p", 1, "q", 10, "r", 100)
+    builder.add_case("p", 2, "r", 200, "q", 20)
+    builder.add_case("r", 300, "q", 30, "p", 3)
+
+    flow = builder.build()
+    flow.get("p", set) == {1, 2, 3}
+    flow.get("q", set) == {10, 20, 30}
+    flow.get("r", set) == {100, 200, 300}
 
 
 def test_then_set(preset_builder):


### PR DESCRIPTION
(This PR has three commits, but most of the action is in the middle commit.)

Previously, when we defined entities jointly using `add_case`, each
entity was provided by a single ValueProvider. Now they are provided by
a single multi-valued ValueProvider. This makes them more consistent
with derived (function) entities.

Now it's the case that jointly-defined entities are always handled by a
single provider, which will simplify future refactoring.

There should be no functional changes in this commit (except the text of
exception messages, and perhaps some untested edge cases).