### PR TITLE
Use a tmp dir for temporary cache files

### DIFF
--- a/bionic/util.py
+++ b/bionic/util.py
@@ -202,7 +202,11 @@ def read_hashable_bytes_from_file_or_dir(path):
 
 
 def ensure_parent_dir_exists(path):
-    path.parent.mkdir(parents=True, exist_ok=True)
+    ensure_dir_exists(path.parent)
+
+
+def ensure_dir_exists(path):
+    path.mkdir(parents=True, exist_ok=True)
 
 
 def recursively_copy_path(src_path, dst_path):


### PR DESCRIPTION
This fixes a race condition in Bionic which happens during parallel
processing. The condition arises when one process is in the middle of
writing a cached artifact for an entity when another process is
searching for the cached value for the same entity.

Bionic created a tmp folder inside the artifact namespace for entities,
writes the artifact in that folder and destroys it after renaming the
written artifact. Searching works by first fetching all the directories
in the artifact namespace and then checking each directory for any
matches. This lead to situations where search operation read the tmp
directory, hold it in memory and look for the cached entries in the tmp
directory after it was destroyed. This results in a file not found error.

The change now writes all the tmp files in a separate tmp cache
directory to essentially remove any side effects of tmp file on caching
and establish clear separations between tmp and longer term artifacts.