### PR TITLE
Update parallel processing executor to use correct worker count

### DIFF
--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -145,6 +145,9 @@ class EntityDeriver:
                 "core__versioning_policy"
             ),
             executor=self._bootstrap_singleton_entity("core__executor"),
+            executor_worker_count=self._bootstrap_singleton_entity(
+                "core__parallel_processing__worker_count"
+            ),
         )
 
     def _prevalidate_base_dnodes(self):
@@ -337,6 +340,9 @@ class EntityDeriver:
             self._get_or_create_task_state_for_key(task.keys[0]) for task in dinfo.tasks
         ]
 
+        if self._bootstrap is not None:
+            self._bootstrap.resize_executor()
+
         task_runner = TaskCompletionRunner(self._bootstrap, self._flow_instance_uuid)
         task_runner.run(requested_task_states)
 
@@ -364,6 +370,11 @@ class Bootstrap:
     persistent_cache = attr.ib()
     versioning_policy = attr.ib()
     executor = attr.ib()
+    executor_worker_count = attr.ib()
+
+    def resize_executor(self):
+        if self.executor is not None:
+            self.executor.init_or_resize_process_pool(self.executor_worker_count)
 
 
 class TaskKeyLogger:

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -145,9 +145,6 @@ class EntityDeriver:
                 "core__versioning_policy"
             ),
             executor=self._bootstrap_singleton_entity("core__executor"),
-            executor_worker_count=self._bootstrap_singleton_entity(
-                "core__parallel_processing__worker_count"
-            ),
         )
 
     def _prevalidate_base_dnodes(self):
@@ -340,9 +337,6 @@ class EntityDeriver:
             self._get_or_create_task_state_for_key(task.keys[0]) for task in dinfo.tasks
         ]
 
-        if self._bootstrap is not None:
-            self._bootstrap.resize_executor()
-
         task_runner = TaskCompletionRunner(self._bootstrap, self._flow_instance_uuid)
         task_runner.run(requested_task_states)
 
@@ -370,11 +364,6 @@ class Bootstrap:
     persistent_cache = attr.ib()
     versioning_policy = attr.ib()
     executor = attr.ib()
-    executor_worker_count = attr.ib()
-
-    def resize_executor(self):
-        if self.executor is not None:
-            self.executor.init_or_resize_process_pool(self.executor_worker_count)
 
 
 class TaskKeyLogger:

--- a/bionic/executor.py
+++ b/bionic/executor.py
@@ -10,7 +10,6 @@ import queue
 import sys
 import threading
 import traceback
-import warnings
 
 from multiprocessing.managers import SyncManager
 
@@ -26,18 +25,7 @@ def get_reusable_executor(worker_count):
     if _executor is None:
         _executor = Executor(worker_count)
     else:
-        prev_worker_count = _executor.worker_count
-        process_pool_resized = _executor.init_or_resize_process_pool(worker_count)
-        if process_pool_resized:
-            warning = f"""
-            The number of workers in the global Loky process pool has
-            changed from {_format_worker_count(prev_worker_count)} to
-            {_format_worker_count(worker_count)}. Because this pool is
-            global, all parallel jobs will now run with the new number
-            of workers, even in Bionic flows that were configured with
-            the old number.
-            """
-            warnings.warn(oneline(warning))
+        _executor.init_or_resize_process_pool(worker_count)
 
     return _executor
 

--- a/bionic/executor.py
+++ b/bionic/executor.py
@@ -16,23 +16,6 @@ from multiprocessing.managers import SyncManager
 from .optdep import import_optional_dependency
 from .util import oneline, SynchronizedSet
 
