### PR TITLE
Fix my username in codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # These owners will be the default owners for everything in the repo.
-*       @jqmp @naman
+*       @jqmp @namanjain


### PR DESCRIPTION
My GitHub username is different than my Square LDAP username, updating
my username to the GitHub one in the codeowners file.