### PR TITLE
Janek/fix cache artifact alias deletion

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -230,10 +230,9 @@ There are three ways for a cached value to become invalid:
 Bionic can detect cases 1 and 2 automatically: if you update the value of any
 entity in your flow, all downstream cached values will automatically be
 invalidated, and they will be recomputed from scratch next time they're
-requested [#f1]_.  However, case 3 is difficult to detect automatically, so we
-provide a special :func:`@version <bionic.version>` decorator to tell Bionic
-when a function's code has changed.  For example, if we've defined a
-``message`` entity:
+requested [#value_hash]_. However, case 3 is difficult to detect automatically, so we
+provide a special :func:`@version <bionic.version>` decorator to tell Bionic when a
+function's code has changed. For example, if we've defined a ``message`` entity:
 
 .. code-block:: python
 
@@ -255,8 +254,8 @@ If the function has a different ``version`` from the cached value, the cached
 value will be disregarded and a new value will be recomputed.  Each subsequent
 time we change this function, we just increment the version number.
 
-.. [#f1] Bionic detects changes by hashing all of the fixed entity values, and
-  storing each computed value alongside a hash of all its inputs.
+.. [#value_hash] Bionic detects changes by hashing all of the fixed entity
+  values, and storing each computed value alongside a hash of all its inputs.
 
 .. _automatic-versioning:
 
@@ -279,10 +278,10 @@ mode from ``'manual'`` to ``'assist'``:
     builder.set('core__versioning_mode', 'assist')
 
 In this mode, if Bionic finds a cached file created by a function with the
-*same version* but *different code* [#f2]_, it will raise a
-``CodeVersioningError``.  You can resolve this error by updating the
-:func:`@version <bionic.version>`, which tells Bionic to ignore the cached file
-and compute a new value.
+*same version* but *different code* [#code_hash]_, it will raise a
+``CodeVersioningError``. You can resolve this error by updating the :func:`@version
+<bionic.version>`, which tells Bionic to ignore the cached file and compute a new
+value.
 
 .. code-block:: python
 
@@ -338,7 +337,7 @@ changes that it can't detect.)  This mode is more dangerous, but can be useful
 when your functions are small, change fast, and have few external dependencies
 -- for example, when your flow is defined in a notebook.
 
-.. [#f2] Bionic detects code changes by extracting and hashing the Python
+.. [#code_hash] Bionic detects code changes by extracting and hashing the Python
   bytecode of each function decorated by a FlowBuilder.
 
 
@@ -426,9 +425,9 @@ You can tell Bionic that a function is non-deterministic by applying the
 This causes Bionic to recompute the entity's value instead of loading a
 cached value from disk. (However, this recomputation will only happen once
 for any given ``Flow`` instance; after that, the value will be cached in
-memory and reused [#f3]_.)
+memory and reused [#per_run]_.)
 
-.. [#f3] I.e., the value is computed once per "run".  This is a compromise:
+.. [#per_run] I.e., the value is computed once per "run".  This is a compromise:
   although it makes logical sense to recompute the value every single time,
   it's much simpler for each entity to have a consistent value within a single
   flow instance.
@@ -812,15 +811,15 @@ Parallel execution can be enabled like this:
 
     builder.set("core__parallel_execution__enabled", True)
 
-When parallel execution is enabled, Bionic starts up several worker processes [#f5]_,
-each of which can work on one value at a time. Of course, a worker can only start
-computing a value once all its dependencies are complete, so the number of processes
-that can be working at once depends on the :ref:`dependency graph <dagviz>`: if there
-aren't many branches in the graph, then most of the processes won't do much work. It
-does take extra time to set up the processes and move information between them, so
-parallel execution is not guaranteed to be faster overall. However, in general, if
-you have many expensive operations which don't depend on each other, enabling
-parallelism will improve performance.
+When parallel execution is enabled, Bionic starts up several worker processes
+[#workers]_, each of which can work on one value at a time. Of course, a worker can
+only start computing a value once all its dependencies are complete, so the number of
+processes that can be working at once depends on the :ref:`dependency graph
+<dagviz>`: if there aren't many branches in the graph, then most of the processes
+won't do much work. It does take extra time to set up the processes and move
+information between them, so parallel execution is not guaranteed to be faster
+overall. However, in general, if you have many expensive operations which don't
+depend on each other, enabling parallelism will improve performance.
 
 By default, Bionic will create one worker process for each CPU on your machine. This
 is usually a sensible number, but it can also be set directly:
@@ -839,7 +838,7 @@ using the :ref:`protocol<protocols>` specified for the entity. Finally, entities
 marked with :func:`@persist(False) <bionic.persist>` are assumed to be unserializable
 and will always be computed in the main process rather than being parallelized.
 
-.. [#f5] The pool of workers is managed by
+.. [#workers] The pool of workers is managed by
   `Loky <https://loky.readthedocs.io/en/stable/>`_,
   which is built on Python's
   `multiprocessing <https://docs.python.org/3.8/library/multiprocessing.html>`_ module.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -617,7 +617,7 @@ cached entity value. These objects contain information about the cached entity a
 the location of the cache file itself (which may be either a local file or a cloud
 blob).
 
-Cached entries can also be safely [#f4]_ deleted using the :meth:`delete
+Cached entries can also be safely deleted using the :meth:`delete
 <bionic.cache_api.CacheEntry.delete>` method. This can be used to selectively clean
 up the cache:
 
@@ -626,10 +626,6 @@ up the cache:
     for entry in flow.cache.get_entries():
         if entry.tier == 'local' and entry.entity == 'model':
             entry.delete()
-
-.. [#f4] Manually deleting the artifact file itself is *not* safe, because Bionic
-  maintains various metadata files that need to be updated as well. In general, the only
-  safe manual operation is to delete the entire cache directory at once.
 
 Multiplicity
 ------------

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -602,6 +602,10 @@ Programmatic Cache Access
 
 .. versionadded:: 0.8.0
 
+.. note::  This API is intentionally quite minimal; we intend to add additional
+  convenience features based on observed usage patterns. If you'd like to add new
+  features, feel free to submit an issue or a PR on GitHub!
+
 Although Bionic attempts to manage the cache for you automatically, it's sometimes
 helpful to be able to interact with it directly. Bionic provides a basic API for
 exploring the cache:

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -80,7 +80,7 @@ Bug Fixes
   get assigned to the wrong entity.
 - Parallel execution (introduced in 0.8.0) had a bug in logging where log messages were
   dropped (with a warning) when any argument to the log message was unpickleable.
-- The cache API introduced in 0.8.0 had a bug where if two cache entries point to the
+- The cache API (introduced in 0.8.0) had a bug where if two cache entries point to the
   same artifact, deleting one of them could leave the other in a bad state.
 
 Improvements

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -80,6 +80,15 @@ Bug Fixes
   get assigned to the wrong entity.
 - Parallel execution (introduced in 0.8.0) had a bug in logging where log messages were
   dropped (with a warning) when any argument to the log message was unpickleable.
+- The cache API introduced in 0.8.0 had a bug where if two cache entries point to the
+  same artifact, deleting one of them could leave the other in a bad state.
+
+Improvements
+............
+
+- Bionic now gracefully handles the situations where a cached artifact file is deleted
+  but the corresponding metadata entry is not. (It now deletes the invalid metadata file
+  and computes a new artifact and metadata entry.)
 
 0.8.1 (Jul 6, 2020)
 --------------------


### PR DESCRIPTION
Now if we load a metadata file whose artifact URL doesn't exist, we
delete the metadata and act like it never existed. This makes it safe to
delete artifact files without also deleting their metadata. In
particular, this fixes a bug in the cache API: if two metadata files
point to the same artifact, the deleting the entry for one of them would
make the other invalid. Now we can handle this situation gracefully.

I've also swapped the order in which cache entry URLs are deleted: we
now delete the artifact first, and then the metadata. Now that it's safe
to have broken URLs in metadata, it's better to avoid orphaning the
artifact.