### PR TITLE
Make default persistence configurable

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -19,8 +19,8 @@ class EntityDefinition:
     name = attr.ib()
     protocol = attr.ib()
     doc = attr.ib()
-    can_persist = attr.ib()
     optional_should_memoize = attr.ib()
+    optional_should_persist = attr.ib()
 
 
 @attr.s(frozen=True)

--- a/bionic/decoration.py
+++ b/bionic/decoration.py
@@ -29,7 +29,7 @@ class DecorationAccumulator:
 
     protocol = attr.ib(default=None)
     docs = attr.ib(default=None)
-    can_persist = attr.ib(default=None)
+    should_persist = attr.ib(default=None)
     should_memoize = attr.ib(default=None)
 
     def wrap_provider(self, wrapper_fn, *args, **kwargs):

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -75,6 +75,7 @@ def version(major=None, minor=None):
 def persist(enabled):
     """
     Indicates whether computed values should be cached persistently.
+    Overrides the value of `core__persist_by_default` when set.
 
     Parameters
     ----------
@@ -93,7 +94,7 @@ def persist(enabled):
         raise ValueError(f"Argument must be a boolean; got {enabled!r}")
 
     return decorator_updating_accumulator(
-        lambda acc: acc.update_attr("can_persist", enabled, "@persist")
+        lambda acc: acc.update_attr("should_persist", enabled, "@persist")
     )
 
 

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -201,6 +201,9 @@ class EntityDeriver:
             should_memoize_default=self._bootstrap_singleton_entity(
                 "core__memoize_by_default"
             ),
+            should_persist_default=self._bootstrap_singleton_entity(
+                "core__persist_by_default"
+            ),
         )
 
     def _prevalidate_base_dnodes(self):
@@ -292,7 +295,7 @@ class EntityDeriver:
                 protocol=TupleProtocol(len(dnode.children)),
                 doc=f"A Python tuple with {len(dnode.children)} values.",
                 optional_should_memoize=True,
-                can_persist=False,
+                optional_should_persist=False,
             )
 
         else:
@@ -467,6 +470,7 @@ class Bootstrap:
     versioning_policy = attr.ib()
     executor = attr.ib()
     should_memoize_default = attr.ib()
+    should_persist_default = attr.ib()
 
     def evolve(self, **kwargs):
         return attr.evolve(self, **kwargs)

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -359,6 +359,24 @@ we can disable persistent caching altogether:
 If your goal is just to force an entity to be recomputed more frequently, you may
 want :ref:`@changes_per_run <changes_per_run>` instead.
 
+Persistent caching can also be globally disabled:
+
+.. code-block:: python
+
+    builder.set('core__persist_by_default', False)
+
+This only changes the default behavior, so it can be explicitly re-enabled for
+individual entities:
+
+.. code-block:: python
+
+    builder.set('core__persist_by_default', False)
+
+    @builder
+    @bionic.persist(True)
+    def message(subject):
+        return f'Hello {subject}.'
+
 
 Disabling In-Memory Caching
 ............................
@@ -375,14 +393,13 @@ cases, we can disable in-memory caching:
     def message(subject):
         return f'Hello {subject}.'
 
-In-memory caching can also be globally disabled:
+Like persistent caching, in-memory caching can also be globally disabled:
 
 .. code-block:: python
 
     builder.set('core__memoize_by_default', False)
 
-This only changes the default behavior, so it can be explicitly re-enabled for
-individual entities:
+This can also be explicitly re-enabled for individual entities:
 
 .. TODO: We should be consistent between the usage of @bn and @bionic.
 
@@ -394,6 +411,11 @@ individual entities:
     @bionic.memoize(True)
     def message(subject):
         return f'Hello {subject}.'
+
+When both persistent and in-memory caching are disabled for an entity, Bionic
+will cache its values in a temporary in-memory cache that only lasts for the
+duration of the :meth:`Flow.get <bionic.Flow.get>` call. These temporarily-cached
+values are discarded when the call is completed.
 
 
 .. _changes_per_run :

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -63,14 +63,20 @@ For each release, we list the following types of change (in this order):
 - **Development Changes**: Significant changes to Bionic's development process, such
   as changes to our Pytest configuration or our Continuous Integration ("CI").
 
-.. Upcoming Version (Not Yet Released)
-.. -----------------------------------
+Upcoming Version (Not Yet Released)
+-----------------------------------
 
 .. Record any notable changes in this section. When we update the current version,
    add a new version heading below, and then comment out the heading above until more
    changes are added. This way, the "Upcoming Version" section will be never be visible
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
+
+New Features
+............
+
+- Persistence can be globally disabled with the ``core__persist_by_default`` entity,
+  which means you can opt-in which entities are persisted instead of opting out.
 
 0.8.2 (Jul 10, 2020)
 --------------------


### PR DESCRIPTION
Like #181, this change introduces a new core entity that lets users
control the default persistence value.

Users can continue to override the default persistence by using
@persist and @immediate decorators.

Here are screenshots for documentation updates:

<img width="764" alt="Screen Shot 2020-07-13 at 2 22 28 PM" src="https://user-images.githubusercontent.com/2109428/87339259-5a1ba380-c514-11ea-918d-5f95ea1ca590.png">
<img width="749" alt="Screen Shot 2020-07-13 at 2 22 40 PM" src="https://user-images.githubusercontent.com/2109428/87339264-5c7dfd80-c514-11ea-9216-078be4499440.png">
