### PR TITLE
Fix bug breaking the use of fixed dataframes

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -202,7 +202,9 @@ class CaseKey(ImmutableMapping):
         self.missing_names = [
             name
             for name, value, token in name_value_token_triples
-            if value == self.MISSING
+            # We don't want to say `value == MISSING` because `value` might override the
+            # `==` operator to mean something different (like a Pandas DataFrame does).
+            if type(value) is MissingCaseKeyValue
         ]
         self.has_missing_values = len(self.missing_names) > 0
 

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -8,6 +8,7 @@ import contextlib
 import threading
 
 import pandas as pd
+import pandas.testing as pdt
 
 import bionic as bn
 from bionic.exception import (
@@ -753,6 +754,17 @@ def test_multiple_compute_attempts(builder):
     # the flow to be in a valid state and able to attempt another run.
     with pytest.raises(EntityComputationError):
         flow.get("uncomputable_value")
+
+
+# Checks that a dataframe can be used as a fixed value. (This was added as a regression
+# test after finding a bug where Bionic was applying == to a fixed value, which doesn't
+# work for DataFrames.)
+def test_fixed_dataframe(builder):
+    df = pd.DataFrame(columns=["a", "b"], data=[[1, 2], [3, 4]],)
+
+    builder.assign("df", df)
+
+    pdt.assert_frame_equal(builder.build().get("df"), df)
 
 
 def test_entity_doc(builder):


### PR DESCRIPTION
In commit 3b86ba0fdbc83a4f95bf14b84e3d030365313bcf, I added some code
that applied `==` to user-provided values. This was a bad idea because some
classes (like pandas.DataFrame) override `==` and return a value that
can't be interpreted as a boolean. Thankfully this caused our
documentation build to fail.

I changed the way we do this comparison and added a test to catch this.