### PR TITLE
Fix bug loading multifile artifacts from GCS

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -78,6 +78,15 @@ New Features
 - Persistence can be globally disabled with the ``core__persist_by_default`` entity,
   which means you can opt-in which entities are persisted instead of opting out.
 
+Bug Fixes
+.........
+
+- The previous release introduced a bug where Bionic would fail to recognize
+  directory artifacts when they were stored in GCS, and would just recompute the values
+  instead. (Most artifacts are stored as a single file, so this mainly affected the
+  :func:`@dask <bionic.protocol.dask>` and :func:`@path <bionic.protocol.path>`
+  protocols.)
+
 0.8.2 (Jul 10, 2020)
 --------------------
 


### PR DESCRIPTION
We had a bug where Bionic would fail to recognize existing multifile
artifacts in GCS and would just recompute them instead. This was caught
by our GCS tests, but these don't run in CI and apparently I failed to
run them since introducing the bug in
462c6c3c74290f686b24ad471c6b8c003d456ea3 ("Gracefully handle metadata
files with no artifact"). Oops!

At this point I'm tempted to try implementing a simple mock of the GCS
API to allow us to catch stuff like this without manually running the
GCS tests, which are slow and can't run in CI.