### PR TITLE
Fix noqa F811 for Python 3.8

### DIFF
--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -321,7 +321,7 @@ def test_merge(builder):
     builder3.declare("b")
 
     @builder3  # noqa: F811
-    def h(a, b):
+    def h(a, b):  # noqa: F811
         return a * b
 
     builder.merge(builder3.build(), keep="new")

--- a/tests/test_flow/test_merge.py
+++ b/tests/test_flow/test_merge.py
@@ -136,7 +136,7 @@ def merge_tester(builder):
 
     @fb  # noqa: F811
     @bn.outputs("x", "y")
-    def x(x_y):
+    def x(x_y):  # noqa: F811
         return x_y
 
     tester.add("DerivedJoint", fb.build())
@@ -165,7 +165,7 @@ def merge_tester(builder):
 
     @fb  # noqa: F811
     @bn.persist(False)
-    def x(root_x):
+    def x(root_x):  # noqa: F811
         return root_x ** 2
 
     tester.add("DS", fb.build())
@@ -176,7 +176,7 @@ def merge_tester(builder):
     @fb  # noqa: F811
     @bn.outputs("x", "y")
     @bn.persist(False)
-    def x(x_y):
+    def x(x_y):  # noqa: F811
         return x_y
 
     tester.add("DJ", fb.build())

--- a/tests/test_flow/test_persistence_gcs.py
+++ b/tests/test_flow/test_persistence_gcs.py
@@ -112,7 +112,7 @@ def test_versioning(gcs_builder, make_counter):
     assert flow.setting("x", 4).get("xy") == 12
 
     @builder  # noqa: F811
-    def xy(x, y):
+    def xy(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
 
@@ -127,7 +127,7 @@ def test_versioning(gcs_builder, make_counter):
 
     @builder  # noqa: F811
     @bn.version(minor=1)
-    def xy(x, y):
+    def xy(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
 
@@ -146,7 +146,7 @@ def test_versioning(gcs_builder, make_counter):
 
     @builder  # noqa: F811
     @bn.version(major=1)
-    def xy(x, y):
+    def xy(x, y):  # noqa: F811
         call_counter.mark()
         return x ** y
 
@@ -189,7 +189,7 @@ def test_indirect_versioning(gcs_builder, make_counter):
 
     @builder  # noqa: F811
     @bn.version(major=1)
-    def xy(x, y):
+    def xy(x, y):  # noqa: F811
         call_counter.mark()
         return int(float(x)) ** y
 
@@ -199,7 +199,7 @@ def test_indirect_versioning(gcs_builder, make_counter):
 
     @builder  # noqa: F811
     @bn.version(major=1, minor=1)
-    def xy(x, y):
+    def xy(x, y):  # noqa: F811
         call_counter.mark()
         return int(float(y)) ** x
 
@@ -210,7 +210,7 @@ def test_indirect_versioning(gcs_builder, make_counter):
 
     @builder  # noqa: F811
     @bn.version(major=2)
-    def xy(x, y):
+    def xy(x, y):  # noqa: F811
         call_counter.mark()
         return y ** x
 


### PR DESCRIPTION
Flake8 behavior for noqa F811 changed with python version 3.8. It now
expects the comment to be on the function defn instead of the first
annotation. We'll keep the comment on both lines. This is in line with
how we fixed it for test_persistence.py.