### PR TITLE
Make ProcessManager global

### DIFF
--- a/bionic/executor.py
+++ b/bionic/executor.py
@@ -73,6 +73,13 @@ def get_singleton_manager():
     return _manager
 
 
+class ProcessManager(SyncManager):
+    pass
+
+
+ProcessManager.register("SynchronizedSet", SynchronizedSet)
+
+
 class ExternalProcessLoggingManager:
     """
     Contains the process manager and logger used by the executor. This class
@@ -81,10 +88,6 @@ class ExternalProcessLoggingManager:
     """
 
     def __init__(self):
-        class ProcessManager(SyncManager):
-            pass
-
-        ProcessManager.register("SynchronizedSet", SynchronizedSet)
         self._process_manager = ProcessManager()
         self._process_manager.start()
 


### PR DESCRIPTION
ProcessManager was defined inside ExternalProcessLoggingManager.__init__
which makes ProcessManager class unpickable. We noticed this problem
when running parallel computing tests on MacOS with python version 3.8.
In python 3.8, multiprocessing uses spawn instead of fork as the default
mode which requires everything passed to be pickable.

This change makes ProcessManager a global class so it can be pickled and
parallel computing works for MacOS on python 3.8.