### PR TITLE
Run all tests without parallel option

### DIFF
--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -31,4 +31,4 @@ jobs:
         black --check .
     - name: Test with pytest
       run: |
-        pytest --slow
+        pytest --all-execution-modes --slow

--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -32,4 +32,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --slow
-        pytest --slow --parallel

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from .helpers import gsutil_path_exists, gsutil_wipe_path, ResettingCounter
 import bionic as bn
 
 
-class ProcessingType(Enum):
+class ExecutionMode(Enum):
     PARALLEL = "PARALLEL"
     SERIAL = "SERIAL"
 
@@ -20,9 +20,9 @@ class ProcessingType(Enum):
 # like test_name[PARALLEL] and test_name[SERIAL]. This is super helpful while
 # debugging and much clearer than parameterizing `parallel_processing_enabled`
 # which suffixes [TRUE] / [FALSE].
-@pytest.fixture(params=[ProcessingType.PARALLEL, ProcessingType.SERIAL])
+@pytest.fixture(params=[ExecutionMode.PARALLEL, ExecutionMode.SERIAL])
 def parallel_processing_enabled(request):
-    return request.param == ProcessingType.PARALLEL
+    return request.param == ExecutionMode.PARALLEL
 
 
 # We provide this at the top level because we want everyone using FlowBuilder
@@ -83,11 +83,21 @@ def pytest_addoption(parser):
     parser.addoption(
         "--bucket", action="store", help="URL to GCS bucket to use for tests"
     )
+    parser.addoption(
+        "--all-execution-modes",
+        action="store_true",
+        default=False,
+        help="also run all tests with parallel execution mode",
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "needs_gcs: mark test as requiring GCS to run")
+    config.addinivalue_line(
+        "markers",
+        "run_with_all_execution_modes_by_default: mark test to always run all execution modes",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -102,6 +112,17 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "needs_gcs" in item.keywords:
                 item.add_marker(skip_gcs)
+
+    if not config.getoption("--all-execution-modes"):
+        skip_execution_mode = pytest.mark.skip(
+            reason="only runs when --all-execution-modes is set"
+        )
+        for item in items:
+            if (
+                any("ExecutionMode.PARALLEL" in keyword for keyword in item.keywords)
+                and "run_with_all_execution_modes_by_default" not in item.keywords
+            ):
+                item.add_marker(skip_execution_mode)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -684,8 +684,7 @@ def test_unpicklable_non_persisted_entity(builder):
     assert builder.build().get("uses_lock")
 
 
-@pytest.mark.no_parallel
-def test_entity_serialization_exception(builder):
+def test_entity_serialization_exception(builder, parallel_processing_enabled):
     @builder
     def unpicklable_value():
         def f():
@@ -697,27 +696,13 @@ def test_entity_serialization_exception(builder):
         builder.build().get("unpicklable_value")
     except EntitySerializationError as e:
         # AttributeError is what happens when we try to pickle a function.
-        assert isinstance(e.__cause__, AttributeError)
+        if parallel_processing_enabled:
+            assert "\nAttributeError:" in e.__cause__.tb
+        else:
+            assert isinstance(e.__cause__, AttributeError)
 
 
-@pytest.mark.only_parallel
-def test_entity_serialization_exception_parallel(builder):
-    @builder
-    def unpicklable_value():
-        def f():
-            return 1
-
-        return f
-
-    try:
-        builder.build().get("unpicklable_value")
-    except EntitySerializationError as e:
-        # AttributeError is what happens when we try to pickle a function.
-        assert "\nAttributeError:" in e.__cause__.tb
-
-
-@pytest.mark.no_parallel
-def test_entity_computation_exception(builder):
+def test_entity_computation_exception(builder, parallel_processing_enabled):
     @builder
     def uncomputable_value():
         return 1 / 0
@@ -725,19 +710,10 @@ def test_entity_computation_exception(builder):
     try:
         builder.build().get("uncomputable_value")
     except EntityComputationError as e:
-        assert isinstance(e.__cause__, ZeroDivisionError)
-
-
-@pytest.mark.only_parallel
-def test_entity_computation_exception_parallel(builder):
-    @builder
-    def uncomputable_value():
-        return 1 / 0
-
-    try:
-        builder.build().get("uncomputable_value")
-    except EntityComputationError as e:
-        assert "\nZeroDivisionError:" in e.__cause__.tb
+        if parallel_processing_enabled:
+            assert "\nZeroDivisionError:" in e.__cause__.tb
+        else:
+            assert isinstance(e.__cause__, ZeroDivisionError)
 
 
 def test_multiple_compute_attempts(builder):

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -371,6 +371,7 @@ def test_get_multiple(preset_flow):
     assert flow.get("q", set) == {5}
 
 
+@pytest.mark.run_with_all_execution_modes_by_default
 def test_get_collections(preset_flow):
     flow = preset_flow
 
@@ -684,6 +685,7 @@ def test_unpicklable_non_persisted_entity(builder):
     assert builder.build().get("uses_lock")
 
 
+@pytest.mark.run_with_all_execution_modes_by_default
 def test_entity_serialization_exception(builder, parallel_processing_enabled):
     @builder
     def unpicklable_value():
@@ -702,6 +704,7 @@ def test_entity_serialization_exception(builder, parallel_processing_enabled):
             assert isinstance(e.__cause__, AttributeError)
 
 
+@pytest.mark.run_with_all_execution_modes_by_default
 def test_entity_computation_exception(builder, parallel_processing_enabled):
     @builder
     def uncomputable_value():

--- a/tests/test_flow/test_gather.py
+++ b/tests/test_flow/test_gather.py
@@ -400,6 +400,7 @@ def test_rename_frame(preset_builder):
     }
 
 
