### PR TITLE
Janek/entity definitions

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -8,6 +8,22 @@ from .util import ImmutableSequence, ImmutableMapping
 
 
 @attr.s(frozen=True)
+class EntityDefinition:
+    """
+    Describes the immutable properties of an entity. These properties generally have
+    to do with the entity's "contract": the assumptions other parts of the system can
+    make about its value. However, this does *not* include the way the entity's value
+    is determined; this is configured separately and can be changed more easily.
+    """
+
+    name = attr.ib()
+    protocol = attr.ib()
+    doc = attr.ib()
+    can_persist = attr.ib(default=True)
+    can_memoize = attr.ib(default=True)
+
+
+@attr.s(frozen=True)
 class TaskKey:
     """
     A unique identifier for a Task.

--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -22,9 +22,8 @@ import numpy as np
 from pyarrow import parquet, Table
 import pandas as pd
 
-from .decoration import decorator_wrapping_provider
-from .exception import UnsupportedSerializedValueError
-from .provider import ProtocolUpdateProvider
+from .decoration import decorator_updating_accumulator
+from .exception import AttributeValidationError, UnsupportedSerializedValueError
 from .optdep import import_optional_dependency
 from .util import (
     read_hashable_bytes_from_file_or_dir,
@@ -186,8 +185,11 @@ class BaseProtocol:
                     )
                 )
 
-            wrapper = decorator_wrapping_provider(ProtocolUpdateProvider, self)
-            return wrapper(func)
+            return decorator_updating_accumulator(
+                lambda acc: acc.update_attr(
+                    "protocol", self, "protocol_decorator", raise_if_already_set=False
+                )
+            )(func)
         else:
             return self.__class__(**kwargs)
 

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -852,6 +852,19 @@ def test_disable_memory_caching(builder):
         assert flow.get("y") == 1
 
 
+@pytest.mark.parametrize("decorator", [bn.persist, bn.memoize])
+@pytest.mark.parametrize("enabled1", [True, False])
+@pytest.mark.parametrize("enabled2", [True, False])
+def test_redundant_decorators(builder, decorator, enabled1, enabled2):
+    with pytest.raises(AttributeValidationError):
+
+        @builder
+        @decorator(enabled1)
+        @decorator(enabled2)
+        def fail():
+            pass
+
+
 def test_unset_and_not_memoized(builder):
     builder.declare("x")
 


### PR DESCRIPTION
Fixes #127

This introduces a new `EntityDefinition` class with the following fields:
- `name`
- `protocol`
- `doc`
- `can_persist`
- `can_memoize`

These fields replace the corresponding fields on `ProviderAttributes`
(except for `names`, which still exists). Corresponding fields have also
been added to `DecorationAccumulator`, which is now responsible for
propagating these settings during the decoration process.

There should be no functional changes, aside from the wording in some
error messages and the use of `AttributeValidationError` in some cases
where we used to use `ValueError`.