### PR TITLE
Refactor `results_by_name` to `results_by_dnode`

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -64,12 +64,8 @@ class Task:
     def compute(self, dep_values):
         return self.compute_func(dep_values)
 
-    def key_for_entity_name(self, name):
-        matching_keys = [
-            task_key
-            for task_key in self.keys
-            if task_key.dnode.to_entity_name() == name
-        ]
+    def key_for_dnode(self, dnode):
+        matching_keys = [task_key for task_key in self.keys if task_key.dnode == dnode]
         (key,) = matching_keys
         return key
 

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -103,7 +103,7 @@ class EntityDeriver:
             for task_ix, task in enumerate(
                 sorted(tasks, key=lambda task: task.keys[0].case_key)
             ):
-                task_key = task.key_for_entity_name(entity_name)
+                task_key = task.key_for_dnode(dnode)
                 state = self._get_or_create_task_state_for_key(task_key)
 
                 node_name = name_template.format(
@@ -209,8 +209,7 @@ class EntityDeriver:
         }
         dep_task_key_lists_by_dnode = {
             dep_dinfo.dnode: [
-                task.key_for_entity_name(dep_dinfo.dnode.to_entity_name())
-                for task in dep_dinfo.tasks
+                task.key_for_dnode(dep_dinfo.dnode) for task in dep_dinfo.tasks
             ]
             for dep_dinfo in dep_dinfos
         }
@@ -349,10 +348,9 @@ class EntityDeriver:
         for state in requested_task_states:
             assert state.is_complete, state
 
-        entity_name = dnode.to_entity_name()
         return ResultGroup(
             results=[
-                state.get_results_assuming_complete(task_key_logger)[entity_name]
+                state.get_results_assuming_complete(task_key_logger)[dnode]
                 for state in requested_task_states
             ],
             key_space=dinfo.key_space,


### PR DESCRIPTION
The point of this field is to hold multiple results for a single
task (that differ only by name). Once we have tuple descriptors, we'll
be able to remove this concept and every task will have a single result.
However, in order to implement tuple descriptors we need to support
descriptors that aren't entity names, so for now it's convenient to
organize results by descriptor.

I also made corresponding changes to `value_hashes_by_name` and
`key_for_entity_name`.

There should be no functional change.