### PR TITLE
Mark fixed entities as _can_persist

### DIFF
--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -152,7 +152,7 @@ class ValueProvider(BaseProvider):
                 names=names,
                 protocols=protocols,
                 docs=docs,
-                can_persist=False,
+                can_persist=True,
                 can_memoize=True,
                 changes_per_run=False,
             ),

--- a/bionic/task_state.py
+++ b/bionic/task_state.py
@@ -23,7 +23,9 @@ class TaskState:
         self.task_keys = task.keys
         self.should_memoize = provider.attrs.should_memoize()
         self.should_persist = (
-            self.provider.attrs.should_persist() and not self.output_would_be_missing()
+            self.provider.attrs.should_persist()
+            and not self.task.is_simple_lookup
+            and not self.output_would_be_missing()
         )
 
         # These are set by initialize().


### PR DESCRIPTION
Previously fixed entities had `_can_persist=False`, which sort of makes
sense since we don't actually want to persist them. However, since we do
expect fixed entities to be serializable, it's not really true that we
*can't* persist them. With this change, we now mark them as
`_can_persist=True`, but we also update `TaskState.should_persist` to
be `False` for fixed entities, so all behavior stays the same.

The upshot is that now all entities default to being persistable. This
makes it easier to break out a separate immutable entity definition
class, since the persistence properties don't change when you convert a
derived entity to a fixed one.