### PR TITLE
Add geopandas protocol to default protocols

### DIFF
--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -44,6 +44,9 @@ from .util import (
 )
 
 DEFAULT_PROTOCOL = protos.CombinedProtocol(
+    # Every GeoPandas DataFrame is also a Pandas DataFrame, so we need to do the
+    # GeoPandas check first.
+    protos.GeoPandasProtocol(),
     protos.ParquetDataFrameProtocol(),
     protos.ImageProtocol(),
     protos.NumPyProtocol(),

--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -668,7 +668,8 @@ class GeoPandasProtocol(BaseProtocol):
     """
     Decorator indicating that an entity's values always have the
     ``geopandas.geodataframe.GeoDataFrame`` type.
-    These values will be serialized to a .shp directory.
+
+    These values will be serialized to SHP files.
     """
 
     def get_fixed_file_extension(self):

--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -85,6 +85,7 @@ Built-In Protocol Decorators
 .. autofunction:: bionic.protocol.dillable
 .. autofunction:: bionic.protocol.enum
 .. autofunction:: bionic.protocol.frame
+.. autofunction:: bionic.protocol.geodataframe
 .. autofunction:: bionic.protocol.image
 .. autofunction:: bionic.protocol.numpy
 .. autofunction:: bionic.protocol.path

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -393,7 +393,7 @@ return different results whenever the database's contents change.  In
 cases like this, it's not appropriate to reuse the function's previous cached
 values; we want Bionic to recompute the value each time.
 
-You can tell Bionic that a function is non-deterministic by applying the 
+You can tell Bionic that a function is non-deterministic by applying the
 :meth:`@changes_per_run <bionic.changes_per_run>` decorator:
 
 .. code-block:: python
@@ -539,13 +539,22 @@ Most Python objects can be serialized with Python's built-in `pickle
 <https://docs.python.org/3/library/pickle.html>`_ module.  However, for some
 object types it's more efficient or more idiomatic to use a different format.
 There are also some types of objects that can't be pickled at all.  Bionic uses
-``pickle`` by default, but handles some types specially: `Pandas
-<https://pandas.pydata.org/>`_ DataFrames are serialized in the `Parquet
-<https://parquet.apache.org/>`_ format, while `Pillow
-<https://pillow.readthedocs.io/en/stable/>`_ Images are serialized as `PNG
-<https://en.wikipedia.org/wiki/Portable_Network_Graphics>`_\ s.  You can
-explictly specify a serialization strategy for an entity by attaching a
-`Protocol`_ to its definition.
+``pickle`` by default, but handles some types specially:
+
+- `Pandas <https://pandas.pydata.org/>`_ DataFrames are serialized as
+  `Parquet <https://parquet.apache.org/>`_ files.
+- `NumPy <https://numpy.org/>`_ Arrays are serialized as `NPY
+  <https://numpy.org/devdocs/reference/generated/numpy.lib.format.html#npy-format>`_
+  files.
+- `Pillow <https://pillow.readthedocs.io/en/stable/>`_ Images are serialized
+  as `PNG <https://en.wikipedia.org/wiki/Portable_Network_Graphics>`_ files.
+- `Dask <https://docs.dask.org/>`_ Dataframes are serialized as `Parquet
+  <https://parquet.apache.org/>`_ files.
+- `GeoPandas <https://geopandas.org/>`_ Dataframes are serialized as `SHP
+  <https://en.wikipedia.org/wiki/Shapefile#Shapefile_shape_format_(.shp)>`_ files.
+
+You can can explictly specify a serialization strategy for an entity by
+attaching a `Protocol`_ to its definition.
 
 .. _Protocol: api/protocols.rst
 

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -72,6 +72,8 @@ full       ``pip install 'bionic[full]'``       every non-development feature
 ---------- ------------------------------------ --------------------------------
 gcp        ``pip install 'bionic[gcp]'``        caching to GCS
 ---------- ------------------------------------ --------------------------------
+geopandas  ``pip install 'bionic[geopandas]'``  the ``@geodataframe`` decorator
+---------- ------------------------------------ --------------------------------
 image      ``pip install 'bionic[image]'``      automatic de/serialization of
                                                 ``PIL.Image`` objects
 ---------- ------------------------------------ --------------------------------


### PR DESCRIPTION
Added geopandas to the list of default protocols. Users won't need to
decorate geopandas entity from now on.

Here's how the documentation changes look like:

<img width="756" alt="Screen Shot 2020-06-12 at 11 10 29 AM" src="https://user-images.githubusercontent.com/2109428/84517465-5b4f7b80-ac9d-11ea-9c49-3208d06d6858.png">

Protocols:
<img width="759" alt="Screen Shot 2020-06-11 at 11 05 58 AM" src="https://user-images.githubusercontent.com/2109428/84405091-b158ec00-abd5-11ea-8d35-7716792edc18.png">
