### PR TITLE
Turn off tag creation in bumpversion config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.7.1
 commit = True
-tag = True
+tag = False
 
 [bumpversion:file:setup.py]
 


### PR DESCRIPTION
We're moving to a release process where we bump the version in a PR
rather than just pushing to master. In this model, it doesn't make sense
to make a tag until the PR is approved, so we don't want bumpversion to
do it automatically. Instead, we'll use the GitHub Releases UI to create
a tag after merging the bump PR.