### PR TITLE
Format logs before sending them to the main process

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -78,6 +78,8 @@ Bug Fixes
 - Fixed a bug in :meth:`FlowBuilder.add_case <bionic.FlowBuilder.add_case>`: if the
   ordering of the entity names changed from case to case, some values would sometimes
   get assigned to the wrong entity.
+- Parallel execution (introduced in 0.8.0) had a bug in logging where log messages were
+  dropped (with a warning) when any argument to the log message was unpickleable.
 
 0.8.1 (Jul 6, 2020)
 --------------------


### PR DESCRIPTION
Bionic sends all the log records to the main process and lets the main
process log them. In this case, the log formatting happens in the main
process, which requires us to send the entire argument list of the
logs. The communication between processes requires every argument to be
pickleable using cloudpickle, which seems unreasonable to enforce.

To avoid breaking logging, we eagerly format the log message the way
logging does (check LogRecord.getMessage). Although the logging works,
this has a side effect of changing the template and arguments for the
log in case users intercepts the LogRecord in their custom handlers.