### PR TITLE
Add changelog file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md
 include LICENSE.txt
+include CHANGELOG.md
 graft bionic
 graft tests
 graft example

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,8 @@
+=========
+Changelog
+=========
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
+and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,4 +59,5 @@ Documentation Contents
     api/index.rst
     get-help
     contributing
+    changelog
     future


### PR DESCRIPTION
Added the rst file that will contain the changelog and added it to the
docs. I'll add notes for 0.8.0 soon and we can consider adding notes
for the older releases later.

I picked the template from [keep-a-changelog](https://github.com/olivierlacan/keep-a-changelog) but happy to try a
different template if you have preference.

This is what the changelog looks like in the documentation.
<img width="1103" alt="Screen Shot 2020-06-03 at 2 43 06 PM" src="https://user-images.githubusercontent.com/2109428/83676423-a46e4400-a5a8-11ea-997a-8716ffe9e492.png">
