### PR TITLE
Support unset values cleanly

### DIFF
--- a/bionic/exception.py
+++ b/bionic/exception.py
@@ -15,6 +15,10 @@ class AlreadyDefinedEntityError(ValueError):
         return cls(f"Entity {name!r} is already defined")
 
 
+class UnsetEntityError(ValueError):
+    pass
+
+
 class IncompatibleEntityError(ValueError):
     pass
 

--- a/bionic/util.py
+++ b/bionic/util.py
@@ -78,7 +78,14 @@ def single_element(iterable):
         )
     return items[0]
 
-    return next(iter(iterable))
+
+def single_unique_element(iterable):
+    """
+    Takes an iterable with exactly one unique element and returns that element.
+
+    Equivalent to `single_element(set(iterable))`.
+    """
+    return single_element(set(iterable))
 
 
 def hash_to_hex(bytestring, n_bytes=None):

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -16,6 +16,7 @@ from bionic.exception import (
     EntitySerializationError,
     IncompatibleEntityError,
     UndefinedEntityError,
+    UnsetEntityError,
 )
 
 from ..helpers import assert_re_matches, count_calls
@@ -335,15 +336,17 @@ def test_merge(builder):
 def test_get_single(preset_flow):
     flow = preset_flow
 
-    with raises(ValueError):
+    with raises(UnsetEntityError):
         flow.get("x")
 
     assert flow.get("y") == 1
 
     with raises(ValueError):
         assert flow.get("z")
-    with raises(ValueError):
+
+    with raises(UnsetEntityError) as excinfo:
         assert flow.get("f")
+    assert "'x'" in str(excinfo.value)
 
     assert flow.get("p") == 4
     assert flow.get("q") == 5

--- a/tests/test_flow/test_gather.py
+++ b/tests/test_flow/test_gather.py
@@ -44,6 +44,36 @@ def test_x(preset_builder):
     }
 
 
+def test_x__with_empty_x(preset_builder):
+    builder = preset_builder
+
+    builder.set("x", values=[])
+
+    @builder
+    @bn.gather("x")
+    def summary(gather_df):
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", set) == {
+        "",
+    }
+
+
+def test_x__with_unset_x(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("x")
+
+    @builder
+    @bn.gather("x")
+    def summary(gather_df):
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", list) == [
+        "",
+    ]
+
+
 def test_x__y(preset_builder):
     builder = preset_builder
 
@@ -56,6 +86,36 @@ def test_x__y(preset_builder):
         "X.Y x.Y",
         "X.y x.y",
     }
+
+
+def test_x__y__with_unset_x(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("x")
+
+    @builder
+    @bn.gather("x", "y")
+    def summary(gather_df):
+        assert set(gather_df.columns) == {"x", "y"}
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", list) == [
+        "",
+        "",
+    ]
+
+
+def test_x__y__with_unset_y(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("y")
+
+    @builder
+    @bn.gather("x", "y")
+    def summary(gather_df):
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", set) == set()
 
 
 def test_x__xy(preset_builder):
@@ -72,6 +132,35 @@ def test_x__xy(preset_builder):
     }
 
 
+def test_x__xy__with_unset_x(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("x")
+
+    @builder
+    @bn.gather("x", "xy")
+    def summary(gather_df):
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", list) == [
+        "",
+        "",
+    ]
+
+
+def test_x__xy__with_unset_y(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("y")
+
+    @builder
+    @bn.gather("x", "xy")
+    def summary(gather_df):
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", list) == []
+
+
 def test_xy__yz(preset_builder):
     builder = preset_builder
 
@@ -84,6 +173,51 @@ def test_xy__yz(preset_builder):
         "XY.YZ Xy.yZ xY.YZ xy.yZ",
         "XY.Yz Xy.yz xY.Yz xy.yz",
     }
+
+
+def test_xy__yz__with_unset_x(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("x")
+
+    @builder
+    @bn.gather("xy", "yz")
+    def summary(gather_df):
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", list) == [
+        "",
+        "",
+    ]
+
+
+def test_xy__yz__with_unset_y(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("y")
+
+    @builder
+    @bn.gather("xy", "yz")
+    def summary(gather_df):
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", list) == [
+        "",
+        "",
+    ]
+
+
+def test_xy__yz__with_unset_z(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("z")
+
+    @builder
+    @bn.gather("xy", "yz")
+    def summary(gather_df):
+        return summarize(gather_df)
+
+    assert builder.build().get("summary", list) == []
 
 
 def test_x_y__z(preset_builder):
@@ -146,6 +280,19 @@ def test_wx__xy__z(preset_builder):
     }
 
 
+def test_wx__xy__z_with_unset_z(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("z")
+
+    @builder
+    @bn.gather("wx", "xy")
+    def summary(gather_df, z):
+        return summarize(gather_df) + " -- " + z
+
+    assert builder.build().get("summary", set) == set()
+
+
 def test_wx__xy__yz(preset_builder):
     builder = preset_builder
 
@@ -182,6 +329,63 @@ def test_xy__yz__wx(preset_builder):
     }
 
 
