### PR TITLE
Remove values from CaseKey

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -179,23 +179,10 @@ class CaseKeySpace(ImmutableSequence):
         return f'CaseKeySpace({", ".join(repr(name) for name in self)})'
 
 
-@attr.s(frozen=True)
-class MissingCaseKeyToken:
-    def __str__(self):
-        return "<MISSING>"
-
-
 class CaseKey(ImmutableMapping):
     """
     A collection of name-token pairs that uniquely identifies a case.
     """
-
-    # This is a sentinel value used to indicate that no value is available. We can't use
-    # None because None is itself a valid token for None Value.
-    # Normally I would prefer to represent missing-ness out-of-band by making the
-    # `missing_names` field the source of truth here, but the relational methods like
-    # `project` are cleaner when we use a sentinel value.
-    MISSING = MissingCaseKeyToken()
 
     def __init__(self, name_token_pairs):
         tokens_by_name = {name: token for name, token in name_token_pairs}
@@ -205,7 +192,13 @@ class CaseKey(ImmutableMapping):
         self.tokens = tokens_by_name
         self.space = CaseKeySpace(list(tokens_by_name.keys()))
         self.missing_names = [
-            name for name, token in name_token_pairs if token == self.MISSING
+            # None is a sentinel value used to indicate that no value is available.
+            # Normally I would prefer to represent missing-ness out-of-band by making the
+            # `missing_names` field the source of truth here, but the relational methods like
+            # `project` are cleaner when we use a sentinel value.
+            name
+            for name, token in name_token_pairs
+            if token is None
         ]
         self.has_missing_values = len(self.missing_names) > 0
 

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -458,7 +458,7 @@ class FlowBuilder:
         )
         state = state.create_provider(name)
         for value in values:
-            case_key = CaseKey([(name, value, protocol.tokenize(value))])
+            case_key = CaseKey([(name, protocol.tokenize(value))])
             state = state.add_case(case_key, [name], [value])
 
         self._state = state
@@ -496,7 +496,7 @@ class FlowBuilder:
             # TODO We can remove this validation, since it also happens in add_case
             # below.
             protocol.validate(value)
-            case_key = CaseKey([(name, value, protocol.tokenize(value))])
+            case_key = CaseKey([(name, protocol.tokenize(value))])
             state = state.add_case(case_key, [name], [value])
 
         self._state = state
@@ -580,7 +580,7 @@ class FlowBuilder:
         state = state.group_names_together(names)
 
         values = []
-        case_nvt_tuples = []
+        name_token_pairs = []
         for name, value in name_value_pairs:
             protocol = state.get_entity_def(name).protocol
             # TODO Both the validation and tokenization are also happening in
@@ -589,9 +589,9 @@ class FlowBuilder:
             token = protocol.tokenize(value)
 
             values.append(value)
-            case_nvt_tuples.append((name, value, token))
+            name_token_pairs.append((name, token))
 
-        case_key = CaseKey(case_nvt_tuples)
+        case_key = CaseKey(name_token_pairs)
 
         state = state.add_case(case_key, names, values)
 

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -224,10 +224,7 @@ class ValueProvider(BaseProvider):
                         TaskKey(
                             dnode=entity_dnode_from_descriptor(name),
                             case_key=CaseKey(
-                                [
-                                    (name, CaseKey.MISSING, "<MISSING>")
-                                    for name in self.entity_names
-                                ]
+                                [(name, CaseKey.MISSING) for name in self.entity_names]
                             ),
                         )
                         for name in self.entity_names


### PR DESCRIPTION
CaseKeys are sent to the subprocesses as part of a lot of objects. We
don't want values to be sent across directly to subprocesses as they
can be unpicklable or user might have defined a custom protocol for
them that we should use instead.

This change stops using values inside CaseKey. It is only used to get
the values for the multi-index when fetching a series for the user.
Instead of storing values in CaseKey, we now store them inside
providers which already takes care of CaseKeys for us, are immutable,
and aren't sent to the subprocesses.