### PR TITLE
Use tuple descriptors internally

### DIFF
--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -18,7 +18,6 @@ from .provider import (
     AttrUpdateProvider,
     PyplotProvider,
     RenamingProvider,
-    NameSplittingProvider,
     ArgDescriptorSubstitutionProvider,
     NewOutputDescriptorProvider,
 )
@@ -254,9 +253,7 @@ def outputs(*names):
         A decorator which can be applied to an entity function.
     """
 
-    return decorator_updating_accumulator(
-        lambda acc: acc.wrap_provider(NameSplittingProvider, names)
-    )
+    return returns(",".join(names) + ",")
 
 
 def docs(*docs):

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -28,7 +28,7 @@ from .code_hasher import CodeHasher
 from .deps.optdep import import_optional_dependency
 from .descriptors.parsing import entity_dnode_from_descriptor
 from .descriptors import ast
-from .exception import EntityComputationError, EntityValueError, IncompatibleEntityError
+from .exception import EntityComputationError, IncompatibleEntityError
 from .utils.misc import groups_dict, oneline
 
 import logging
@@ -136,18 +136,25 @@ class ValueProvider(BaseProvider):
         return ValueProvider(names)
 
     def __init__(self, names):
-        dnodes = [entity_dnode_from_descriptor(name) for name in names]
+        # TODO Move this special-casing out of this class -- perhaps into the Flow code,
+        # or perhaps breaking out these cases into subclasses.
+        entity_dnodes = [entity_dnode_from_descriptor(name) for name in names]
+        if len(entity_dnodes) == 1:
+            (dnode,) = entity_dnodes
+            output_is_tuple = False
+        else:
+            dnode = ast.TupleNode(entity_dnodes)
+            output_is_tuple = True
+
         super(ValueProvider, self).__init__(
-            attrs=ProviderAttributes(
-                dnodes=dnodes,
-                changes_per_run=False,
-            ),
+            attrs=ProviderAttributes(dnodes=[dnode], changes_per_run=False),
         )
 
         self.key_space = CaseKeySpace(names)
         self._has_any_values = False
         self._value_tuples_by_case_key = {}
         self._token_tuples_by_case_key = {}
+        self._output_is_tuple = output_is_tuple
 
     def add_case(self, case_key, values, tokens):
         provider = self._copy()
@@ -222,16 +229,12 @@ class ValueProvider(BaseProvider):
         assert not dep_key_spaces_by_dnode
         assert not dep_task_key_lists_by_dnode
 
+        (out_dnode,) = self.attrs.dnodes
+
         if self.has_any_cases():
             return [
                 Task(
-                    keys=[
-                        TaskKey(
-                            dnode=entity_dnode_from_descriptor(name),
-                            case_key=case_key,
-                        )
-                        for name in self.entity_names
-                    ],
+                    keys=[TaskKey(dnode=out_dnode, case_key=case_key)],
                     dep_keys=[],
                     compute_func=functools.partial(
                         self._compute,
@@ -249,12 +252,11 @@ class ValueProvider(BaseProvider):
                 Task(
                     keys=[
                         TaskKey(
-                            dnode=entity_dnode_from_descriptor(name),
+                            dnode=out_dnode,
                             case_key=CaseKey(
                                 [(name, None) for name in self.entity_names]
                             ),
                         )
-                        for name in self.entity_names
                     ],
                     dep_keys=[],
                     compute_func=None,
@@ -262,7 +264,10 @@ class ValueProvider(BaseProvider):
             ]
 
     def _compute(self, dep_values, case_key):
-        return self._value_tuples_by_case_key[case_key]
+        if self._output_is_tuple:
+            return [self._value_tuples_by_case_key[case_key]]
+        else:
+            return [self._value_tuples_by_case_key[case_key][0]]
 
 
 class BaseDerivedProvider(BaseProvider):
@@ -446,85 +451,6 @@ class RenamingProvider(WrappingProvider):
             dep_key_spaces_by_dnode,
             dep_task_key_lists_by_dnode,
         )
-        return [wrap_task(task) for task in inner_tasks]
-
-
-class NameSplittingProvider(WrappingProvider):
-    def __init__(self, wrapped_provider, names):
-
-        super(NameSplittingProvider, self).__init__(wrapped_provider)
-
-        orig_dnodes = wrapped_provider.attrs.dnodes
-        if len(orig_dnodes) != 1:
-            orig_descriptors = [dnode.to_descriptor() for dnode in orig_dnodes]
-            raise ValueError(
-                oneline(
-                    f"""
-                Can't change a provider's number of names multiple times;
-                need exactly one name but got {tuple(orig_descriptors)!r}"""
-                )
-            )
-
-        dnodes = [entity_dnode_from_descriptor(name) for name in names]
-
-        self.attrs = copy(wrapped_provider.attrs)
-        self.attrs.dnodes = dnodes
-
-    def get_tasks(self, dep_key_spaces_by_dnode, dep_task_key_lists_by_dnode):
-        inner_tasks = self.wrapped_provider.get_tasks(
-            dep_key_spaces_by_dnode,
-            dep_task_key_lists_by_dnode,
-        )
-
-        def wrap_task(task):
-            assert len(task.keys) == 1
-            (task_key,) = task.keys
-
-            def wrapped_compute_func(dep_values):
-                (value_seq,) = task.compute(dep_values)
-
-                try:
-                    value_seq_len = len(value_seq)
-                except TypeError:
-                    descriptors = [dnode.to_descriptor() for dnode in self.attrs.dnodes]
-                    raise EntityValueError(
-                        oneline(
-                            f"""
-                        Expected provider
-                        {self.wrapped_provider.attrs.dnodes[0].to_descriptor()!r} to
-                        return a sequence of {len(descriptors)} outputs named
-                        {descriptors!r};
-                        got a non-sequence output {value_seq!r}"""
-                        )
-                    )
-
-                if value_seq_len != len(self.attrs.dnodes):
-                    descriptors = [dnode.to_descriptor() for dnode in self.attrs.dnodes]
-                    raise EntityValueError(
-                        oneline(
-                            f"""
-                        Expected provider
-                        {self.wrapped_provider.attrs.dnodes[0].to_descriptor()!r} to
-                        return {len(descriptors)} outputs named
-                        {descriptors!r};
-                        got {len(value_seq)} outputs {tuple(value_seq)!r}"""
-                        )
-                    )
-
-                return tuple(value_seq)
-
-            return Task(
-                keys=[
-                    TaskKey(
-                        dnode=dnode,
-                        case_key=task_key.case_key,
-                    )
-                    for dnode in self.attrs.dnodes
-                ],
-                dep_keys=task.dep_keys,
-                compute_func=wrapped_compute_func,
-            )
-
         return [wrap_task(task) for task in inner_tasks]
 
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -96,6 +96,13 @@ Deprecated Features
   crashes on Mac OS when using multiprocessing. Versions 3.1.x and 3.3+ are still
   supported.
 
+Improvements
+............
+
+- When a function returns multiple entities (using the :func:`@outputs
+  <bionic.outputs>` decorator), it now appears in Bionic's DAG visualization as a
+  separate node, with the individual entity nodes depending on it.
+
 Bug Fixes
 .........
 

--- a/tests/test_flow/test_dagviz.py
+++ b/tests/test_flow/test_dagviz.py
@@ -58,7 +58,7 @@ def nodes_by_name_from_dot(dot):
 
 
 def test_dag_size(flow_graph):
-    assert len(flow_graph.nodes) == 9
+    assert len(flow_graph.nodes) == 11
 
 
 def test_dot_properties(flow_dot):
@@ -69,6 +69,8 @@ def test_dot_properties(flow_dot):
         '"first_name[0]"',
         '"first_name[1]"',
         '"last_name"',
+        '"(full_name, initials)[0]"',
+        '"(full_name, initials)[1]"',
         '"full_name[0]"',
         '"full_name[1]"',
         '"initials[0]"',
@@ -81,6 +83,10 @@ def test_dot_properties(flow_dot):
     assert nodes['"all_names"'].get_tooltip() == "Comma-separated list of names."
     assert nodes['"initials[0]"'].get_tooltip() == "Just the initials."
     assert nodes['"initials[1]"'].get_tooltip() == "Just the initials."
+    assert (
+        nodes['"(full_name, initials)[0]"'].get_tooltip()
+        == "A Python tuple with 2 values."
+    )
 
     assert nodes['"last_name"'].get_fillcolor() != nodes['"all_names"'].get_fillcolor()
     assert (


### PR DESCRIPTION
This changes implementation of `@outputs` and `builder.adding_cases` to
use tuple descriptors instead of using providers that return multiple
values. This has no functional changes, with the exception that tuples
nodes now appear in the DAG visualization as their own nodes.  (The
logging for these nodes is probably also slightly different.)

One big benefit of this change is that now every task has exactly one
key and returns exactly one value, which means we can substantially
simplify a lot of code in a future refactor.