### PR TITLE
Janek/cache delete interface

### DIFF
--- a/bionic/cache_api.py
+++ b/bionic/cache_api.py
@@ -110,6 +110,11 @@ class CacheEntry:
     def metadata_path(self):
         return path_from_url_if_file(self.metadata_url)
 
+    def delete(self):
+        """Safely deletes the artifact and its metadata from the cache."""
+
+        self._inventory.delete_entry(self.metadata_url, self.artifact_url)
+
     def __hash__(self):
         return hash(self._comparison_key)
 

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -681,7 +681,7 @@ class TaskCompletionRunner:
         if task_key not in self._entries_by_task_key:
             # Before doing anything with this task state, we should make sure its
             # cache state is up to date.
-            state.refresh_all_cache_state(self._bootstrap)
+            state.refresh_all_persistent_cache_state(self._bootstrap)
             self._entries_by_task_key[task_key] = TaskRunnerEntry(
                 state=state, is_requested=is_requested
             )

--- a/bionic/persistence.py
+++ b/bionic/persistence.py
@@ -530,9 +530,8 @@ class Inventory:
                 descriptor=metadata_record.descriptor,
             )
 
-    def delete_entry(self, metadata_url, artifact_url):
-        self._fs.delete(metadata_url)
-        self._fs.delete(artifact_url)
+    def delete_url(self, url):
+        return self._fs.delete(url)
 
     def _find_best_match(self, query):
         equivalent_url_prefix = self._equivalent_metadata_url_prefix_for_query(query)
@@ -771,7 +770,10 @@ class LocalFilesystem:
 
     def delete(self, url):
         path = path_from_url(url)
+        if not path.exists():
+            return False
         path.unlink()
+        return True
 
     def write_bytes(self, content_bytes, url):
         path = path_from_url(url)
@@ -812,7 +814,10 @@ class GcsFilesystem:
 
     def delete(self, url):
         blob = self._tool.blob_from_url(url)
+        if blob is None:
+            return False
         blob.delete()
+        return True
 
     def write_bytes(self, content_bytes, url):
         self._tool.blob_from_url(url).upload_from_string(content_bytes)

--- a/bionic/persistence.py
+++ b/bionic/persistence.py
@@ -530,6 +530,10 @@ class Inventory:
                 descriptor=metadata_record.descriptor,
             )
 
+    def delete_entry(self, metadata_url, artifact_url):
+        self._fs.delete(metadata_url)
+        self._fs.delete(artifact_url)
+
     def _find_best_match(self, query):
         equivalent_url_prefix = self._equivalent_metadata_url_prefix_for_query(query)
         possible_urls = self._fs.search(equivalent_url_prefix)
@@ -765,6 +769,10 @@ class LocalFilesystem:
             for sub_path in path_prefix.glob("**/*")
         ]
 
+    def delete(self, url):
+        path = path_from_url(url)
+        path.unlink()
+
     def write_bytes(self, content_bytes, url):
         path = path_from_url(url)
         ensure_parent_dir_exists(path)
@@ -801,6 +809,10 @@ class GcsFilesystem:
             self._tool.url_from_object_name(blob.name)
             for blob in self._tool.blobs_matching_url_prefix(url_prefix)
         ]
+
+    def delete(self, url):
+        blob = self._tool.blob_from_url(url)
+        blob.delete()
 
     def write_bytes(self, content_bytes, url):
         self._tool.blob_from_url(url).upload_from_string(content_bytes)

--- a/bionic/task_state.py
+++ b/bionic/task_state.py
@@ -147,6 +147,32 @@ class TaskState:
 
         self._load_value_hashes()
 
+    def refresh_all_cache_state(self, bootstrap):
+        """
+        Refreshes all state that depends on the persistent cache.
+
+        This is useful if the external cache state might have changed since we last
+        worked with this task.
+        """
+
+        # If this task state is not initialized or not persisted, there's nothing to
+        # refresh.
+        if not self._is_initialized or not self.should_persist:
+            return
+
+        self.refresh_cache_accessors(bootstrap)
+
+        # If we haven't loaded anything from the cache, we can stop here.
+        if self._result_value_hashes_by_dnode is None:
+            return
+
+        # Otherwise, let's update our value hashes from the cache.
+        if all(axr.can_load() for axr in self._cache_accessors):
+            self._load_value_hashes()
+        else:
+            self._result_value_hashes_by_dnode = None
+            self.is_complete = False
+
     def compute(self, task_key_logger, return_results=False):
         """
         Computes the values of a task state by running its task. Requires that all

--- a/bionic/task_state.py
+++ b/bionic/task_state.py
@@ -147,7 +147,7 @@ class TaskState:
 
         self._load_value_hashes()
 
-    def refresh_all_cache_state(self, bootstrap):
+    def refresh_all_persistent_cache_state(self, bootstrap):
         """
         Refreshes all state that depends on the persistent cache.
 
