### PR TITLE
Make all dnodes comparable with each other

### DIFF
--- a/tests/test_descriptors.py
+++ b/tests/test_descriptors.py
@@ -161,3 +161,18 @@ def test_dnode_hashing(dnodes):
         assert dnode not in dnode_dict
         dnode_dict[dnode] = dnode
         assert dnode_dict[dnode] == dnode
+
+
+def test_dnode_sorting(dnodes):
+    def descs_from_dnodes(dnodes):
+        return [dnode.to_descriptor() for dnode in dnodes]
+
+    assert descs_from_dnodes(sorted(dnodes)) == sorted(descs_from_dnodes(dnodes))
+
+
+def test_dnode_equality_and_hashing_are_not_by_identity():
+    dnode1 = E("x")
+    dnode2 = E("x")
+    assert id(dnode1) != id(dnode2)
+    assert dnode1 == dnode2
+    assert hash(dnode1) == hash(dnode2)


### PR DESCRIPTION
Previously, comparison operations like `<` didn't work on
`DescriptorNode`s with different types, because each node class had its
own comparison operators defined separately by the `attrs` library.
However, it's useful to be able to sort a collection of heterogeneous
descriptor nodes, so I've implemented comparison operators on the root
`DescriptorNode` class. All comparisons are based on the string
representations of the descriptors.