### PR TITLE
Submit task completion runner to the subprocesses

### DIFF
--- a/bionic/core/task_execution.py
+++ b/bionic/core/task_execution.py
@@ -601,7 +601,6 @@ class TaskState:
         if task_state.is_cached:
             task_state.dep_states = []
             task_state.task = None
-            task_state._queries = None
         else:
             task_state.dep_states = [
                 dep_state.strip_state_for_subprocess(new_task_states_by_key)

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -9,7 +9,7 @@ from .descriptors.parsing import entity_dnode_from_descriptor
 from .descriptors import ast
 from .deps.optdep import import_optional_dependency
 from .exception import UndefinedEntityError
-from .core.flow_execution import TaskCompletionRunner
+from .core.flow_execution import TaskCompletionRunner, TaskKeyLogger
 from .core.task_execution import TaskState
 from .protocols import TupleProtocol
 from .provider import TupleConstructionProvider, TupleDeconstructionProvider
@@ -437,7 +437,12 @@ class EntityDeriver:
             self._get_or_create_task_state_for_key(task.keys[0]) for task in dinfo.tasks
         ]
 
-        task_runner = TaskCompletionRunner(self._bootstrap, self._flow_instance_uuid)
+        task_key_logger = TaskKeyLogger(self._bootstrap)
+        task_runner = TaskCompletionRunner(
+            bootstrap=self._bootstrap,
+            flow_instance_uuid=self._flow_instance_uuid,
+            task_key_logger=task_key_logger,
+        )
         results_by_dnode_by_task_key = task_runner.run(requested_task_states)
 
         for state in requested_task_states:
@@ -462,6 +467,9 @@ class Bootstrap:
     versioning_policy = attr.ib()
     executor = attr.ib()
     should_memoize_default = attr.ib()
+
+    def evolve(self, **kwargs):
+        return attr.evolve(self, **kwargs)
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
Instead of submitting the task state to the subprocesses, we now send
the task completion runner and the task state. This is a step towards
making the runner resolve dependencies stack-based instead of mixing
the stack and recursion-based execution.

This change was a part of #199