### PR TITLE
Remove need for `count_calls`

### DIFF
--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -7,7 +7,8 @@ import random
 from ..helpers import (
     gsutil_path_exists,
     gsutil_wipe_path,
-    ResettingCounter,
+    SimpleCounter,
+    ResettingCallCounter,
 )
 
 import bionic as bn
@@ -47,7 +48,7 @@ class PytestManager(SyncManager):
     pass
 
 
-PytestManager.register("ResettingCounter", ResettingCounter)
+PytestManager.register("SimpleCounter", SimpleCounter)
 
 
 @pytest.fixture(scope="session")
@@ -69,9 +70,10 @@ def process_manager(parallel_execution_enabled, multiprocessing_manager):
 def make_counter(process_manager):
     def _make_counter():
         if process_manager is None:
-            return ResettingCounter()
+            counter = SimpleCounter()
         else:
-            return process_manager.ResettingCounter()
+            counter = process_manager.SimpleCounter()
+        return ResettingCallCounter(counter)
 
     return _make_counter
 

--- a/tests/test_flow/generate_test_compatibility_cache.py
+++ b/tests/test_flow/generate_test_compatibility_cache.py
@@ -15,7 +15,7 @@ import os
 
 import bionic as bn
 
-from ..helpers import count_calls, ResettingCounter
+from ..helpers import ResettingCallCounter
 
 
 CACHE_TEST_DIR = os.path.join(
@@ -39,21 +39,21 @@ class Harness:
         xy_counter = make_counter()
 
         @builder
-        @count_calls(xy_counter)
+        @xy_counter
         def xy(x, y):
             return x * y
 
         yz_counter = make_counter()
 
         @builder
-        @count_calls(yz_counter)
+        @yz_counter
         def yz(y, z):
             return y * z
 
         xy_plus_yz_counter = make_counter()
 
         @builder
-        @count_calls(xy_plus_yz_counter)
+        @xy_plus_yz_counter
         def xy_plus_yz(xy, yz):
             return xy + yz
 
@@ -66,7 +66,7 @@ class Harness:
 if __name__ == "__main__":
 
     def make_counter():
-        return ResettingCounter()
+        return ResettingCallCounter()
 
     flow = Harness(CACHE_TEST_DIR, make_counter).flow
 

--- a/tests/test_flow/test_api.py
+++ b/tests/test_flow/test_api.py
@@ -20,7 +20,7 @@ from bionic.exception import (
     UnsetEntityError,
 )
 
-from ..helpers import assert_re_matches, count_calls
+from ..helpers import assert_re_matches
 
 
 @pytest.fixture(scope="function")
@@ -606,7 +606,7 @@ def test_in_memory_caching(builder, make_counter):
 
     @builder
     @bn.persist(False)
-    @count_calls(counter)
+    @counter
     def xy(x, y):
         return x * y
 

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -3,7 +3,7 @@ import pytest
 import math
 import threading
 
-from ..helpers import RoundingProtocol, count_calls
+from ..helpers import RoundingProtocol
 from bionic.exception import AttributeValidationError, CodeVersioningError
 from bionic.protocols import PicklableProtocol
 
@@ -37,7 +37,7 @@ def test_caching_and_invalidation(builder, make_counter, parallel_execution_enab
     xy_counter = make_counter()
 
     @builder
-    @count_calls(xy_counter)
+    @xy_counter
     def xy(x, y):
         return x * y
 
@@ -45,14 +45,14 @@ def test_caching_and_invalidation(builder, make_counter, parallel_execution_enab
 
     @builder
     @bn.persist(False)
-    @count_calls(yz_counter)
+    @yz_counter
     def yz(y, z):
         return y * z
 
     xy_plus_yz_counter = make_counter()
 
     @builder
-    @count_calls(xy_plus_yz_counter)
+    @xy_plus_yz_counter
     def xy_plus_yz(xy, yz):
         return xy + yz
 
@@ -678,7 +678,7 @@ def test_all_returned_results_are_deserialized(builder, make_counter):
 
     @builder
     @RoundingProtocol()
-    @count_calls(counter)
+    @counter
     def pi():
         return math.pi
 
@@ -731,21 +731,21 @@ def test_deps_not_called_when_values_not_changed(builder, make_counter):
     xy_counter = make_counter()
 
     @builder
-    @count_calls(xy_counter)
+    @xy_counter
     def xy(x, y):
         return x * y
 
     yz_counter = make_counter()
 
     @builder
-    @count_calls(yz_counter)
+    @yz_counter
     def yz(y, z):
         return y * z
 
     xy_plus_yz_counter = make_counter()
 
     @builder
-    @count_calls(xy_plus_yz_counter)
+    @xy_plus_yz_counter
     def xy_plus_yz(xy, yz):
         return xy + yz
 
@@ -777,7 +777,7 @@ def test_gather_cache_invalidation(builder, make_counter):
 
     @builder
     @bn.gather("x", "x", "df")
-    @count_calls(counter)
+    @counter
     def z(df, y):
         return df["x"].sum() + y
 
@@ -803,7 +803,7 @@ def test_gather_cache_invalidation_with_over_vars(builder, make_counter):
 
     @builder
     @bn.gather("x", "y", "df")
-    @count_calls(counter)
+    @counter
     def z(df):
         return df.sum().sum()
 
@@ -843,7 +843,7 @@ def test_complex_input_type(builder, make_counter):
     counter = make_counter()
 
     @builder
-    @count_calls(counter)
+    @counter
     def x_plus_y(x, y):
         return x + y
 
@@ -868,7 +868,7 @@ def test_persisting_none(builder, make_counter):
     counter = make_counter()
 
     @builder
-    @count_calls(counter)
+    @counter
     def none():
         return None
 
@@ -884,7 +884,7 @@ def test_disable_memory_caching(builder, make_counter):
     @builder
     @protocol
     @bn.memoize(False)
-    @count_calls(counter)
+    @counter
     def x():
         return 1
 
@@ -898,7 +898,7 @@ def test_disable_memory_caching(builder, make_counter):
     @protocol
     @bn.persist(False)
     @bn.memoize(False)
-    @count_calls(counter)
+    @counter
     def x():  # noqa: F811
         return 1
 
@@ -916,7 +916,7 @@ def test_disable_default_memory_caching(builder, make_counter):
 
     @builder
     @x_protocol
-    @count_calls(x_counter)
+    @x_counter
     def x():
         return 1
 
@@ -935,7 +935,7 @@ def test_disable_default_memory_caching(builder, make_counter):
 
     @builder
     @y_protocol
-    @count_calls(y_counter)
+    @y_counter
     def y():
         return 2
 
@@ -953,7 +953,7 @@ def test_disable_default_memory_caching(builder, make_counter):
     @builder
     @z_protocol
     @bn.memoize(True)
-    @count_calls(z_counter)
+    @z_counter
     def z():
         return 3
 
@@ -1010,7 +1010,7 @@ def test_changes_per_run_and_not_persist(
     @builder
     @bn.persist(False)
     @bn.changes_per_run
-    @count_calls(x_plus_one_counter)
+    @x_plus_one_counter
     def x_plus_one(x):
         return x + 1
 
@@ -1018,21 +1018,21 @@ def test_changes_per_run_and_not_persist(
 
     @builder
     @bn.persist(False)
-    @count_calls(x_plus_two_counter)
+    @x_plus_two_counter
     def x_plus_two(x_plus_one):
         return x_plus_one + 1
 
     x_plus_three_counter = make_counter()
 
     @builder
-    @count_calls(x_plus_three_counter)
+    @x_plus_three_counter
     def x_plus_three(x_plus_two):
         return x_plus_two + 1
 
     x_plus_four_counter = make_counter()
 
     @builder
-    @count_calls(x_plus_four_counter)
+    @x_plus_four_counter
     def x_plus_four(x_plus_three):
         return x_plus_three + 1
 
@@ -1082,7 +1082,7 @@ def test_changes_per_run_and_persist(builder, make_counter, parallel_execution_e
 
     @builder
     @bn.changes_per_run
-    @count_calls(x_plus_one_counter)
+    @x_plus_one_counter
     def x_plus_one(x):
         return x + 1
 
@@ -1090,14 +1090,14 @@ def test_changes_per_run_and_persist(builder, make_counter, parallel_execution_e
 
     @builder
     @bn.persist(False)
-    @count_calls(x_plus_two_counter)
+    @x_plus_two_counter
     def x_plus_two(x_plus_one):
         return x_plus_one + 1
 
     x_plus_three_counter = make_counter()
 
     @builder
-    @count_calls(x_plus_three_counter)
+    @x_plus_three_counter
     def x_plus_three(x_plus_two):
         return x_plus_two + 1
 
@@ -1139,7 +1139,7 @@ def test_changes_per_run_and_not_memoize(builder, make_counter):
     @bn.memoize(False)
     @bn.persist(False)
     @bn.changes_per_run
-    @count_calls(counter)
+    @counter
     def x_plus_one(x):
         return x + 1
 
@@ -1197,14 +1197,14 @@ def test_updating_cache_works_only_with_immediate(builder):
 
 
 def test_multiple_outputs_all_persisted_at_once(builder, make_counter):
-    call_counter = make_counter()
+    counter = make_counter()
 
     @builder
     @bn.outputs("x", "y")
-    @count_calls(call_counter)
+    @counter
     def x_y():
         return 1, 2
 
     assert builder.build().get("x") == 1
     assert builder.build().get("y") == 2
-    assert call_counter.times_called() == 1
+    assert counter.times_called() == 1

--- a/tests/test_flow/test_persistence_gcs.py
+++ b/tests/test_flow/test_persistence_gcs.py
@@ -15,7 +15,6 @@ import tempfile
 import dask.dataframe as dd
 
 from ..helpers import (
-    count_calls,
     df_from_csv_str,
     equal_frame_and_index_content,
     gsutil_wipe_path,
@@ -47,7 +46,7 @@ def test_gcs_caching(preset_gcs_builder, make_counter):
     builder = preset_gcs_builder
 
     @builder
-    @count_calls(call_counter)
+    @call_counter
     def xy(x, y):
         return x * y
 
@@ -229,7 +228,7 @@ def test_multifile_serialization(preset_gcs_builder, make_counter):
 
     @builder
     @bn.protocol.dask
-    @count_calls(call_counter)
+    @call_counter
     def df():
         return dask_df
 
@@ -254,7 +253,7 @@ def test_file_path_copying(preset_gcs_builder, make_counter):
     file_contents = "DATA"
 
     @builder
-    @count_calls(call_counter)
+    @call_counter
     @bn.protocol.path(operation="move")
     def data_path():
         call_counter.mark()

--- a/tests/test_flow/test_protocols.py
+++ b/tests/test_flow/test_protocols.py
@@ -11,7 +11,7 @@ import pandas.testing as pdt
 from PIL import Image
 import dask.dataframe as dd
 
-from ..helpers import count_calls, df_from_csv_str, equal_frame_and_index_content
+from ..helpers import df_from_csv_str, equal_frame_and_index_content
 
 import bionic as bn
 from bionic.exception import (
@@ -57,7 +57,7 @@ def test_picklable_value(builder, make_counter, protocol, value):
 
     @builder
     @protocol
-    @count_calls(counter)
+    @counter
     def picklable_value():
         return value
 
@@ -73,7 +73,7 @@ def test_jsonable_value(builder, make_counter, protocol, value):
 
     @builder
     @protocol
-    @count_calls(counter)
+    @counter
     def jsonable_value():
         return value
 
@@ -99,7 +99,7 @@ def test_picklable_with_parens(builder, make_counter):
 
     @builder
     @bn.protocol.picklable()
-    @count_calls(counter)
+    @counter
     def picklable_value():
         return 1
 
@@ -114,7 +114,7 @@ def test_picklable_value_is_also_dillable(builder, make_counter, value):
 
     @builder
     @bn.protocol.dillable
-    @count_calls(counter)
+    @counter
     def dillable_value():
         return value
 
@@ -138,7 +138,7 @@ def test_dillable(builder, make_counter):
 
     @builder
     @bn.protocol.dillable
-    @count_calls(counter)
+    @counter
     def add_two():
         return make_adder(2)
 
@@ -161,7 +161,7 @@ def test_simple_dataframe(builder, make_counter):
 
     @builder
     @bn.protocol.frame
-    @count_calls(counter)
+    @counter
     def df():
         return df_value
 
@@ -290,7 +290,7 @@ def test_simple_dask_dataframe(builder, make_counter, protocol):
 
     @builder
     @protocol
-    @count_calls(counter)
+    @counter
     def df():
         return dask_df
 
@@ -318,7 +318,7 @@ def test_multiple_partitions_dask_dataframe(builder, make_counter):
 
     @builder
     @bn.protocol.dask
-    @count_calls(counter)
+    @counter
     def df():
         return dask_df
 
@@ -529,7 +529,7 @@ def test_path_protocol(builder, make_counter, tmp_path, operation):
 
     @builder
     @bn.protocol.path(operation=operation)
-    @count_calls(phrase_file_path_counter)
+    @phrase_file_path_counter
     def phrase_file_path():
         "A path to a file containing a phrase."
         output_phrase_file_path.write_text(phrase_str)
@@ -539,7 +539,7 @@ def test_path_protocol(builder, make_counter, tmp_path, operation):
 
     @builder
     @bn.protocol.path(operation=operation)
-    @count_calls(colors_dir_path_counter)
+    @colors_dir_path_counter
     def colors_dir_path():
         "A path to a directory containing some files named after colors."
         output_colors_dir_path.mkdir()


### PR DESCRIPTION
This makes the output of the `make_counter` fixture usable as a
decorator, so instead of writing `@count_calls(counter)`, we can just
write `@counter`.

This is a little tricky because of the way SyncManager proxies work: I
had to split the ResettingCounter class into a SimpleCounter class
(which can be proxied) and a ResettingCallCounter class (which can't,
but wraps a SimpleCounter).