### PR TITLE
Unquote URI path values

### DIFF
--- a/bionic/persistence.py
+++ b/bionic/persistence.py
@@ -369,9 +369,7 @@ class CacheAccessor:
         stores = [self._local]
         if self._cloud:
             stores.append(self._cloud)
-        inventory_root_urls = (
-            " and ".join(store.inventory.root_url for store in stores),
-        )
+        inventory_root_urls = " and ".join(store.inventory.root_url for store in stores)
 
         raise InvalidCacheStateError(
             oneline(

--- a/bionic/utils/urls.py
+++ b/bionic/utils/urls.py
@@ -4,7 +4,7 @@ Utilities for working with URLs.
 
 import os
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 FILE_SCHEME = "file"
 GCS_SCHEME = "gs"
@@ -32,7 +32,7 @@ def is_absolute_url(url):
 
 def path_from_url(url):
     result = urlparse(url)
-    return Path(result.path)
+    return Path(unquote(result.path))
 
 
 def url_from_path(path):

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -94,6 +94,8 @@ Bug Fixes
 - Fixed an `issue <https://github.com/square/bionic/issues/111>`_ where non-persistable
   entities could be spuriously recomputed even when their values weren't directly
   needed.
+- Fixed an `issue <https://github.com/square/bionic/issues/229>`_ where caching fails
+  when cache directory paths contain whitespaces.
 
 Documentation
 .............

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -1219,3 +1219,17 @@ def test_avoid_recomputing_nonpersisted_dep(builder, make_counter):
     assert builder.build().get("b") == 2
     assert builder.build().get("b") == 2
     assert a_counter.times_called() == 1
+
+
+def test_caching_dir_with_whitespaces(builder, make_counter, tmp_path):
+    builder.set("core__persistent_cache__flow_dir", str(tmp_path / "BN TEST DATA"))
+    counter = make_counter()
+
+    @builder
+    @counter
+    def one():
+        return 1
+
+    assert builder.build().get("one") == 1
+    assert builder.build().get("one") == 1
+    assert counter.times_called() == 1


### PR DESCRIPTION
This change fixes a bug in path to uri conversion that leads to quoted
uri value. Refer to #229 for an example of this issue.

<img width="742" alt="Screen Shot 2020-08-18 at 11 54 04 AM" src="https://user-images.githubusercontent.com/2109428/90536064-919bf200-e149-11ea-8d0c-838e79d078d2.png">