-_executor = None
-
-
-def get_reusable_executor(worker_count):
-    global _executor
-
-    if _executor is None:
-        _executor = Executor(worker_count)
-    else:
-        _executor.init_or_resize_process_pool(worker_count)
-
-    return _executor
-
-
-def _format_worker_count(worker_count):
-    return worker_count if worker_count is not None else "the default value"
-
 
 class Executor:
     """
@@ -43,58 +26,77 @@ class Executor:
 
     def __init__(self, worker_count):
         self.worker_count = worker_count
-
-        class MyManager(SyncManager):
-            pass
-
-        MyManager.register("SynchronizedSet", SynchronizedSet)
-        self.process_manager = MyManager()
-        self.process_manager.start()
-
-        self._logging_queue = self.process_manager.Queue(-1)
-        self._logging_receiver = LoggingReceiver(self._logging_queue)
-        self._logging_receiver.start()
-
+        self._manager = get_singleton_manager()
         self._process_pool_exec = None
-        self.init_or_resize_process_pool(worker_count)
+        self._init_or_resize_process_pool()
 
-    def init_or_resize_process_pool(self, worker_count):
+    def _init_or_resize_process_pool(self):
         """
-        If the process pool is not initialized yet, initializes it and
-        returns True.
-
-        If already initialized, resizes the process pool if the
-        worker_count is different than the worker count used previously
-        and returns whether the process pool was resized.
+        Initializes the process pool if not initialized yet. If  already initialized,
+        since the process pool is a singleton in Loky, it attempts to register it again
+        which resizes the executor if the worker count changed.
         """
-
-        # When already initialized and worker count didn't change,
-        # no need to resize the process pool.
-        if self._process_pool_exec is not None and worker_count == self.worker_count:
-            return False
-
-        self.worker_count = worker_count
 
         # Loky uses cloudpickle by default. We should investigate further what would
         # it take to make is use pickle and wrap the functions that are non-picklable
         # using `loky.wrap_non_picklable_objects`.
         loky = import_optional_dependency("loky", purpose="parallel processing")
 
+        # This call to resize the executor is cheap when worker count doesn't change.
+        # Loky simply compares the arguments sent before and now. Since they match when
+        # worker count doesn't change, it returns the underlying executor without doing
+        # any kind of resizing (which might take time if the executor is running any tasks).
         self._process_pool_exec = loky.get_reusable_executor(
-            max_workers=worker_count,
+            max_workers=self.worker_count,
             initializer=logging_initializer,
-            initargs=(self._logging_queue,),
+            initargs=(self._manager.logging_queue,),
         )
-        return True
+
+    def flush_logs(self):
+        self._manager.flush_logs()
+
+    def submit(self, fn, *args, **kwargs):
+        self._init_or_resize_process_pool()
+        return self._process_pool_exec.submit(fn, *args, **kwargs)
+
+    def create_synchronized_set(self):
+        return self._manager.create_synchronized_set()
+
+
+_manager = None
+
+
+def get_singleton_manager():
+    global _manager
+    if _manager is None:
+        _manager = ExternalProcessLoggingManager()
+    return _manager
+
+
+class ExternalProcessLoggingManager:
+    """
+    Contains the process manager and logger used by the executor. This class
+    should be a singleton as it spins up a new process for process manager
+    and a new thread for receiving logs.
+    """
+
+    def __init__(self):
+        class ProcessManager(SyncManager):
+            pass
+
+        ProcessManager.register("SynchronizedSet", SynchronizedSet)
+        self._process_manager = ProcessManager()
+        self._process_manager.start()
+
+        self.logging_queue = self._process_manager.Queue(-1)
+        self._logging_receiver = LoggingReceiver(self.logging_queue)
+        self._logging_receiver.start()
 
     def flush_logs(self):
         self._logging_receiver.flush()
 
-    def submit(self, fn, *args, **kwargs):
-        return self._process_pool_exec.submit(fn, *args, **kwargs)
-
     def create_synchronized_set(self):
-        return self.process_manager.SynchronizedSet()
+        return self._process_manager.SynchronizedSet()
 
 
 def logging_initializer(logging_queue):

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -25,7 +25,7 @@ from .exception import (
     IncompatibleEntityError,
     UnsetEntityError,
 )
-from .executor import get_reusable_executor
+from .executor import Executor
 from .provider import (
     ValueProvider,
     HashableWrapper,
@@ -1759,6 +1759,6 @@ def create_default_flow_state():
     ):
         if not core__parallel_processing__enabled:
             return None
-        return get_reusable_executor(core__parallel_processing__worker_count)
+        return Executor(core__parallel_processing__worker_count)
 
     return builder._state.mark_all_entities_default()

--- a/tests/test_flow/test_executor.py
+++ b/tests/test_flow/test_executor.py
@@ -2,20 +2,36 @@ import pytest
 
 from ..conftest import ExecutionMode
 
-import bionic.executor as bnexec
+from bionic.executor import get_singleton_manager, logging_initializer
+from bionic.optdep import import_optional_dependency
 
 
+# TODO use a marker to run parallel execution mode tests.
+# This overrides the fixture defined in conftest.py.
 @pytest.fixture(params=[ExecutionMode.PARALLEL])
 def parallel_processing_enabled(request):
     return request.param == ExecutionMode.PARALLEL
 
 
-def test_exeuctor_resizes(builder):
-    builder.set("core__parallel_processing__enabled", True)
+@pytest.fixture
+def loky_executor():
+    loky = import_optional_dependency("loky", purpose="parallel processing")
+    return loky.get_reusable_executor(
+        max_workers=None,
+        initializer=logging_initializer,
+        initargs=(get_singleton_manager().logging_queue,),
+    )
+
+
+def test_executor_resizes(builder, loky_executor):
     builder.assign("x", 1)
 
     @builder
     def y(x):
+        return x
+
+    @builder
+    def z(x):
         return x
 
     builder.set("core__parallel_processing__worker_count", 2)
@@ -25,10 +41,15 @@ def test_exeuctor_resizes(builder):
     flow2 = builder.build()
 
     assert flow1.get("y") == 1
-    assert bnexec._executor.worker_count == 2
+    # It's gross to check a private variable of the executor but this is
+    # the best way to check that it was resized correctly.
+    # TODO: Return PIDs in functions and assert that PIDs are different.
+    assert loky_executor._max_workers == 2
 
     assert flow2.get("y") == 1
-    assert bnexec._executor.worker_count == 3
+    assert loky_executor._max_workers == 3
 
-    assert flow1.get("y") == 1
-    assert bnexec._executor.worker_count == 2
+    # Call a non-cached entity so that a task is submitted to executor
+    # and it resizes.
+    assert flow1.get("z") == 1
+    assert loky_executor._max_workers == 2

--- a/tests/test_flow/test_executor.py
+++ b/tests/test_flow/test_executor.py
@@ -1,0 +1,34 @@
+import pytest
+
+from ..conftest import ExecutionMode
+
+import bionic.executor as bnexec
+
+
+@pytest.fixture(params=[ExecutionMode.PARALLEL])
+def parallel_processing_enabled(request):
+    return request.param == ExecutionMode.PARALLEL
+
+
+def test_exeuctor_resizes(builder):
+    builder.set("core__parallel_processing__enabled", True)
+    builder.assign("x", 1)
+
+    @builder
+    def y(x):
+        return x
+
+    builder.set("core__parallel_processing__worker_count", 2)
+    flow1 = builder.build()
+
+    builder.set("core__parallel_processing__worker_count", 3)
+    flow2 = builder.build()
+
+    assert flow1.get("y") == 1
+    assert bnexec._executor.worker_count == 2
+
+    assert flow2.get("y") == 1
+    assert bnexec._executor.worker_count == 3
+
+    assert flow1.get("y") == 1
+    assert bnexec._executor.worker_count == 2


### PR DESCRIPTION
Bionic maintains a single instance of process pool executor that it
shares between all flow instances in the current process. If the worker
count between flows is different, that creates a problem since the
executor is shared.

Till now, Bionic used the worker count as defined by the last flow and
emitted a user warning if the worker count changed. With this change,
Bionic resizes the executor using each flows worker count before any
entity is derived. This removes the user overhead of making sure that
the worker count is correct and allows them to experiment with
different worker count as well.