### PR TITLE
Consistent naming of parallel execution

### DIFF
--- a/bionic/executor.py
+++ b/bionic/executor.py
@@ -1,8 +1,8 @@
 """
-Contains an Executor class which wraps the Loky parallel processing
-executor in a way that allows logging to work seamlessly. Also contains
-Logging classes used by the Executor to make logging work in a parallel
-setting.
+Contains an Executor class which wraps the Loky process pool
+executor in a way that allows logging to work seamlessly. Also
+contains Logging classes used by the Executor to make logging
+work in a parallel setting.
 """
 
 import logging
@@ -19,9 +19,9 @@ from .util import oneline, SynchronizedSet
 
 class Executor:
     """
-    Encapsulates all objects related to parallel processing in one place.
-    It wraps the Loky parallel processing executor in a way that allows
-    logging to work seamlessly.
+    Encapsulates all objects related to parallel execution in one place.
+    It wraps the Loky process pool executor in a way that allows logging
+    to work seamlessly.
     """
 
     def __init__(self, worker_count):
@@ -40,7 +40,7 @@ class Executor:
         # Loky uses cloudpickle by default. We should investigate further what would
         # it take to make is use pickle and wrap the functions that are non-picklable
         # using `loky.wrap_non_picklable_objects`.
-        loky = import_optional_dependency("loky", purpose="parallel processing")
+        loky = import_optional_dependency("loky", purpose="parallel execution")
 
         # This call to resize the executor is cheap when worker count doesn't change.
         # Loky simply compares the arguments sent before and now. Since they match when
@@ -122,7 +122,7 @@ def logging_initializer(logging_queue):
         warning = """
         Root logger in the subprocess seems to be modified and have
         multiple logging handlers. Make any logger changes outside
-        Bionic functions for logging to work correctly when processing
+        Bionic functions for logging to work correctly when executing
         in parallel.
         """
     orig_handlers = logger.handlers

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1779,17 +1779,17 @@ def create_default_flow_state():
             cloud_store=core__persistent_cache__cloud_store,
         )
 
-    builder.assign("core__parallel_processing__enabled", False, persist=False)
+    builder.assign("core__parallel_execution__enabled", False, persist=False)
     # The executor uses max available CPUs when set to None.
-    builder.assign("core__parallel_processing__worker_count", None, persist=False)
+    builder.assign("core__parallel_execution__worker_count", None, persist=False)
 
     @builder
     @decorators.immediate
     def core__executor(
-        core__parallel_processing__enabled, core__parallel_processing__worker_count,
+        core__parallel_execution__enabled, core__parallel_execution__worker_count,
     ):
-        if not core__parallel_processing__enabled:
+        if not core__parallel_execution__enabled:
             return None
-        return Executor(core__parallel_processing__worker_count)
+        return Executor(core__parallel_execution__worker_count)
 
     return builder._state.mark_all_entities_default()

--- a/bionic/task_state.py
+++ b/bionic/task_state.py
@@ -68,7 +68,7 @@ class TaskState:
 
 
         Note that the definition is complicated because dependencies that cannot be
-        persisted can potentially be computed again in case of parallel processing.
+        persisted can potentially be computed again in case of parallel execution.
         But we don't want to complete the persisted entities when trying to complete
         this task state. They should already be complete to avoid doing any unnecessary
         state tracking for completing this state.
@@ -284,7 +284,7 @@ class TaskState:
                     )
                 self._result_value_hashes_by_dnode[accessor.query.dnode] = value_hash
 
-        # Lastly, we can mark the process as complete.
+        # Lastly, we can mark the task state as complete.
         self.is_complete = True
 
     def initialize(self, bootstrap, flow_instance_uuid):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,20 +18,20 @@ class ExecutionMode(Enum):
 
 # Parameterizing a fixture adds the parameter in the test name at the end,
 # like test_name[PARALLEL] and test_name[SERIAL]. This is super helpful while
-# debugging and much clearer than parameterizing `parallel_processing_enabled`
+# debugging and much clearer than parameterizing `parallel_execution_enabled`
 # which suffixes [TRUE] / [FALSE].
 @pytest.fixture(params=[ExecutionMode.PARALLEL, ExecutionMode.SERIAL])
-def parallel_processing_enabled(request):
+def parallel_execution_enabled(request):
     return request.param == ExecutionMode.PARALLEL
 
 
 # We provide this at the top level because we want everyone using FlowBuilder
 # to use a temporary directory rather than the default one.
 @pytest.fixture
