### PR TITLE
Execute tasks in parallel

### DIFF
--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1647,7 +1647,9 @@ def create_default_flow_state():
         # it take to make is use pickle and wrap the functions that are non-picklable
         # using `loky.wrap_non_picklable_objects`.
         loky = import_optional_dependency("loky", purpose="parallel processing")
-        return loky.get_reusable_executor(max_workers=1)
+        # TODO: Use a config / cpu cores instead of using a hardcoded value.
+        # Same applies to the test executor.
+        return loky.get_reusable_executor(max_workers=2)
 
     @builder
     @decorators.immediate

--- a/bionic/task_state.py
+++ b/bionic/task_state.py
@@ -46,6 +46,18 @@ class TaskState:
     def incomplete_dep_states(self):
         return [dep_state for dep_state in self.dep_states if not dep_state.is_complete]
 
+    def incomplete_dep_task_keys(self):
+        incomplete_dep_states = self.incomplete_dep_states()
+        return set(
+            incomplete_dep_state_tk
+            for incomplete_dep_state in incomplete_dep_states
+            for incomplete_dep_state_tk in incomplete_dep_state.task.keys
+        )
+
+    @property
+    def is_blocked(self):
+        return len(self.incomplete_dep_states()) > 0
+
     @property
     def is_completable(self):
         """
@@ -96,6 +108,8 @@ class TaskState:
             self._compute(task_key_logger)
 
         self.is_complete = True
+
+        return self.task.keys[0]
 
     def get_results_assuming_complete(self, task_key_logger):
         "Returns the results of an already-completed task state."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def process_executor(request):
         return None
 
     loky = import_optional_dependency("loky", purpose="parallel processing")
-    return loky.get_reusable_executor(max_workers=1)
+    return loky.get_reusable_executor(max_workers=2)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Move task tracking and compute logic out from EntityDeriver into a
separate class called TaskCompletionRunner.

TaskCompletionRunner follows the current stack based logic for single
process execution but now submits multiple tasks to process executor
and sees them to completion by also tracking the futures returned.