### PR TITLE
Refactor Bionic decorators

### DIFF
--- a/bionic/decoration.py
+++ b/bionic/decoration.py
@@ -1,0 +1,63 @@
+"""
+Code for creating and applying Bionic decorators.
+
+Bionic decorators are expected to be applied like this:
+
+    @builder
+    @decorator1
+    @decorator2
+    def func(arg1, arg2, ...):
+        ...
+
+Each decorator attaches information to the decorated function by by creating or updating
+a DecorationAccumulator object, set as an attribute on the function. The assumption is
+that the decorator at the top, (``@builder``) will be a FlowBuilder object which removes
+this accumulator object and uses it to define a new entity.
+"""
+
+import attr
+
+from .provider import FunctionProvider
+
+
+@attr.s
+class DecorationAccumulator:
+    provider = attr.ib()
+
+    def wrap_provider(self, wrapper_fn, *args, **kwargs):
+        self.provider = wrapper_fn(self.provider, *args, **kwargs)
+
+
+def decorator_wrapping_provider(wrapper_fn, *args, **kwargs):
+    """
+    Returns a decorator which transforms the accumulated provider on a decorated
+    function by applying the given wrapping function and arguments.
+    """
+
+    def decorator(func):
+        init_accumulator_if_not_set_on_func(func)
+        acc = get_accumulator_from_func(func)
+        acc.wrap_provider(wrapper_fn, *args, **kwargs)
+        return func
+
+    return decorator
+
+
+ACC_ATTR_NAME = "bionic_decorator_accumulator"
+
+
+def init_accumulator_if_not_set_on_func(func):
+    if not hasattr(func, ACC_ATTR_NAME):
+        setattr(
+            func, ACC_ATTR_NAME, DecorationAccumulator(provider=FunctionProvider(func)),
+        )
+
+
+def get_accumulator_from_func(func):
+    return getattr(func, ACC_ATTR_NAME)
+
+
+def pop_accumulator_from_func(func):
+    acc = get_accumulator_from_func(func)
+    delattr(func, ACC_ATTR_NAME)
+    return acc

--- a/bionic/protocol.py
+++ b/bionic/protocol.py
@@ -1,5 +1,4 @@
 from . import protocols
-from .provider import is_func_or_provider
 from .util import oneline
 
 # These are callable with or without arguments.  See BaseProtocol.__call__ for
@@ -14,7 +13,7 @@ path = protocols.PathProtocol()  # noqa: F401
 geodataframe = protocols.GeoPandasProtocol()  # noqa: F401
 
 
-def frame(func_or_provider=None, file_format=None, check_dtypes=None):
+def frame(func=None, file_format=None, check_dtypes=None):
     """
     Decorator indicating that an entity will always have a pandas DataFrame
     type.
@@ -49,10 +48,10 @@ def frame(func_or_provider=None, file_format=None, check_dtypes=None):
 
     # If the first argument is present, we were (hopefully) used as a decorator
     # without any other arguments.
-    if func_or_provider is not None:
+    if func is not None:
         if file_format is not None or check_dtypes is not None:
             raise ValueError("frame can't be called with both a function and keywords")
-        if not is_func_or_provider(func_or_provider):
+        if not callable(func):
             raise ValueError(
                 oneline(
                     """
@@ -62,7 +61,7 @@ def frame(func_or_provider=None, file_format=None, check_dtypes=None):
                 """
                 )
             )
-        return protocols.ParquetDataFrameProtocol()(func_or_provider)
+        return protocols.ParquetDataFrameProtocol()(func)
 
     # Otherwise, we have arguments and should return a decorator.
     if file_format is None or file_format == "parquet":

--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -22,8 +22,9 @@ import numpy as np
 from pyarrow import parquet, Table
 import pandas as pd
 
+from .decoration import decorator_wrapping_provider
 from .exception import UnsupportedSerializedValueError
-from .provider import provider_wrapper, ProtocolUpdateProvider, is_func_or_provider
+from .provider import ProtocolUpdateProvider
 from .optdep import import_optional_dependency
 from .util import (
     read_hashable_bytes_from_file_or_dir,
@@ -168,13 +169,13 @@ class BaseProtocol:
     #    def func(...):
     #        ...
     #
-    def __call__(self, func_or_provider=None, **kwargs):
-        if func_or_provider is not None:
+    def __call__(self, func=None, **kwargs):
+        if func is not None:
             if len(kwargs) > 0:
                 raise ValueError(
                     f"{self} can't be called with both a function and keywords"
                 )
-            if not is_func_or_provider(func_or_provider):
+            if not callable(func):
                 raise ValueError(
                     oneline(
                         f"""
@@ -185,8 +186,8 @@ class BaseProtocol:
                     )
                 )
 
-            wrapper = provider_wrapper(ProtocolUpdateProvider, self)
-            return wrapper(func_or_provider)
+            wrapper = decorator_wrapping_provider(ProtocolUpdateProvider, self)
+            return wrapper(func)
         else:
             return self.__class__(**kwargs)
 

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -13,8 +13,8 @@ from collections import defaultdict
 import functools
 from io import BytesIO
 
-import pandas as pd
 import attr
+import pandas as pd
 
 from .datatypes import (
     Task,
@@ -1016,40 +1016,3 @@ class GatherTable:
 
     rows = attr.ib()
     out_task_key = attr.ib()
-
-
-# -- Helpers for working with providers.
-
-PROVIDER_METHODS = [
-    "get_code_fingerprint",
-    "get_dependency_dnodes",
-    "get_tasks",
-    "get_source_func",
-]
-
-
-def is_provider(obj):
-    return all(hasattr(obj, method_name) for method_name in PROVIDER_METHODS)
-
-
-def is_func_or_provider(obj):
-    return callable(obj) or is_provider(obj)
-
-
-def as_provider(func_or_provider):
-    if is_provider(func_or_provider):
-        provider = func_or_provider
-    elif callable(func_or_provider):
-        provider = FunctionProvider(func_or_provider)
-    else:
-        raise ValueError("func must be either callable or a Provider")
-
-    return provider
-
-
-def provider_wrapper(wrapper_fn, *args, **kwargs):
-    def decorator(func_or_provider):
-        provider = as_provider(func_or_provider)
-        return wrapper_fn(provider, *args, **kwargs)
-
-    return decorator


### PR DESCRIPTION
This is the first step towards addressing #127.

This changes the way Bionic decorators are implemented. Previously each
decorator worked by accepting either a function or a provider, and
wrapping it in a new provider. Now they accept a function and return it
after modifying a special `bionic_decorator_accumulator` attribute.
This is conceptually cleaner (no more `func_or_provider`) and introduces
the `DecorationAccumulator` class described in the issue linked above.