### PR TITLE
Convert namedtuple to attr classes

### DIFF
--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -3,8 +3,8 @@ This module provides local and cloud storage of computed values.  The main
 point of entry is the PersistentCache, which encapsulates this functionality.
 """
 
-from collections import namedtuple
 from hashlib import sha256
+import attr
 import os
 import shutil
 import subprocess
@@ -369,23 +369,41 @@ class CacheAccessor:
         ) from source_exc
 
 
-# TODO In Python 3 we can store these comments as docstrings.
-# A simple wrapper for a value that might be None.  We use this when we want
-# to distinguish between "we have a value which is None" from "we don't have a
-# value".
-NullableWrapper = namedtuple("NullableWrapper", "value")
+@attr.s(frozen=True)
+class NullableWrapper:
+    """
+    A simple wrapper for a value that might be None.  We use this when we want
+    to distinguish between "we have a value which is None" from "we don't have a
+    value".
+    """
+
+    value = attr.ib()
 
 
-# Represents a saved artifact tracked by an Inventory; returned by Inventory
-# to CacheAccessor.
-InventoryEntry = namedtuple(
-    "InventoryEntry",
-    "tier has_artifact artifact_url provenance exactly_matches_query value_hash",
-)
+@attr.s(frozen=True)
+class InventoryEntry:
+    """
+    Represents a saved artifact tracked by an Inventory; returned by Inventory
+    to CacheAccessor.
+    """
 
-# Represents a match between a query and a saved artifact.  `level` is a string
-# describing the match level, ranging from "functional" to "exact".
-MetadataMatch = namedtuple("MetadataMatch", "metadata_url level")
+    tier = attr.ib()
+    has_artifact = attr.ib()
+    artifact_url = attr.ib()
+    provenance = attr.ib()
+    exactly_matches_query = attr.ib()
+    value_hash = attr.ib()
+
+
+@attr.s(frozen=True)
+class MetadataMatch:
+    """
+    Represents a match between a query and a saved artifact.  `level` is a string
+    describing the match level, ranging from "functional" to "exact".
+    """
+
+    metadata_url = attr.ib()
+    level = attr.ib()
 
 
 class Inventory:

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -2,8 +2,6 @@
 Contains various data structures used by Bionic's infrastructure.
 """
 
-from collections import namedtuple
-
 import attr
 
 from .util import ImmutableSequence, ImmutableMapping
@@ -285,11 +283,22 @@ class CodeVersion:
     minor = attr.ib(converter=str_from_version_value)
 
 
-# A collection of characteristics attempting to uniquely identify a function.
-CodeFingerprint = namedtuple("CodeFingerprint", "version bytecode_hash orig_flow_name")
+@attr.s(frozen=True)
+class CodeFingerprint:
+    """
+    A collection of characteristics attempting to uniquely identify a function.
+    """
+
+    version = attr.ib()
+    bytecode_hash = attr.ib()
+    orig_flow_name = attr.ib()
 
 
-# Encodes the versioning rules to use when computing entity values.
-VersioningPolicy = namedtuple(
-    "VersioningPolicy", "check_for_bytecode_errors treat_bytecode_as_functional"
-)
+@attr.s(frozen=True)
+class VersioningPolicy:
+    """
+    Encodes the versioning rules to use when computing entity values.
+    """
+
+    check_for_bytecode_errors = attr.ib()
+    treat_bytecode_as_functional = attr.ib()


### PR DESCRIPTION
Namedtuples were used before we introduced attr classes in bionic. Now
that we have attr classes, there is no real reason to keep using
namedtuples since we don't want those classes as a tuple.