### PR TITLE
Add CI workflow in GitHub Actions

### DIFF
--- a/bionic-test.yml
+++ b/bionic-test.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on: push
+
+jobs:
+  build:
+
+    # Consider running on macos-latest as well.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # TODO: Run tests on python 3.8 as well.
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        sudo apt-get install graphviz
+        pip install --upgrade --upgrade-strategy eager '.[dev]'
+        # This prints out all installed package versions, which may help for debugging
+        # build failures.
+        pip freeze
+    - name: Lint with flake8 and black
+      run: |
+        flake8
+        black --check .
+    - name: Test with pytest
+      run: |
+        pytest --slow
+        pytest --slow --parallel


### PR DESCRIPTION
Janek and I both got an email from Travis that our trial ended. This
gives us a good opportunity to move to GitHub Actions for good. To
start with, this PR adds the basic CI workflow. I'll create a follow-up
PR to add the publish workflow.

Link to the original template:
https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#starting-with-the-python-workflow-template