### PR TITLE
Allow uncached entities

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -91,16 +91,6 @@ class ResettingCounter:
         self._n_calls_since_last_check = 0
 
 
-def _decorate_count_calls(counter, func):
-    def wrapper(func, *args, **kwargs):
-        counter.mark()
-        return func(*args, **kwargs)
-
-    wrapped = decorate(func, wrapper)
-    counter.reset()
-    return wrapped
-
-
 class RoundingProtocol(bn.protocols.BaseProtocol):
     def get_fixed_file_extension(self):
         return "round"


### PR DESCRIPTION
Bionic did not allow entities to be uncached. All the entities had to
be either memoized or persisted or both. This change removes that
restriction and allows entities to be uncached. The entities are now
computed every time they are needed.

This also simplifies some of the `TaskState` code by removing
`TaskState.is_complete` in favor of `TaskState.is_cached` property.