+@pytest.mark.run_with_all_execution_modes_by_default
 def test_multiple_gathers(preset_builder):
     builder = preset_builder
 
@@ -431,6 +432,7 @@ def test_multiple_gathers__unset_x(preset_builder):
     assert builder.build().get("summary", list) == []
 
 
+@pytest.mark.run_with_all_execution_modes_by_default
 def test_multiple_gathers__unset_y(preset_builder):
     builder = preset_builder
 
@@ -483,6 +485,7 @@ def test_multiple_gathers__unset_w(preset_builder):
     }
 
 
+@pytest.mark.run_with_all_execution_modes_by_default
 def test_multiple_gathers_complex(preset_builder):
     builder = preset_builder
 

--- a/tests/test_flow/test_logging.py
+++ b/tests/test_flow/test_logging.py
@@ -19,6 +19,7 @@ def log_checker(caplog):
     return LogChecker(caplog)
 
 
+@pytest.mark.run_with_all_execution_modes_by_default
 def test_logging_details(builder, log_checker, parallel_processing_enabled):
     """
     Test the details of the log messages we emit. Since these messages are currently the

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -8,6 +8,10 @@ from bionic.exception import AttributeValidationError, CodeVersioningError
 import bionic as bn
 
 
+# This is detected by pytest and applied to all the tests in this module.
+pytestmark = pytest.mark.run_with_all_execution_modes_by_default
+
+
 class ReadCountingProtocol(bn.protocols.PicklableProtocol):
     def __init__(self):
         self.times_read_called = 0

--- a/tests/test_flow/test_relative_cache_path.py
+++ b/tests/test_flow/test_relative_cache_path.py
@@ -1,10 +1,8 @@
 import os
-import pytest
 import shutil
 
 
-@pytest.fixture
-def builder(builder):
+def test_move_cache_files(builder, tmp_path):
     builder.assign("x", 2)
     builder.assign("y", 3)
 
@@ -12,10 +10,6 @@ def builder(builder):
     def xy(x, y):
         return x * y
 
-    return builder
-
-
-def test_move_cache_files(builder, tmp_path):
     cur_dir = os.path.join(tmp_path, "current")
     new_dir = os.path.join(tmp_path, "new")
 


### PR DESCRIPTION
This change runs all the tests by default and removes the --parallel
option. We don't have to run pytest command twice going forward.