### PR TITLE
Set default pickle protocol to 4

### DIFF
--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -198,14 +198,22 @@ class PicklableProtocol(BaseProtocol):
     """
     Decorator indicating that an entity's values can be serialized using the
     ``pickle`` library.
+
+    Parameters:
+        pickle_protocol_version: int (default: 4)
+            The pickle serialization protocol to use.
     """
+
+    def __init__(self, pickle_protocol_version=4):
+        super(PicklableProtocol, self).__init__()
+        self._pickle_protocol_version = pickle_protocol_version
 
     def get_fixed_file_extension(self):
         return "pkl"
 
     def write(self, value, path):
         with path.open("wb") as file_:
-            pickle.dump(value, file_)
+            pickle.dump(value, file_, protocol=self._pickle_protocol_version)
 
     def read(self, path):
         with path.open("rb") as file_:


### PR DESCRIPTION
In python versions 3.0-3.7, the default [pickle protocol](https://docs.python.org/3/library/pickle.html#data-stream-format) is `3`. Using this protocol, one cannot pickle files larger than 4GB. This PR changes the default pickle protocol used by bionic to `4` which allows for pickling larger files. `4` is also the default protocol for python 3.8 FWIW.

BTW I made the protocol a kwarg named `protocol`. Not sure if that's a name collision with all the other protocol stuff in bionic.