@@ -171,7 +171,6 @@ class TaskState:
             self._load_value_hashes()
         else:
             self._result_value_hashes_by_dnode = None
-            self.is_complete = False
 
     def compute(self, task_key_logger, return_results=False):
         """

--- a/docs/api/flow.rst
+++ b/docs/api/flow.rst
@@ -45,3 +45,14 @@ Flow API
 .. autoclass:: bionic.Flow
     :members:
 
+Cache API
+---------
+
+.. autoclass:: bionic.cache_api.Cache
+    :members:
+
+CacheEntry API
+--------------
+
+.. autoclass:: bionic.cache_api.CacheEntry
+    :members:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -595,6 +595,42 @@ plots.) This can be achieved with the ``mode`` argument to
 
 This would return a ``Path`` object for the ``subject`` entity.
 
+.. _cache-api:
+
+Programmatic Cache Access
+.........................
+
+.. versionadded:: 0.8.0
+
+Although Bionic attempts to manage the cache for you automatically, it's sometimes
+helpful to be able to interact with it directly. Bionic provides a basic API for
+exploring the cache:
+
+.. code-block:: python
+
+    for entry in flow.cache.get_entries():
+        print(entry.artifact_url)
+
+The :meth:`get_entries <bionic.cache_api.Cache.get_entries>` method returns a
+sequence of :class:`CacheEntry <bionic.cache_api.CacheEntry>` objects, one for each
+cached entity value. These objects contain information about the cached entity and
+the location of the cache file itself (which may be either a local file or a cloud
+blob).
+
+Cached entries can also be safely [#f4]_ deleted using the :meth:`delete
+<bionic.cache_api.CacheEntry.delete>` method. This can be used to selectively clean
+up the cache:
+
+.. code-block:: python
+
+    for entry in flow.cache.get_entries():
+        if entry.tier == 'local' and entry.entity == 'model':
+            entry.delete()
+
+.. [#f4] Manually deleting the artifact file itself is *not* safe, because Bionic
+  maintains various metadata files that need to be updated as well. In general, the only
+  safe manual operation is to delete the entire cache directory at once.
+
 Multiplicity
 ------------
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -93,6 +93,8 @@ New Features
   Bionic will do this automatically when an entity function returns a value of the
   appropriate type, but it can also be explicitly controlled with the new
   :func:`@geodataframe <bionic.protocol.geodataframe>` protocol.
+- Bionic now provides an :ref:`API <cache-api>` for listing and deleting cached
+  artifacts.
 
 Documentation Changes
 .....................

--- a/tests/test_cache_api.py
+++ b/tests/test_cache_api.py
@@ -152,14 +152,16 @@ def test_entry_delete(preset_flow):
     (x_entry,) = [
         entry for entry in tester.flow.cache.get_entries() if entry.entity == "x"
     ]
-    x_entry.delete()
+    assert x_entry.delete()
     tester.expect_removed_entries("x")
+    assert not x_entry.delete()
 
     (xy_entry,) = [
         entry for entry in tester.flow.cache.get_entries() if entry.entity == "xy"
     ]
-    xy_entry.delete()
+    assert xy_entry.delete()
     tester.expect_removed_entries("xy")
+    assert not xy_entry.delete()
 
     tester.flow = tester.flow.to_builder().build()
     tester.flow.get("xy_squared")
@@ -186,6 +188,8 @@ def test_flow_handles_delete_gracefully(builder):
     (b_entry,) = [entry for entry in flow.cache.get_entries() if entry.entity == "b"]
     b_entry.delete()
 
+    # The goal here is to make sure that Bionic correctly updates its cache state,
+    # detects that `b` is deleted, and recomputes it.
     flow.get("c")
 
 


### PR DESCRIPTION
This has four commits:
1. Non-functional refactoring of the cache accessors.
2. Support for gracefully handling deleted entries.
3. Adding deletion to the external cache API.
4. Documentation for the external cache API.