### PR TITLE
Disallow Sphinx 3.2.0

### DIFF
--- a/bionic/deps/extras.py
+++ b/bionic/deps/extras.py
@@ -43,7 +43,7 @@ extras["dev"] = combine(
         "flake8",
         "flake8-print",
         "flake8-fixme",
-        "sphinx",
+        "sphinx!=3.2.0",
         "sphinx_rtd_theme",
         "sphinx-autobuild",
         "nbsphinx",

--- a/bionic/deps/optdep.py
+++ b/bionic/deps/optdep.py
@@ -13,7 +13,7 @@ def first_token_from_package_desc(desc):
     if first_mismatch is None:
         return desc
 
-    if desc[first_mismatch.start()] not in " <>=":
+    if desc[first_mismatch.start()] not in " <>!=":
         raise AssertionError(
             oneline(
                 f"""


### PR DESCRIPTION
This version of Sphinx fails to build our docs with the following error:

    Handler <function _process_docstring at 0x7f156ef03598> for event
    'autodoc-process-docstring' threw an exception (exception: module,
    class, method, function, traceback, frame, or code object was expected,
    got PathProtocol)

This appears to be a bug in Sphinx which should be fixed in the next
version. (See [here](https://github.com/sphinx-doc/sphinx/issues/8074) for more details.) I've confirmed that
the build works properly with Sphinx master.