### PR TITLE
Add verbose flag to twine upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,4 +25,4 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python setup.py sdist bdist_wheel --universal
-        twine upload dist/*
+        twine upload --verbose dist/*


### PR DESCRIPTION
Publish workflow failed because of 403 response from PyPI. Let's add
verbose flag to upload command and see what's not working.