### PR TITLE
Store inventory entries immediately on creation

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -87,6 +87,13 @@ Bug Fixes
   :func:`@dask <bionic.protocol.dask>` and :func:`@path <bionic.protocol.path>`
   protocols.)
 
+Improvements
+.........
+
+- Bionic's cache now makes fewer round-trip calls to the storage system (local disk
+  or GCS) while reading and writing data. This might (or might not) improve performance
+  if your connection to GCS is slow.
+
 0.8.2 (Jul 10, 2020)
 --------------------
 


### PR DESCRIPTION
I noticed that when we write to the persistent cache, we flush its
stored entries and don't reconstruct them, so we end up looking up the
same artifact again immediately. I'm not sure if this makes a real
performance difference, but it does increase the number of round-trips
to GCS, so it seemed worthwhile to fix it.