### PR TITLE
Add JsonProtocol

### DIFF
--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -51,6 +51,7 @@ from .util import (
 )
 
 DEFAULT_PROTOCOL = protos.CombinedProtocol(
+    protos.JsonProtocol(),
     # Every GeoPandas DataFrame is also a Pandas DataFrame, so we need to do the
     # GeoPandas check first.
     protos.GeoPandasProtocol(),

--- a/bionic/protocol.py
+++ b/bionic/protocol.py
@@ -11,6 +11,7 @@ numpy = protocols.NumPyProtocol()  # noqa: F401
 yaml = protocols.YamlProtocol()  # noqa: F401
 path = protocols.PathProtocol()  # noqa: F401
 geodataframe = protocols.GeoPandasProtocol()  # noqa: F401
+json = protocols.JsonProtocol()  # noqa: F401
 
 
 def frame(func=None, file_format=None, check_dtypes=None):

--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -87,6 +87,7 @@ Built-In Protocol Decorators
 .. autofunction:: bionic.protocol.frame
 .. autofunction:: bionic.protocol.geodataframe
 .. autofunction:: bionic.protocol.image
+.. autofunction:: bionic.protocol.json
 .. autofunction:: bionic.protocol.numpy
 .. autofunction:: bionic.protocol.path
 .. autofunction:: bionic.protocol.picklable

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -584,6 +584,8 @@ object types it's more efficient or more idiomatic to use a different format.
 There are also some types of objects that can't be pickled at all.  Bionic uses
 ``pickle`` by default, but handles some types specially:
 
+- `JSON <https://www.json.org/json-en.html>`_-serializable built-in types (int, float,
+  str, bool, list, and dict) are serialized as JSON files.
 - `Pandas <https://pandas.pydata.org/>`_ DataFrames are serialized as
   `Parquet <https://parquet.apache.org/>`_ files.
 - `NumPy <https://numpy.org/>`_ Arrays are serialized as `NPY

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -77,6 +77,10 @@ New Features
 
 - Persistence can be globally disabled with the ``core__persist_by_default`` entity,
   which means you can opt-in which entities are persisted instead of opting out.
+- `JSON <https://www.json.org/json-en.html>`_-serializable values are now serialized and
+  cached using the JSON format (instead of the Pickle format). Bionic will do this
+  automatically when an entity function returns a JSON-able value, but it can also be
+  explicitly controlled with the new :func:`@json <bionic.protocol.json>` protocol.
 
 Bug Fixes
 .........

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import raises
 
 import io
-import pickle
+import json
 from pathlib import Path
 import contextlib
 import threading
@@ -424,12 +424,12 @@ def test_get_modes_persisted(preset_flow, name, tmp_path):
 
     for mode in [Path, "path"]:
         path = flow.get(name, mode=mode)
-        assert pickle.loads(path.read_bytes()) == 1
+        assert json.loads(path.read_bytes()) == 1
 
     flow.get(name, mode="FileCopier").copy(destination=tmp_path)
-    serialized_fname = name + ".pkl"
+    serialized_fname = name + ".json"
     expected_file_path = tmp_path / serialized_fname
-    assert pickle.loads(expected_file_path.read_bytes()) == 1
+    assert json.loads(expected_file_path.read_bytes()) == 1
 
     filename = flow.get(name, mode="filename")
     assert isinstance(filename, str)
@@ -458,16 +458,16 @@ def test_export(preset_flow, tmp_path, recwarn):
     flow = preset_flow
 
     value_path = flow.export("y_fxn")
-    assert value_path.name == "y_fxn.pkl"
-    assert pickle.loads(value_path.read_bytes()) == 1
+    assert value_path.name == "y_fxn.json"
+    assert json.loads(value_path.read_bytes()) == 1
 
     flow.export("y_fxn", dir_path=tmp_path)
-    expected_path = tmp_path / "y_fxn.pkl"
-    assert pickle.loads(expected_path.read_bytes()) == 1
+    expected_path = tmp_path / "y_fxn.json"
+    assert json.loads(expected_path.read_bytes()) == 1
 
     explicit_path = tmp_path / "some_filename"
     flow.export("y_fxn", file_path=explicit_path)
-    assert pickle.loads(explicit_path.read_bytes()) == 1
+    assert json.loads(explicit_path.read_bytes()) == 1
 
     (warning,) = recwarn
     assert "deprecated" in str(warning.message)

--- a/tests/test_flow/test_cache_api.py
+++ b/tests/test_flow/test_cache_api.py
@@ -1,6 +1,6 @@
 import pytest
 
-import pickle
+import json
 
 import bionic as bn
 from bionic import interpret
@@ -63,7 +63,7 @@ class CacheTester:
 
     def _validate_entry(self, entry):
         artifact_bytes = read_bytes_from_url(entry.artifact_url)
-        value = pickle.loads(artifact_bytes)
+        value = json.loads(artifact_bytes)
         assert value == self.flow.get(entry.entity)
 
         if entry.tier == "local":

--- a/tests/test_flow/test_copy.py
+++ b/tests/test_flow/test_copy.py
@@ -1,6 +1,6 @@
 import pytest
 
-import pickle
+import json
 from pathlib import Path
 from subprocess import check_call
 
@@ -56,40 +56,40 @@ def test_copy_file_to_existing_local_dir(flow, tmp_path):
     dir_path.mkdir()
     flow.get("f", mode="FileCopier").copy(destination=dir_path)
 
-    expected_file_path = dir_path / "f.pkl"
-    assert pickle.loads(expected_file_path.read_bytes()) == 5
+    expected_file_path = dir_path / "f.json"
+    assert json.loads(expected_file_path.read_bytes()) == 5
 
 
 def test_copy_file_to_local_file(flow, tmp_path):
-    file_path = tmp_path / "data.pkl"
+    file_path = tmp_path / "data.json"
     flow.get("f", mode="FileCopier").copy(destination=file_path)
 
-    assert pickle.loads(file_path.read_bytes()) == 5
+    assert json.loads(file_path.read_bytes()) == 5
 
 
 def test_copy_file_to_local_file_using_str(flow, tmp_path):
-    file_path = tmp_path / "data.pkl"
+    file_path = tmp_path / "data.json"
     file_path_str = str(file_path)
     flow.get("f", mode="FileCopier").copy(destination=file_path_str)
-    assert pickle.loads(file_path.read_bytes()) == 5
+    assert json.loads(file_path.read_bytes()) == 5
 
 
 @pytest.mark.needs_gcs
 def test_copy_file_to_gcs_dir(flow, tmp_path, tmp_gcs_url_prefix):
     flow.get("f", mode="FileCopier").copy(destination=tmp_gcs_url_prefix)
-    cloud_url = tmp_gcs_url_prefix + "f.pkl"
-    local_path = tmp_path / "f.pkl"
+    cloud_url = tmp_gcs_url_prefix + "f.json"
+    local_path = tmp_path / "f.json"
     check_call(f"gsutil -m cp {cloud_url} {local_path}", shell=True)
-    assert pickle.loads(local_path.read_bytes()) == 5
+    assert json.loads(local_path.read_bytes()) == 5
 
 
 @pytest.mark.needs_gcs
 def test_copy_file_to_gcs_file(flow, tmp_path, tmp_gcs_url_prefix):
-    cloud_url = tmp_gcs_url_prefix + "f.pkl"
+    cloud_url = tmp_gcs_url_prefix + "f.json"
     flow.get("f", mode="FileCopier").copy(destination=cloud_url)
-    local_path = tmp_path / "f.pkl"
+    local_path = tmp_path / "f.json"
     check_call(f"gsutil -m cp {cloud_url} {local_path}", shell=True)
-    assert pickle.loads(local_path.read_bytes()) == 5
+    assert json.loads(local_path.read_bytes()) == 5
 
 
 def test_copy_dask_to_dir(tmp_path, expected_dask_df, dask_flow):
@@ -126,6 +126,6 @@ def test_get_multi_value_entity(builder):
 
     flow = builder.build()
     results = flow.get("multi_entity", collection=set, mode=Path)
-    results = {pickle.loads(res.read_bytes()) for res in results}
+    results = {json.loads(res.read_bytes()) for res in results}
 
     assert results == my_set

--- a/tests/test_flow/test_protocols.py
+++ b/tests/test_flow/test_protocols.py
@@ -22,6 +22,18 @@ from bionic.protocols import CombinedProtocol, PicklableProtocol
 from bionic.util import recursively_delete_path
 
 
+JSONABLE_VALUES = [
+    None,
+    1,
+    1.1,
+    "string",
+    True,
+    [1, 2, [3]],
+    {"a": 1, "b": {"c": [2]}, "d": None},
+    {"ń": "ņ"},
+]
+
+
 PICKLABLE_VALUES = [
     1,
     "string",
@@ -52,6 +64,34 @@ def test_picklable_value(builder, make_counter, protocol, value):
     assert builder.build().get("picklable_value") == value
     assert builder.build().get("picklable_value") == value
     assert counter.times_called() == 1
+
+
+@pytest.mark.parametrize("value", JSONABLE_VALUES)
+@pytest.mark.parametrize("protocol", [bn.protocol.json, passthrough])
+def test_jsonable_value(builder, make_counter, protocol, value):
+    counter = make_counter()
+
+    @builder
+    @protocol
+    @count_calls(counter)
+    def jsonable_value():
+        return value
+
+    assert builder.build().get("jsonable_value") == value
+    assert builder.build().get("jsonable_value") == value
+    assert counter.times_called() == 1
+
+
+def test_non_jsonable_value_fails(builder):
+    @builder
+    @bn.protocol.json
+    def non_jsonable_value():
+        circular_ref_array = [1]
+        circular_ref_array.append(circular_ref_array)
+        return circular_ref_array
+
+    with pytest.raises(RecursionError):
+        builder.build().get("non_jsonable_value")
 
 
 def test_picklable_with_parens(builder, make_counter):


### PR DESCRIPTION
This change adds a new protocol that supports JSON serialization for
simple types, namely, int, float, string, bool, list, and dict.

We might add further improvements to this protocol where users can
add a custom encoder for class types.

Release notes screenshot:

<img width="729" alt="Screen Shot 2020-07-14 at 4 41 25 PM" src="https://user-images.githubusercontent.com/2109428/87474328-ea2f1b00-c5f0-11ea-8176-b8f08b0bc381.png">
