### PR TITLE
Make default memoization configurable

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -20,7 +20,7 @@ class EntityDefinition:
     protocol = attr.ib()
     doc = attr.ib()
     can_persist = attr.ib()
-    can_memoize = attr.ib(default=True)
+    optional_should_memoize = attr.ib()
 
 
 @attr.s(frozen=True)

--- a/bionic/decoration.py
+++ b/bionic/decoration.py
@@ -30,7 +30,7 @@ class DecorationAccumulator:
     protocol = attr.ib(default=None)
     docs = attr.ib(default=None)
     can_persist = attr.ib(default=None)
-    can_memoize = attr.ib(default=None)
+    should_memoize = attr.ib(default=None)
 
     def wrap_provider(self, wrapper_fn, *args, **kwargs):
         self.provider = wrapper_fn(self.provider, *args, **kwargs)

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -100,6 +100,7 @@ def persist(enabled):
 def memoize(enabled):
     """
     Indicates whether computed values should be cached in memory.
+    Overrides the value of `core__memoize_by_default` when set.
 
     Parameters
     ----------
@@ -117,7 +118,7 @@ def memoize(enabled):
         raise ValueError(f"Argument must be a boolean; got {enabled!r}")
 
     return decorator_updating_accumulator(
-        lambda acc: acc.update_attr("can_memoize", enabled, "@memoize")
+        lambda acc: acc.update_attr("should_memoize", enabled, "@memoize")
     )
 
 
@@ -440,7 +441,7 @@ def returns(out_descriptor):
 
 immediate = persist(False)
 immediate.__doc__ = """
-Guarantees that an entity can computed during bootstrap resolution.
+Guarantees that an entity can be computed during bootstrap resolution.
 
 Currently ``@immediate`` is equivalent to ``@persist(False)``.
 """

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -376,6 +376,26 @@ cases, we can disable in-memory caching:
     def message(subject):
         return f'Hello {subject}.'
 
+In-memory caching can also be globally disabled:
+
+.. code-block:: python
+
+    builder.set('core__memoize_by_default', False)
+
+This only changes the default behavior, so it can be explicitly re-enabled for
+individual entities:
+
+.. TODO: We should be consistent between the usage of @bn and @bionic.
+
+.. code-block:: python
+
+    builder.set('core__memoize_by_default', False)
+
+    @builder
+    @bionic.memoize(True)
+    def message(subject):
+        return f'Hello {subject}.'
+
 
 .. _changes_per_run :
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -82,6 +82,11 @@ Cache Compatibility Changes
 New Features
 ............
 
+- Memoization can be globally disabled with the ``core_memoize_by_default`` entity,
+  which means you can opt-in which entities are memoized instead of opting out.
+- Bionic now allows entities to have no caching at all. Previously each entity needed
+  to be cached either in memory or on disk; now both of these can be disabled, in which
+  case it will be recomputed each time it's needed.
 - `GeoPandas <https://geopandas.org>`_ DataFrames can now be serialized and cached.
   Bionic will do this automatically when an entity function returns a value of the
   appropriate type, but it can also be explicitly controlled with the new
@@ -116,10 +121,11 @@ Improvements
 ............
 
 - "Unset" entity (entities that are declared but have no value set) are now
-  handled more cleanly. They now appear in the DAG visualization; if an entity value can't be computed because one of its ancestors is unset, the
-  exception message now describes the exact problem and the name of the problematic
-  ancestor; and the ``@gather`` decorator now handles "missing" values more consistently by
-  treating them as an empty set of values.
+  handled more cleanly. They now appear in the DAG visualization; if an entity value
+  can't be computed because one of its ancestors is unset, the exception message now
+  describes the exact problem and the name of the problematic ancestor; and the
+  ``@gather`` decorator now handles "missing" values more consistently by treating them
+  as an empty set of values.
 - Bionic now uses `version 4
   <https://docs.python.org/3/library/pickle.html#data-stream-format>`_ of the Pickle
   data format by default, so objects larger than 4 GB can be serialized without
@@ -146,9 +152,9 @@ Cache Compatibility Changes
 New Features
 ............
 
-- :meth:`Flow.render_dag <bionic.Flow.render_dag>` can now output the DAG as SVG in addition to
-  existing formats.  When SVG is used, entity docstrings appear as tooltips.
-  SVG is the new default format for rendering in Jupyter Notebooks.
+- :meth:`Flow.render_dag <bionic.Flow.render_dag>` can now output the DAG as SVG in
+  addition to existing formats.  When SVG is used, entity docstrings appear as
+  tooltips. SVG is the new default format for rendering in Jupyter Notebooks.
 - The :func:`@changes_per_run <bionic.changes_per_run>` decorator was added; this
   tells Bionic that a function is non-deterministic and should be re-run for each
   instance of a Flow.


### PR DESCRIPTION
Bionic assumed that all entities are memoized by default unless asked
not to. We are changing that assumption by introducing a new variable
that controls the default memoization value.

Users can continue to override the default memoization by using
`@memoize` and `@immediate` decorators.

Here's the update to in-memory caching documentation.

<img width="746" alt="Screen Shot 2020-06-30 at 5 43 53 PM" src="https://user-images.githubusercontent.com/2109428/86180006-5130d800-baf9-11ea-8aa7-b3d4955d3661.png">
