### PR TITLE
Update PyPI username in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,7 @@ jobs:
         pip install setuptools wheel twine
     - name: Build and publish
       env:
-        # TODO: setup secrets in github.
-        # https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel --universal


### PR DESCRIPTION
We use API token to authenticate with PyPI. As per the documentation,
we need to set the username as
`__token__ <https://pypi.org/help/#apitoken>`.

Also, note that we have already uploaded the password in
`GitHub secrets <https://github.com/square/bionic/settings/secrets>`.