### PR TITLE
Janek/extra flake8 plugins

### DIFF
--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -12,7 +12,6 @@ These are the decorators we expose to Bionic users.  They are used as follows:
 
 from .datatypes import CodeVersion
 from .decoration import decorator_updating_accumulator
-from .exception import AttributeValidationError
 from .provider import (
     GatherProvider,
     AttrUpdateProvider,
@@ -20,7 +19,6 @@ from .provider import (
     RenamingProvider,
     NameSplittingProvider,
 )
-from .util import oneline
 from . import interpret
 
 

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -10,7 +10,7 @@ import attr
 
 from .datatypes import ResultGroup
 from .descriptors.parsing import entity_dnode_from_descriptor
-from .exception import AttributeValidationError, UndefinedEntityError
+from .exception import AttributeValidationError
 from .optdep import import_optional_dependency
 from .task_state import TaskState
 from .util import oneline

--- a/bionic/extras.py
+++ b/bionic/extras.py
@@ -38,6 +38,7 @@ extras["dev"] = combine(
         "pytest",
         "black",
         "flake8",
+        "flake8-print",
         "sphinx",
         "sphinx_rtd_theme",
         "sphinx-autobuild",

--- a/bionic/extras.py
+++ b/bionic/extras.py
@@ -39,6 +39,7 @@ extras["dev"] = combine(
         "black",
         "flake8",
         "flake8-print",
+        "flake8-fixme",
         "sphinx",
         "sphinx_rtd_theme",
         "sphinx-autobuild",

--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -23,7 +23,7 @@ from pyarrow import parquet, Table
 import pandas as pd
 
 from .decoration import decorator_updating_accumulator
-from .exception import AttributeValidationError, UnsupportedSerializedValueError
+from .exception import UnsupportedSerializedValueError
 from .optdep import import_optional_dependency
 from .util import (
     read_hashable_bytes_from_file_or_dir,

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -9,7 +9,6 @@ rethink.
 
 import inspect
 from copy import copy
-from collections import defaultdict
 import functools
 from io import BytesIO
 

--- a/bionic/util.py
+++ b/bionic/util.py
@@ -2,7 +2,6 @@
 Miscellaneous utility functions.
 """
 
-import logging
 from collections import defaultdict
 from hashlib import sha256
 from binascii import hexlify

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,6 @@ ignore =
     W503  # "line break occurred before a binary operator"
     # Black handles line lengths for us (slightly less strictly than flake8).
     E501  # "line too long"
-    # TODO I think we can get rid of these two.
-    F811  # "redefinition of unused name"
-    F401  # "module imported but unused"
     # We allow TODO and XXX comments in code (but not FIXME).
     T101  # "fixme found (TODO)"
     T102  # "fixme found (XXX)"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,18 @@
 [flake8]
 max-line-length=88
 exclude = docs,.venv
-ignore = E203, E501, W503, F811, F401
+ignore =
+    # These rules are not compatible with black (our code formatter).
+    E203  # "whitespace before ':'"
+    W503  # "line break occurred before a binary operator"
+    # Black handles line lengths for us (slightly less strictly than flake8).
+    E501  # "line too long"
+    # TODO I think we can get rid of these two.
+    F811  # "redefinition of unused name"
+    F401  # "module imported but unused"
+    # We allow TODO and XXX comments in code (but not FIXME).
+    T101  # "fixme found (TODO)"
+    T102  # "fixme found (XXX)"
 per-file-ignores =
     # Allow print statements in example code.
     example/*:T001

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,9 @@
 max-line-length=88
 exclude = docs,.venv
 ignore = E203, E501, W503, F811, F401
+per-file-ignores =
+    # Allow print statements in example code.
+    example/*:T001
 
 [tool:pytest]
 filterwarnings=ignore::DeprecationWarning

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -726,8 +726,6 @@ def test_entity_computation_exception(builder):
         builder.build().get("uncomputable_value")
     except EntityComputationError as e:
         assert isinstance(e.__cause__, ZeroDivisionError)
-        # FIXME: Parallel processing should assert the error differently.
-        # assert "\nZeroDivisionError:" in e.__cause__.tb
 
 
 @pytest.mark.only_parallel

--- a/tests/test_flow/test_persistence_gcs.py
+++ b/tests/test_flow/test_persistence_gcs.py
@@ -15,7 +15,6 @@ import tempfile
 import dask.dataframe as dd
 
 from ..helpers import (
-    ResettingCounter,
     count_calls,
     df_from_csv_str,
     equal_frame_and_index_content,

--- a/tests/test_flow/test_protocols.py
+++ b/tests/test_flow/test_protocols.py
@@ -15,7 +15,6 @@ from ..helpers import count_calls, df_from_csv_str, equal_frame_and_index_conten
 
 import bionic as bn
 from bionic.exception import (
-    AttributeValidationError,
     EntitySerializationError,
     UnsupportedSerializedValueError,
 )


### PR DESCRIPTION
I added the `flake8-print` and `flake8-fixme` plugins to catch stray `print`s and `FIXME`s in our code. I also re-enabled checking for unused imports, which had gotten turned off for some reason.