### PR TITLE
Add follow-up tasks

### DIFF
--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -642,7 +642,7 @@ class CombinedProtocol(BaseProtocol):
         self._protocol_for_value(value).write(value, path)
 
     def __repr__(self):
-        return f"CombinedProtocol{tuple(self._subprotocols)!r}"
+        return "CombinedProtocol(...)"
 
 
 class TypeProtocol(PicklableProtocol):

--- a/bionic/utils/keyed_priority_stack.py
+++ b/bionic/utils/keyed_priority_stack.py
@@ -1,0 +1,109 @@
+"""
+Provides an implementation of an updatable priority queue with specific ordering rules.
+
+The other implementations I found (including `heapq` and `queue.PriorityQueue`) all have
+one or more problems:
+
+1. They're based on min-heaps, so they return the lowest value first; this is
+counterintuitive when dealing with priorities.
+2. Built-in tiebreaking is not provided.
+3. Updating priorities is impossible, or needs to be implemented separately.
+
+The implementation here is based on the `heapq` implementation of a binary heap, but
+adds reversed ordering (highest priority first), LIFO tiebreaking, and keyed lookup.
+"""
+
+import heapq
+from functools import total_ordering
+
+
+class KeyedPriorityStack:
+    """
+    An updatable priority queue where ties are broken in last-in-first-out (LIFO) order.
+
+    This data structure has a stack-like interface, supporting `push` and `pop`, but
+    each element on the stack also has an associated key and priority. By default,
+    `pop` removes returns the element with the *highest* priority (breaking ties in
+    LIFO order), but it also accepts an optional key argument that specifies a specific
+    element to be popped. This can be used to easily update an element's priority.
+    """
+
+    def __init__(self):
+        self._heap = []
+        self._next_seq_id = 0
+        self._n_unremoved_entries = 0
+        self._unremoved_entries_by_key = {}
+
+    def push(self, key, value, priority):
+        """
+        Adds a value to the stack with associated key and priority.
+        """
+
+        if key is None:
+            raise KeyError("Attempted to add None as key to priority stack")
+        if key in self._unremoved_entries_by_key:
+            raise ValueError(
+                f"Attempted to add duplicate key to priority stack: {key!r}"
+            )
+        seq_id = self._next_seq_id
+        self._next_seq_id += 1
+        entry = PriorityEntry(priority, seq_id, key, value)
+        self._unremoved_entries_by_key[key] = entry
+        heapq.heappush(self._heap, entry)
+        self._n_unremoved_entries += 1
+
+    def pop(self, key=None):
+        """
+        Removes a value from the stack and returns it.
+
+        If no key is provided, removes and returns the highest-priority element (or
+        the last-added such element, if there is a tie).
+
+        If a key is provided, removes and returns the element with that key.
+        """
+
+        if key is not None:
+            if key not in self._unremoved_entries_by_key:
+                raise KeyError(f"Key not found in priority stack: {key!r}")
+            entry = self._unremoved_entries_by_key.pop(key)
+            entry.is_removed = True
+            self._n_unremoved_entries -= 1
+            return entry.value
+
+        else:
+            while True:
+                if self._n_unremoved_entries == 0:
+                    raise IndexError("Attempted to get item from empty priority stack")
+                entry = heapq.heappop(self._heap)
+                if entry.is_removed:
+                    continue
+                self._n_unremoved_entries -= 1
+                del self._unremoved_entries_by_key[entry.key]
+                return entry.value
+
+    def __len__(self):
+        """
+        Returns the number of elements on the stack.
+        """
+
+        return self._n_unremoved_entries
+
+
+@total_ordering
+class PriorityEntry:
+    def __init__(self, priority, seq_id, key, value):
+        self.priority = priority
+        self.seq_id = seq_id
+        self.key = key
+        self.value = value
+        self.is_removed = False
+
+    def __lt__(self, other):
+        assert isinstance(other, PriorityEntry)
+
+        return (self.priority, self.seq_id) > (other.priority, other.seq_id)
+
+    def __eq__(self, other):
+        if not isinstance(other, PriorityEntry):
+            return False
+        return (self.priority, self.seq_id) == (other.priority, other.seq_id)