+def test_xy__yz__wx__unset_x(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("x")
+
+    @builder
+    @bn.gather("xy", "yz")
+    def summary(gather_df, wx):
+        return summarize(gather_df) + " -- " + wx
+
+    assert builder.build().get("summary", list) == []
+
+
+def test_xy__yz__wx__unset_y(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("y")
+
+    @builder
+    @bn.gather("xy", "yz")
+    def summary(gather_df, wx):
+        return summarize(gather_df) + " -- " + wx
+
+    assert builder.build().get("summary", set) == {
+        " -- WX",
+        " -- Wx",
+        " -- wX",
+        " -- wx",
+    }
+
+
+def test_xy__yz__wx__unset_z(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("z")
+
+    @builder
+    @bn.gather("xy", "yz")
+    def summary(gather_df, wx):
+        return summarize(gather_df) + " -- " + wx
+
+    assert builder.build().get("summary", list) == []
+
+
+def test_xy__yz__wx__unset_w(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("w")
+
+    @builder
+    @bn.gather("xy", "yz")
+    def summary(gather_df, wx):
+        return summarize(gather_df) + " -- " + wx
+
+    assert builder.build().get("summary", list) == []
+
+
 def test_rename_frame(preset_builder):
     builder = preset_builder
 
@@ -210,6 +414,72 @@ def test_multiple_gathers(preset_builder):
         "W.WX w.wX -- Y.Yz y.yz",
         "W.Wx w.wx -- Y.YZ y.yZ",
         "W.Wx w.wx -- Y.Yz y.yz",
+    }
+
+
+def test_multiple_gathers__unset_x(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("x")
+
+    @builder
+    @bn.gather("w", "wx", "df1")
+    @bn.gather("y", "yz", "df2")
+    def summary(df1, df2):
+        return summarize(df1) + " -- " + summarize(df2)
+
+    assert builder.build().get("summary", list) == []
+
+
+def test_multiple_gathers__unset_y(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("y")
+
+    @builder
+    @bn.gather("w", "wx", "df1")
+    @bn.gather("y", "yz", "df2")
+    def summary(df1, df2):
+        return summarize(df1) + " -- " + summarize(df2)
+
+    assert builder.build().get("summary", set) == {
+        "W.WX w.wX -- ",
+        "W.WX w.wX -- ",
+        "W.Wx w.wx -- ",
+        "W.Wx w.wx -- ",
+    }
+
+
+def test_multiple_gathers__unset_z(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("z")
+
+    @builder
+    @bn.gather("w", "wx", "df1")
+    @bn.gather("y", "yz", "df2")
+    def summary(df1, df2):
+        return summarize(df1) + " -- " + summarize(df2)
+
+    assert builder.build().get("summary", list) == []
+
+
+def test_multiple_gathers__unset_w(preset_builder):
+    builder = preset_builder
+
+    builder.clear_cases("w")
+
+    @builder
+    @bn.gather("w", "wx", "df1")
+    @bn.gather("y", "yz", "df2")
+    def summary(df1, df2):
+        return summarize(df1) + " -- " + summarize(df2)
+
+    assert builder.build().get("summary", set) == {
+        " -- Y.YZ y.yZ",
+        " -- Y.Yz y.yz",
+        " -- Y.YZ y.yZ",
+        " -- Y.Yz y.yz",
     }
 
 

--- a/tests/test_flow/test_join.py
+++ b/tests/test_flow/test_join.py
@@ -1,5 +1,7 @@
 import pytest
 
+from bionic.exception import UnsetEntityError
+
 
 @pytest.fixture(scope="function")
 def preset_builder(builder):
@@ -75,3 +77,8 @@ def test_empty(preset_builder):
     assert flow.get("xy", set) == set()
     assert flow.get("yz", set) == {12, 15}
     assert flow.get("xy_plus_yz", set) == set()
+
+    with pytest.raises(UnsetEntityError):
+        flow.get("xy")
+    with pytest.raises(UnsetEntityError):
+        flow.get("xy_plus_yz")

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -852,6 +852,28 @@ def test_disable_memory_caching(builder):
         assert flow.get("y") == 1
 
 
+def test_unset_and_not_memoized(builder):
+    builder.declare("x")
+
+    @builder
+    @bn.memoize(False)
+    def x_plus_one(x):
+        return x + 1
+
+    assert builder.build().get("x_plus_one", list) == []
+
+
+def test_unset_and_not_persisted(builder):
+    builder.declare("x")
+
+    @builder
+    @bn.persist(False)
+    def x_plus_one(x):
+        return x + 1
+
+    assert builder.build().get("x_plus_one", list) == []
+
+
 @pytest.mark.no_parallel
 def test_changes_per_run_and_not_persist(builder, make_counter):
     builder.assign("x", 5)


### PR DESCRIPTION
(I've updated this text to match the current commit message, since
I was able to make a major simplification thanks to a great suggestion
by @namanjain!)

This commit improves the handling of unset entities. An entity is
"unset" if it meets any of the following criteria:

1. It has been declared but not set.
2. It has been set with an empty list of values.
3. Any of its ancestors is unset.

(Note that this conflates the concepts of "empty list" and "null value".
This conflation is deliberate and based on the idea that Bionic should
automatically convert between these two representations. In the future
the user will be able to distinguish between these two concepts using
descriptors, but Bionic will still automatically translate between them
when the result is unambiguous.)

I've fixed three outstanding problems with unset entities:

1. They didn't appear in the DAG visualization. Now they do.

2. When the user tried to compute their value, they got a vague error
message (see #103). Now they get
a helpful error message describing exactly which entities are unset.

3. `@gather` didn't handle them properly. Now it does: an entity with an
empty list of values can be gathered into an empty dataframe. (However,
emptiness/unset-ness can also be propagated when the also= argument is
used. As always with `@gather`, the details are subtle. I added several
gathering tests for this.)

Architecturally, this required the following changes:

1. CaseKeys can now include "missing" values, where "missing" is
represented by the sentinel constant `CaseKey.MISSING`.
2. A Task or Result is now considered "missing" if its CaseKey has any
missing values. Any Task with missing inputs must also have a missing
output. When a Task has a missing output, we don't compute it; instead
we generate a missing Result. Missing values are filtered out at the
last minute during `get` and `gather` operations.
3. I refactored some of the code in GatherProvider to be a little
clearer. (However, that provider's code is still insanely complex.)

Fixes #103