### PR TITLE
 Support tuple descriptors

### DIFF
--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -10,6 +10,8 @@ from .decorators import (  # noqa: F401
     pyplot,
     immediate,
     changes_per_run,
+    accepts,
+    returns,
 )
 
 from . import protocol  # noqa: F401

--- a/bionic/cache.py
+++ b/bionic/cache.py
@@ -332,10 +332,11 @@ class CacheAccessor:
         try:
             self.query.protocol.write(value, value_path)
         except Exception as e:
+            # TODO Should we rename this to just SerializationError?
             raise EntitySerializationError(
                 oneline(
                     f"""
-                Value of entity {self.query.dnode.to_entity_name()!r}
+                Value of descriptor {self.query.dnode.to_descriptor()!r}
                 could not be serialized to disk
                 """
                 )

--- a/bionic/dagviz.py
+++ b/bionic/dagviz.py
@@ -93,12 +93,12 @@ def dot_from_graph(graph, vertical=False, curvy_lines=False, name=None):
 
     node_lists_by_cluster = defaultdict(list)
     for node in graph.nodes():
-        entity_name = graph.nodes[node]["entity_name"]
-        node_lists_by_cluster[entity_name].append(node)
+        descriptor = graph.nodes[node]["descriptor"]
+        node_lists_by_cluster[descriptor].append(node)
 
-    entity_names = list(set(graph.nodes[node]["entity_name"] for node in graph.nodes()))
-    color_strs_by_entity_name = hpluv_color_dict(
-        entity_names, saturation=99, lightness=90
+    descriptors = list(set(graph.nodes[node]["descriptor"] for node in graph.nodes()))
+    color_strs_by_descriptor = hpluv_color_dict(
+        descriptors, saturation=99, lightness=90
     )
 
     def name_from_node(node):
@@ -115,16 +115,16 @@ def dot_from_graph(graph, vertical=False, curvy_lines=False, name=None):
         subdot = pydot.Cluster(cluster, style="invis")
 
         for node in sorted_nodes:
-            entity_name = graph.nodes[node]["entity_name"]
-            entity_doc = doc_from_node(node)
+            descriptor = graph.nodes[node]["descriptor"]
+            doc = doc_from_node(node)
             dot_node = pydot.Node(
                 name_from_node(node),
                 style="filled",
-                fillcolor=color_strs_by_entity_name[entity_name],
+                fillcolor=color_strs_by_descriptor[descriptor],
                 shape="box",
             )
-            if entity_doc:
-                tooltip = rewrap_docstring(entity_doc)
+            if doc:
+                tooltip = rewrap_docstring(doc)
                 dot_node.set("tooltip", tooltip)
             subdot.add_node(dot_node)
 

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -34,7 +34,7 @@ class TaskKey:
 
     def __str__(self):
         args_str = ", ".join(f"{name}={value}" for name, value in self.case_key.items())
-        return f"{self.dnode.to_entity_name()}({args_str})"
+        return f"{self.dnode.to_descriptor(near_commas=True)}({args_str})"
 
 
 @attr.s(frozen=True)

--- a/bionic/descriptors/ast.py
+++ b/bionic/descriptors/ast.py
@@ -119,4 +119,4 @@ class TupleNode(DescriptorNode):
         return desc
 
     def all_entity_names(self):
-        return [name for child in self.children for name in child.entity_names()]
+        return [name for child in self.children for name in child.all_entity_names()]

--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -698,3 +698,29 @@ class GeoPandasProtocol(BaseProtocol):
     def validate(self, value):
         assert gpd is not None
         assert isinstance(value, gpd.GeoDataFrame)
+
+
+class TupleProtocol(BaseProtocol):
+    """
+    Describes values that are Python tuples of a fixed length. This is used mainly
+    by Bionic's infrastructure for values corresponding to tuple descriptors.
+
+    This protocol does not support serializing or deserializing values.
+    """
+
+    def __init__(self, length):
+        super(TupleProtocol, self).__init__()
+
+        self._expected_length = length
+
+    def validate(self, value):
+        try:
+            items = tuple(value)
+        except TypeError as e:
+            raise AssertionError(str(e))
+        if len(items) != self._expected_length:
+            message = f"""
+            Expected a sequence with length {self._expected_length};
+            instead, got {len(items)} values: {items!r}
+            """
+            raise AssertionError(oneline(message))

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -922,6 +922,34 @@ class ArgDescriptorSubstitutionProvider(WrappingProvider):
         "inner" nodes, which correspond dependency descriptors expected by the wrapped
         provider tasks. The values are the "outer" nodes, corresponding to dependency
         descriptors exposed by this provider.
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        @builder
+        @bn.accepts(x_y="x, y")
+        def x_plus_y(x_y):
+            x, y = x_y
+            return x + y
+
+    In this case, ``x, y`` is the "outer" descriptor (exposed to Bionic's
+    infrastructure), and ``x_y`` is the "inner" descriptor (visible to the wrapped
+    function but not corresponding to any actual entity). This diagram may clarify the
+    relationship between "inner" and "outer":
+
+    ::
+
+         -----------------this_provider--------------------
+         |                                                |
+         |           -- wrapped_provider --               |
+         |           |                    |               |
+        x, y   ->   x_y        ->     x_plus_y   ->   x_plus_y
+         |           |                    |               |
+         |           ----------------------               |
+         |                                                |
+         -------------------------------------------------|
     """
 
     def __init__(self, wrapped_provider, outer_dnodes_by_inner):

--- a/tests/test_flow/test_new_api.py
+++ b/tests/test_flow/test_new_api.py
@@ -1,0 +1,102 @@
+"""
+These tests are for experimental descriptor-based uses of Bionic's API.
+"""
+
+import pytest
+
+import bionic as bn
+
+
+def test_returns(builder):
+    @builder
+    @bn.returns("one")
+    def _():
+        return 1
+
+    @builder
+    @bn.returns("two,")
+    def _():
+        return (2,)
+
+    @builder
+    @bn.returns("three, four")
+    def _():
+        return 3, 4
+
+    @builder
+    @bn.returns("five, (six, seven)")
+    def _():
+        return 5, (6, 7)
+
+    flow = builder.build()
+
+    assert flow.get("one") == 1
+    assert flow.get("two") == 2
+    assert flow.get("three") == 3
+    assert flow.get("four") == 4
+    assert flow.get("five") == 5
+    assert flow.get("six") == 6
+    assert flow.get("seven") == 7
+
+
+def test_accepts(builder):
+    builder.assign("x", 2)
+    builder.assign("y", 3)
+    builder.assign("z", 4)
+
+    @builder
+    @bn.accepts(my_x="x")
+    def x_plus_one(my_x):
+        return my_x + 1
+
+    @builder
+    @bn.accepts(x_="x,")
+    def x_plus_two(x_):
+        (x,) = x_
+        return x + 2
+
+    @builder
+    @bn.accepts(my_y="y", my_other_y="y")
+    def x_plus_two_y(x, my_y, my_other_y):
+        return x + my_y + my_other_y
+
+    @builder
+    @bn.accepts(x_y="x, y")
+    def x_plus_y(x_y):
+        x, y = x_y
+        return x + y
+
+    @builder
+    @bn.accepts(my_x="x", my_y="y")
+    def xy(my_x, my_y):
+        return my_x * my_y
+
+    @builder
+    @bn.accepts(x_y_z="x, (y, z)")
+    def x_plus_y_plus_z(x_y_z):
+        x, (y, z) = x_y_z
+        return x + y + z
+
+    flow = builder.build()
+
+    assert flow.get("x_plus_one") == 3
+    assert flow.get("x_plus_two") == 4
+    assert flow.get("x_plus_y") == 5
+    assert flow.get("x_plus_two_y") == 8
+    assert flow.get("xy") == 6
+    assert flow.get("x_plus_y_plus_z") == 9
+
+
+@pytest.mark.skip("Not implemented yet")
+def test_get(builder):
+    builder.assign("x", 2)
+    builder.assign("y", 3)
+    builder.assign("z", 4)
+
+    flow = builder.build()
+
+    assert flow.get("()") == ()
+    assert flow.get("x,") == (2,)
+    assert flow.get("x, x") == (2, 2)
+    assert flow.get("x, y") == (2, 3)
+    assert flow.get("x, (y, z)") == (2, (3, 4))


### PR DESCRIPTION
This is an extensive refactor of Bionic's plumbing to support tuple
descriptors (in addition to entity descriptors, which were already
supported). Currently the only way to actually use tuple descriptors is
with the new `@accepts` and `@returns` decorators; however, these
decorators are experimental and undocumented.

Other than these new decorators, there should be no functional change.

In a future commit, I'll update the `@outputs` and
`builder.adding_cases` to use tuple descriptors behind the scenes.
(Again, with almost no functional change.)