--- a/tests/test_utils/test_keyed_priority_stack.py
+++ b/tests/test_utils/test_keyed_priority_stack.py
@@ -1,0 +1,191 @@
+import pytest
+
+from random import Random
+
+from bionic.utils.keyed_priority_stack import KeyedPriorityStack
+
+
+def test_simple_push():
+    kps = KeyedPriorityStack()
+
+    assert len(kps) == 0
+
+    kps.push("ONE", "1", 1)
+    kps.push("TWO_A", "2a", 2)
+    kps.push("THREE", "3", 3)
+    kps.push("TWO_B", "2b", 2)
+
+    assert len(kps) == 4
+
+    assert kps.pop() == "3"
+    assert kps.pop() == "2b"
+    assert kps.pop() == "2a"
+    assert kps.pop() == "1"
+
+    assert len(kps) == 0
+
+
+def test_pop_by_key():
+    kps = KeyedPriorityStack()
+
+    with pytest.raises(KeyError):
+        kps.pop("ONE")
+
+    kps.push("ONE", "1", 1)
+    kps.push("TWO_A", "2a", 2)
+    kps.push("THREE", "3", 3)
+    kps.push("TWO_B", "2b", 2)
+
+    with pytest.raises(KeyError):
+        kps.pop("1")
+
+    assert kps.pop("TWO_B") == "2b"
+    assert kps.pop() == "3"
+    assert kps.pop("TWO_A") == "2a"
+    assert kps.pop() == "1"
+
+    with pytest.raises(KeyError):
+        kps.pop("THREE")
+
+
+def test_incomparable_unhashable_values():
+    class Wrapper:
+        def __init__(self, value):
+            self.value = value
+
+        def __eq__(self, other):
+            raise NotImplementedError("!")
+
+        def __hash__(self, other):
+            raise NotImplementedError("!")
+
+    kps = KeyedPriorityStack()
+
+    kps.push("ONE", Wrapper("1"), 1)
+    kps.push("TWO_A", Wrapper("2a"), 2)
+    kps.push("THREE", Wrapper("3"), 3)
+    kps.push("TWO_B", Wrapper("2b"), 2)
+
+    assert kps.pop().value == "3"
+    assert kps.pop().value == "2b"
+    assert kps.pop().value == "2a"
+    assert kps.pop().value == "1"
+
+
+def test_random():
+    """
+    Tests our data structure by applying a series of random operations and comparing
+    the results to an oracle (SimpleKeyedPriorityStack).
+    """
+
+    random = Random(0)
+    MAX_VALUE = 1000000
+
+    test_kps = KeyedPriorityStack()
+    ctrl_kps = SimpleKeyedPriorityStack()
+
+    def do_push():
+        value = random.randrange(MAX_VALUE)
+        priority = random.randrange(MAX_VALUE)
+        key = random.randrange(MAX_VALUE)
+
+        test_kps.push(key, value, priority)
+        ctrl_kps.push(key, value, priority)
+
+    def do_and_check_pop():
+        if len(test_kps) == 0:
+            with pytest.raises(IndexError):
+                test_kps.pop()
+            return
+
+        assert test_kps.pop() == ctrl_kps.pop()
+
+    def do_and_check_pop_with_key():
+        key = ctrl_kps._get_random_key(random)
+        if key is None:
+            return
+
+        assert test_kps.pop(key) == ctrl_kps.pop(key)
+
+    def check_pop_missing_key():
+        key = random.randrange(MAX_VALUE) + MAX_VALUE
+
+        with pytest.raises(KeyError):
+            test_kps.pop(key)
+
+    def check_push():
+        key = ctrl_kps._get_random_key(random)
+        if key is None:
+            return
+        value = random.randrange(MAX_VALUE)
+        priority = random.randrange(MAX_VALUE)
+
+        with pytest.raises(ValueError):
+            test_kps.push(key, value, priority)
+
+    def check_len():
+        assert len(test_kps) == len(ctrl_kps)
+
+    N_ITERS = 3000
+    ACTIONS = [
+        # We have more pushes than pops, so the size of the stack should tend to grow
+        # over time.
+        do_push,
+        do_push,
+        do_push,
+        do_and_check_pop,
+        do_and_check_pop_with_key,
+        check_len,
+        check_push,
+        check_pop_missing_key,
+    ]
+    for i in range(N_ITERS):
+        action = random.choice(ACTIONS)
+        action()
+    while len(test_kps) > 0:
+        do_and_check_pop()
+    check_len()
+
+
+class SimpleKeyedPriorityStack:
+    """
+    An alternative implementation of KeyedPriorityStack which is simpler but less
+    efficient.
+    """
+
+    def __init__(self):
+        self._sorted_quads = []
+        self._next_seq_id = 0
+
+    def push(self, key, value, priority):
+        seq_id = self._next_seq_id
+        self._next_seq_id += 1
+
+        self._sorted_quads.append([priority, seq_id, value, key])
+        self._sorted_quads.sort()
+
+    def pop(self, key=None):
+        if key is not None:
+            ix = self._quad_ix_for_key(key)
+            _, _, value, _ = self._sorted_quads.pop(ix)
+            return value
+
+        else:
+            _, _, value, _ = self._sorted_quads.pop()
+            return value
+
+    def __len__(self):
+        return len(self._sorted_quads)
+
+    def _quad_ix_for_key(self, key):
+        (quad_ix,) = [
+            quad_ix
+            for (quad_ix, (_, _, _, quad_key)) in enumerate(self._sorted_quads)
+            if quad_key == key
+        ]
+        return quad_ix
+
+    def _get_random_key(self, random):
+        if len(self) == 0:
+            return None
+        return random.choice(self._sorted_quads)[3]


### PR DESCRIPTION
As noted in the commit messages below, I'd prefer to have some more fuzz testing in place before merging this, but I think the code is correct.

### Add KeyedPriorityStack data structure
We'll use this to add priority to our stack of pending task entries.

### Add follow-up tasks for tuples
This adds the concept of "follow-up tasks": when a task is finished, if
it has any "follow-up" tasks, those tasks must also be completed
immediately. This allows us to guarantee that when a tuple-returning
task is computed, all of the individual entities in the tuple are
persisted immediately.

Implementation-wise, this includes the following changes:
- Modifying TaskState creation to include these followups (which can now
introduce circular relationships between tasks)
- Modifying the TaskCompletionRunner to:
  - use a "priority stack" instead of a simple list
  - queue up follow-ups, at high priority, at the appropriate time
  - when dispatching tasks remotely, include any additional follow-ups
    that need to be computed as well

I think this code is correct, but I'd like to find a way to add more
fuzz tests before merging it.