### PR TITLE
Fix heading sizes in upcoming release notes

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -75,21 +75,21 @@ Upcoming Version (Not Yet Released)
    "latest" docs (corresponding to the master branch).
 
 Deprecated Features
--------------------
+...................
 
 - Bionic no longer supports Matplotlib version 3.2.x, since that version can cause
   crashes on Mac OS when using multiprocessing. Versions 3.1.x and 3.3+ are still
   supported.
 
 Bug Fixes
----------
+.........
 
 - Fixed an `issue <https://github.com/square/bionic/issues/111>`_ where non-persistable
   entities could be spuriously recomputed even when their values weren't directly
   needed.
 
 Documentation
--------------
+.............
 
 - Fixed broken link in the documentation for the
   :class:`FileCopier <bionic.filecopier.FileCopier>` class.


### PR DESCRIPTION
Looks like I accidentally used the wrong heading size for the upcoming release notes: everything is a little larger than it should be.

Before:
![image](https://user-images.githubusercontent.com/42037/90136727-9e33db00-dd42-11ea-8fa8-7bc341f3b79c.png)

After:
![image](https://user-images.githubusercontent.com/42037/90136758-a8ee7000-dd42-11ea-97e2-30257200115a.png)
