### PR TITLE
Add test for persistence of multiple outputs

### DIFF
--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -1082,3 +1082,17 @@ def test_updating_cache_works_only_with_immediate(builder):
     # persist the cache entity using a cache, which leads to a circular dependency.
     with pytest.raises(AttributeValidationError):
         builder.build().get("x")
+
+
+def test_multiple_outputs_all_persisted_at_once(builder, make_counter):
+    call_counter = make_counter()
+
+    @builder
+    @bn.outputs("x", "y")
+    @count_calls(call_counter)
+    def x_y():
+        return 1, 2
+
+    assert builder.build().get("x") == 1
+    assert builder.build().get("y") == 2
+    assert call_counter.times_called() == 1


### PR DESCRIPTION
This tests that when a function computes multiple entities at once, all
of them are immediately persisted, even if the user only requested one
of them. I expect this test to start failing on [this PR](https://github.com/square/bionic/pull/150),
for reasons described in [this comment](https://github.com/square/bionic/pull/150#issuecomment-640723925).