### PR TITLE
Fix visualization of tuple nodes

### DIFF
--- a/bionic/dagviz.py
+++ b/bionic/dagviz.py
@@ -102,17 +102,22 @@ def dot_from_graph(graph, vertical=False, curvy_lines=False, name=None):
     )
 
     def name_from_node(node):
-        return graph.nodes[node]["name"]
+        # We wrap all names in quotes; if we don't, pydot will react to special
+        # characters by either adding its own quotes or emitting invalid code. These
+        # quotes aren't visible in the actual visualization.
+        return '"' + (graph.nodes[node]["name"]) + '"'
 
     def doc_from_node(node):
         return graph.nodes[node].get("doc")
 
-    for cluster, node_list in node_lists_by_cluster.items():
+    for cluster_ix, node_list in enumerate(node_lists_by_cluster.values()):
         sorted_nodes = list(
             sorted(node_list, key=lambda node: graph.nodes[node]["task_ix"])
         )
 
-        subdot = pydot.Cluster(cluster, style="invis")
+        # We use a numerical cluster index instead of the actual cluster descriptor,
+        # because pydot can break if the cluster name constains special characters.
+        subdot = pydot.Cluster(str(cluster_ix), style="invis")
 
         for node in sorted_nodes:
             descriptor = graph.nodes[node]["descriptor"]

--- a/tests/test_flow/test_dagviz.py
+++ b/tests/test_flow/test_dagviz.py
@@ -26,7 +26,8 @@ def flow(builder):
 
     @builder
     @bn.gather(over="full_name")
-    def all_names(gather_df):
+    @bn.returns("all_names,")
+    def _(gather_df):
         """Comma-separated list of names."""
         return ", ".join(gather_df["full_name"])
 
@@ -57,30 +58,31 @@ def nodes_by_name_from_dot(dot):
 
 
 def test_dag_size(flow_graph):
-    assert len(flow_graph.nodes) == 8
+    assert len(flow_graph.nodes) == 9
 
 
 def test_dot_properties(flow_dot):
     nodes = nodes_by_name_from_dot(flow_dot)
     assert set(nodes.keys()) == {
-        # pydot puts quotes around the name if it contains square brackets. (However,
-        # these quotes are not visible when the graph is rendered as an image.)
+        # We've wrapped all our names in quotes to work around pydot. However, they're
+        # not visible in the visualization.
         '"first_name[0]"',
         '"first_name[1]"',
-        "last_name",
+        '"last_name"',
         '"full_name[0]"',
         '"full_name[1]"',
         '"initials[0]"',
         '"initials[1]"',
-        "all_names",
+        '"all_names,"',
+        '"all_names"',
     }
 
-    assert nodes["last_name"].get_tooltip() is None
-    assert nodes["all_names"].get_tooltip() == "Comma-separated list of names."
+    assert nodes['"last_name"'].get_tooltip() is None
+    assert nodes['"all_names"'].get_tooltip() == "Comma-separated list of names."
     assert nodes['"initials[0]"'].get_tooltip() == "Just the initials."
     assert nodes['"initials[1]"'].get_tooltip() == "Just the initials."
 
-    assert nodes["last_name"].get_fillcolor() != nodes["all_names"].get_fillcolor()
+    assert nodes['"last_name"'].get_fillcolor() != nodes['"all_names"'].get_fillcolor()
     assert (
         nodes['"first_name[0]"'].get_fillcolor()
         == nodes['"first_name[1]"'].get_fillcolor()


### PR DESCRIPTION
Pydot can break when it encounters special characters, so we need some
special handling when visualizing nodes that aren't just entities. I've
added a singleton tuple to our test fixture; once we activate tuple
descriptors everywhere, the `outputs` part of the test will also use a
tuple.