-def builder(parallel_processing_enabled, tmp_path):
+def builder(parallel_execution_enabled, tmp_path):
     builder = bn.FlowBuilder("test")
     builder.set("core__persistent_cache__flow_dir", str(tmp_path / "BNTESTDATA"))
-    builder.set("core__parallel_processing__enabled", parallel_processing_enabled)
+    builder.set("core__parallel_execution__enabled", parallel_execution_enabled)
     return builder
 
 
@@ -57,8 +57,8 @@ def multiprocessing_manager(request):
 
 
 @pytest.fixture
-def process_manager(parallel_processing_enabled, multiprocessing_manager):
-    if not parallel_processing_enabled:
+def process_manager(parallel_execution_enabled, multiprocessing_manager):
+    if not parallel_execution_enabled:
         return None
     return multiprocessing_manager
 

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -686,7 +686,7 @@ def test_unpicklable_non_persisted_entity(builder):
 
 
 @pytest.mark.run_with_all_execution_modes_by_default
-def test_entity_serialization_exception(builder, parallel_processing_enabled):
+def test_entity_serialization_exception(builder, parallel_execution_enabled):
     @builder
     def unpicklable_value():
         def f():
@@ -698,14 +698,14 @@ def test_entity_serialization_exception(builder, parallel_processing_enabled):
         builder.build().get("unpicklable_value")
     except EntitySerializationError as e:
         # AttributeError is what happens when we try to pickle a function.
-        if parallel_processing_enabled:
+        if parallel_execution_enabled:
             assert "\nAttributeError:" in e.__cause__.tb
         else:
             assert isinstance(e.__cause__, AttributeError)
 
 
 @pytest.mark.run_with_all_execution_modes_by_default
-def test_entity_computation_exception(builder, parallel_processing_enabled):
+def test_entity_computation_exception(builder, parallel_execution_enabled):
     @builder
     def uncomputable_value():
         return 1 / 0
@@ -713,7 +713,7 @@ def test_entity_computation_exception(builder, parallel_processing_enabled):
     try:
         builder.build().get("uncomputable_value")
     except EntityComputationError as e:
-        if parallel_processing_enabled:
+        if parallel_execution_enabled:
             assert "\nZeroDivisionError:" in e.__cause__.tb
         else:
             assert isinstance(e.__cause__, ZeroDivisionError)

--- a/tests/test_flow/test_executor.py
+++ b/tests/test_flow/test_executor.py
@@ -9,13 +9,13 @@ from bionic.optdep import import_optional_dependency
 # TODO use a marker to run parallel execution mode tests.
 # This overrides the fixture defined in conftest.py.
 @pytest.fixture(params=[ExecutionMode.PARALLEL])
-def parallel_processing_enabled(request):
+def parallel_execution_enabled(request):
     return request.param == ExecutionMode.PARALLEL
 
 
 @pytest.fixture
 def loky_executor():
