### PR TITLE
Rename --all-execution-modes to --parallel

### DIFF
--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -39,4 +39,4 @@ jobs:
         black --check .
     - name: Test with pytest
       run: |
-        pytest --all-execution-modes --slow
+        pytest --parallel --slow

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -111,6 +111,12 @@ Documentation
 - Fixed broken link in the documentation for the
   :class:`FileCopier <bionic.filecopier.FileCopier>` class.
 
+Development Changes
+...................
+
+- The ``pytest`` flag for activating parallel execution tests has been renamed from
+  ``--all-execution-modes`` to ``--parallel``.
+
 0.8.3 (Jul 23, 2020)
 --------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ def pytest_addoption(parser):
         "--bucket", action="store", help="URL to GCS bucket to use for tests"
     )
     parser.addoption(
-        "--all-execution-modes",
+        "--parallel",
         action="store_true",
         default=False,
         help="also run all tests with parallel execution mode",
@@ -41,7 +41,7 @@ def pytest_collection_modifyitems(config, items):
     has_gcs = config.getoption("--bucket")
     skip_needs_gcs = pytest.mark.skip(reason="only runs when --bucket is set")
 
-    also_run_parallel = config.getoption("--all-execution-modes")
+    also_run_parallel = config.getoption("--parallel")
 
     items_to_keep = []
     for item in items:


### PR DESCRIPTION
Whenever I use this flag, I find myself typing `--parallel`. This
name is also shorter and consistent with the `--slow` flag. Note
that this flag still just *adds* tests, like `--slow` does; if you want
*only* the parallel tests, you can filter them down using `-m parallel`.