### PR TITLE
Introduce FunctionAttributes class

### DIFF
--- a/bionic/core/task_execution.py
+++ b/bionic/core/task_execution.py
@@ -307,13 +307,13 @@ class TaskState:
     intermediate state and the deriving logic.
     """
 
-    def __init__(self, task, dep_states, case_key, provider, entity_defs_by_dnode):
+    def __init__(self, task, dep_states, case_key, func_attrs, entity_defs_by_dnode):
         assert len(entity_defs_by_dnode) == len(task.keys)
 
         self.task = task
         self.dep_states = dep_states
         self.case_key = case_key
-        self.provider = provider
+        self.func_attrs = func_attrs
         self.entity_defs_by_dnode = entity_defs_by_dnode
 
         # Cached values.
@@ -477,11 +477,11 @@ class TaskState:
         }
 
         self._provenance = Provenance.from_computation(
-            code_fingerprint=self.provider.get_code_fingerprint(self.case_key),
+            code_fingerprint=self.func_attrs.code_fingerprint,
             case_key=self.case_key,
             dep_provenance_digests_by_task_key=dep_provenance_digests_by_task_key,
             treat_bytecode_as_functional=treat_bytecode_as_functional,
-            can_functionally_change_per_run=self.provider.attrs.changes_per_run,
+            can_functionally_change_per_run=self.func_attrs.changes_per_run,
             flow_instance_uuid=flow_instance_uuid,
         )
 
@@ -523,7 +523,7 @@ class TaskState:
             should_memoize = bootstrap.should_memoize_default
         else:
             should_memoize = True
-        if self.provider.attrs.changes_per_run and not should_memoize:
+        if self.func_attrs.changes_per_run and not should_memoize:
             descriptors = [
                 task_key.dnode.to_descriptor() for task_key in self.task_keys
             ]
@@ -705,7 +705,7 @@ class TaskState:
         # Clear up memoized cache to avoid sending it through IPC.
         task_state._results_by_dnode = None
         # Clear up fields not needed in subprocess, for computing or for cache lookup.
-        task_state.provider = None
+        task_state.func_attrs = None
         task_state.entity_defs_by_dnode = None
         task_state.case_key = None
         task_state._provenance = None

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -294,3 +294,13 @@ class VersioningPolicy:
 
     check_for_bytecode_errors = attr.ib()
     treat_bytecode_as_functional = attr.ib()
+
+
+@attr.s(frozen=True)
+class FunctionAttributes:
+    """
+    Describes properties of a Python function.
+    """
+
+    code_fingerprint = attr.ib()
+    changes_per_run = attr.ib()

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -22,6 +22,7 @@ from .datatypes import (
     CaseKeySpace,
     CodeFingerprint,
     CodeVersion,
+    FunctionAttributes,
 )
 from .bytecode import canonical_bytecode_bytes_from_func
 from .deps.optdep import import_optional_dependency
@@ -48,6 +49,18 @@ class ProviderAttributes:
 class BaseProvider:
     def __init__(self, attrs):
         self.attrs = attrs
+
+    # TODO It would probably make more sense to attach this directly to the Task class,
+    # but at the moment that would require a lot of clunky copying in all the wrapper
+    # classes, to make sure each wrapping task inherits all the attributes of the
+    # wrapped task. A better strategy would be to copy tasks using `attr.evolve`. At
+    # that point it probably makes sense to move Task.is_simple_lookup to
+    # FunctionAttributes.
+    def get_func_attrs(self, case_key):
+        return FunctionAttributes(
+            code_fingerprint=self.get_code_fingerprint(case_key),
+            changes_per_run=self.attrs.changes_per_run,
+        )
 
     def get_code_fingerprint(self, case_key):
         source_func = self.get_source_func()


### PR DESCRIPTION
I moved the `code_fingerprint` and `changes_per_run` attributes into
a small data class, which `TaskState` can use instead of keeping a
reference to the original `Provider`. This makes no real difference now,
but it gives us the option of simplifying our task stripping code,
because `FunctionAttributes` is picklable but `Provider` is not. I think
this will be useful for fixing tuple persistence.

I also added a TODO for a further refactor that would move
`FunctionAttributes` onto the `Task` itself.