### PR TITLE
Add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Check out the link below for more information.
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in the repo.
+*       @jqmp @naman


### PR DESCRIPTION
Code owners are automatically requested for review when someone opens a
pull request that modifies code that they own. This change only adds us
automatically to the PR but does not require an approval from us to
merge the PR.

See https://github.blog/2017-07-06-introducing-code-owners/ or
https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
for more info.