### PR TITLE
Janek/fix add case arg order bug

### DIFF
--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -187,7 +187,7 @@ class FlowState(pyrs.PClass):
                     {provider.entity_names!r},
                     and all subsequent assignments must be to that same group
                     """
-                    raise IncompatibleEntityError(oneline(message))
+                raise IncompatibleEntityError(oneline(message))
 
             return self
 

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -238,11 +238,12 @@ class FlowState(pyrs.PClass):
 
         # We should already have called group_names_together(), so we know the names
         # argument should match the names of the provider. However, the names may not
-        # be in the expected order. If not, we'll reorder the values to correspond to
-        # the expected order.
-        provider_names = provider.entity_names
-        if names != provider_names:
-            values = [values[provider_names.index(name)] for name in names]
+        # be in the expected order. If not, we'll reorder the names and values to
+        # correspond to the expected order.
+        names_in_orig_order = provider.entity_names
+        if names != names_in_orig_order:
+            values = [values[names.index(name)] for name in names_in_orig_order]
+            names = names_in_orig_order
 
         tokens = []
         for name, value in zip(names, values):

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -63,7 +63,7 @@ For each release, we list the following types of change (in this order):
 - **Development Changes**: Significant changes to Bionic's development process, such
   as changes to our Pytest configuration or our Continuous Integration ("CI").
 
-.. Upcoming Version (Not Yet Released)
+Upcoming Version (Not Yet Released)
 -----------------------------------
 
 .. Record any notable changes in this section. When we update the current version,
@@ -71,6 +71,13 @@ For each release, we list the following types of change (in this order):
    changes are added. This way, the "Upcoming Version" section will be never be visible
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
+
+Bug Fixes
+.........
+
+- Fixed a bug in :meth:`FlowBuilder.add_case <bionic.FlowBuilder.add_case>`: if the
+  ordering of the entity names changed from case to case, some values would sometimes
+  get assigned to the wrong entity.
 
 0.8.1 (Jul 6, 2020)
 --------------------

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -202,11 +202,12 @@ def test_add_case_out_of_order(builder):
     builder.add_case("p", 1, "q", 10, "r", 100)
     builder.add_case("p", 2, "r", 200, "q", 20)
     builder.add_case("r", 300, "q", 30, "p", 3)
+    builder.add_case("r", 400, "p", 4, "q", 40)
 
     flow = builder.build()
-    flow.get("p", set) == {1, 2, 3}
-    flow.get("q", set) == {10, 20, 30}
-    flow.get("r", set) == {100, 200, 300}
+    assert flow.get("p", set) == {1, 2, 3, 4}
+    assert flow.get("q", set) == {10, 20, 30, 40}
+    assert flow.get("r", set) == {100, 200, 300, 400}
 
 
 def test_then_set(preset_builder):


### PR DESCRIPTION
The `FlowBuilder.add_case` method accepts multiple name-value pairs;
these can be given in any order, and are automatically permuted to get
them into a canonical order. Unfortunately, we had a bug where we
instead applied the inverse of the correct permutation.

As it happened, our test for this logic only required permutations with
a single swap -- which meant there was no difference between a correct
permutation and its inverse.

Oh, and that test case was also missing the word `assert` in all its
checks.