-    loky = import_optional_dependency("loky", purpose="parallel processing")
+    loky = import_optional_dependency("loky", purpose="parallel execution")
     return loky.get_reusable_executor(
         max_workers=None,
         initializer=logging_initializer,
@@ -34,10 +34,10 @@ def test_executor_resizes(builder, loky_executor):
     def z(x):
         return x
 
-    builder.set("core__parallel_processing__worker_count", 2)
+    builder.set("core__parallel_execution__worker_count", 2)
     flow1 = builder.build()
 
-    builder.set("core__parallel_processing__worker_count", 3)
+    builder.set("core__parallel_execution__worker_count", 3)
     flow2 = builder.build()
 
     assert flow1.get("y") == 1

--- a/tests/test_flow/test_logging.py
+++ b/tests/test_flow/test_logging.py
@@ -20,7 +20,7 @@ def log_checker(caplog):
 
 
 @pytest.mark.run_with_all_execution_modes_by_default
-def test_logging_details(builder, log_checker, parallel_processing_enabled):
+def test_logging_details(builder, log_checker, parallel_execution_enabled):
     """
     Test the details of the log messages we emit. Since these messages are currently the
     best way to get visibility into what Bionic is doing, we have much more detailed
@@ -51,8 +51,8 @@ def test_logging_details(builder, log_checker, parallel_processing_enabled):
 
     assert flow.get("x_plus_two") == 3
 
-    if parallel_processing_enabled:
-        # This is different from serial processing because we don't pass
+    if parallel_execution_enabled:
+        # This is different from serial execution because we don't pass
         # in-memory cache to the subprocesses. The subprocess loads the
         # entities from disk cache instead.
         log_checker.expect(
@@ -70,7 +70,7 @@ def test_logging_details(builder, log_checker, parallel_processing_enabled):
     flow = builder.build()
     assert flow.get("x_plus_one") == 2
     # We don't access the definitions for simple lookup objects in
-    # parallel processing unless we use the objects for computation.
+    # parallel execution unless we use the objects for computation.
     # Since we load x_plus_one from disk cache, we don't access the
     # definition for x.
     # To clarify: we do access it for looking at the cache, but it's

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -27,7 +27,7 @@ class ReadCountingProtocol(bn.protocols.PicklableProtocol):
 # It would be nice to move the builder setup into fixtures, but since we need
 # to access the bound functions as well (to check the number of times they were
 # called), it's easiest to just have one long test.
-def test_caching_and_invalidation(builder, make_counter, parallel_processing_enabled):
+def test_caching_and_invalidation(builder, make_counter, parallel_execution_enabled):
     # Set up the builder with singleton values.
 
     builder.assign("x", 2)
@@ -71,8 +71,8 @@ def test_caching_and_invalidation(builder, make_counter, parallel_processing_ena
     assert flow.get("xy_plus_yz") == 18
     assert flow.get("xy_plus_yz") == 18
     assert xy_counter.times_called() == 0
-    if parallel_processing_enabled:
-        # This is different from serial processing because we don't pass
+    if parallel_execution_enabled:
+        # This is different from serial execution because we don't pass
         # in-memory cache to the subprocesses. The subprocess computes
         # non-persisted entities instead.
         assert yz_counter.times_called() == 1
@@ -110,7 +110,7 @@ def test_caching_and_invalidation(builder, make_counter, parallel_processing_ena
     assert flow.get("xy_plus_yz") == -6
     assert flow.get("xy_plus_yz") == -6
     assert xy_counter.times_called() == 0
-    if parallel_processing_enabled:
+    if parallel_execution_enabled:
         assert yz_counter.times_called() == 1
     else:
         assert yz_counter.times_called() == 0
@@ -134,7 +134,7 @@ def test_caching_and_invalidation(builder, make_counter, parallel_processing_ena
         2 * 6 + 6 * 4,
     }  # noqa: E226
     assert xy_counter.times_called() == 0
-    if parallel_processing_enabled:
+    if parallel_execution_enabled:
         assert yz_counter.times_called() == 3
     else:
         assert yz_counter.times_called() == 0
@@ -176,7 +176,7 @@ def test_caching_and_invalidation(builder, make_counter, parallel_processing_ena
         2 * 9 + 9 * 4,
     }  # noqa: E226
     assert xy_counter.times_called() == 0
-    if parallel_processing_enabled:
+    if parallel_execution_enabled:
         assert yz_counter.times_called() == 2
     else:
         assert yz_counter.times_called() == 0
@@ -940,7 +940,7 @@ def test_unset_and_not_persisted(builder):
 
 
 def test_changes_per_run_and_not_persist(
-    builder, make_counter, parallel_processing_enabled
+    builder, make_counter, parallel_execution_enabled
 ):
     builder.assign("x", 5)
 
@@ -978,8 +978,8 @@ def test_changes_per_run_and_not_persist(
     flow = builder.build()
     assert flow.get("x_plus_one") == 6
     assert flow.get("x_plus_four") == 9
-    if parallel_processing_enabled:
-        # This is different from serial processing because we don't pass
+    if parallel_execution_enabled:
+        # This is different from serial execution because we don't pass
         # in-memory cache to the subprocesses. The subprocess computes
         # non-persisted entities instead.
         assert x_plus_one_counter.times_called() == 2
@@ -1014,9 +1014,7 @@ def test_changes_per_run_and_not_persist(
     assert x_plus_four_counter.times_called() == 0
 
 
-def test_changes_per_run_and_persist(
-    builder, make_counter, parallel_processing_enabled
-):
+def test_changes_per_run_and_persist(builder, make_counter, parallel_execution_enabled):
     builder.assign("x", 5)
 
     x_plus_one_counter = make_counter()
@@ -1059,8 +1057,8 @@ def test_changes_per_run_and_persist(
     assert flow.get("x_plus_three") == 8
     # x_plus_one changes per run and should be recomputed between runs.
     assert x_plus_one_counter.times_called() == 1
-    if parallel_processing_enabled:
-        # When processed in parallel, we don't compute every entity in
+    if parallel_execution_enabled:
+        # When executed in parallel, we don't compute every entity in
         # the subprocess. Subprocess computes a non-persisted entity
         # only if it is required to compute any other entity.
         assert x_plus_two_counter.times_called() == 0


### PR DESCRIPTION
As of now, we use processing / execution / computing for execution mode
interchangeably. This changes renames processing and computing to
execution to be consistent across the codebase.