### PR TITLE
Improve error reporting for multiple outputs

### DIFF
--- a/bionic/core/task_execution.py
+++ b/bionic/core/task_execution.py
@@ -181,7 +181,7 @@ class TaskRunnerEntry:
         results_by_dnode = {}
         result_value_hashes_by_dnode = {}
         for ix, (query, value) in enumerate(zip(state._queries, values)):
-            query.protocol.validate(value)
+            query.protocol.validate_for_dnode(query.dnode, value)
 
             result = Result(query=query, value=value)
 

--- a/bionic/exception.py
+++ b/bionic/exception.py
@@ -39,6 +39,10 @@ class EntityComputationError(Exception):
     pass
 
 
+class EntityValueError(ValueError):
+    pass
+
+
 class AttributeValidationError(Exception):
     pass
 

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -249,7 +249,7 @@ class FlowState(pyrs.PClass):
         tokens = []
         for name, value in zip(names, values):
             protocol = self.get_entity_def(name).protocol
-            protocol.validate(value)
+            protocol.validate_for_entity(name, value)
             tokens.append(protocol.tokenize(value))
         provider = provider.add_case(case_key, values, tokens)
 
@@ -489,10 +489,6 @@ class FlowBuilder:
             )
             doc = docstring
 
-        # TODO We can remove this validation, since it also happens in add_case below.
-        for value in values:
-            protocol.validate(value)
-
         state = self._state
 
         state = state.define_entity(
@@ -541,9 +537,6 @@ class FlowBuilder:
         protocol = state.get_entity_def(name).protocol
 
         for value in values:
-            # TODO We can remove this validation, since it also happens in add_case
-            # below.
-            protocol.validate(value)
             case_key = CaseKey([(name, protocol.tokenize(value))])
             state = state.add_case(case_key, [name], [value])
 
@@ -633,7 +626,7 @@ class FlowBuilder:
             protocol = state.get_entity_def(name).protocol
             # TODO Both the validation and tokenization are also happening in
             # state.add_case below; maybe we can remove some duplicate work.
-            protocol.validate(value)
+            protocol.validate_for_entity(name, value)
             token = protocol.tokenize(value)
 
             values.append(value)

--- a/tests/test_flow/test_merge.py
+++ b/tests/test_flow/test_merge.py
@@ -2,9 +2,10 @@ import pytest
 
 import bionic as bn
 from bionic.exception import (
-    UndefinedEntityError,
     AlreadyDefinedEntityError,
+    EntityValueError,
     IncompatibleEntityError,
+    UndefinedEntityError,
 )
 
 ALL_KEEP_VALUES = ["error", "old", "new", "combine"]
@@ -298,12 +299,12 @@ def test_protocols_conflict(builder):
 
     builder.merge(incoming_builder.build(), keep="old")
     builder.set("x", 1)
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         builder.set("x", "blue")
 
     builder.merge(incoming_builder.build(), keep="new")
     builder.set("x", "blue")
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         builder.set("x", 1)
 
 
@@ -315,7 +316,7 @@ def test_protocol_is_overwritten(builder):
 
     builder.merge(incoming_builder.build(), keep="new")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         builder.set("x", 3)
 
     assert builder.build().get("x") == "blue"

--- a/tests/test_flow/test_new_api.py
+++ b/tests/test_flow/test_new_api.py
@@ -5,6 +5,7 @@ These tests are for experimental descriptor-based uses of Bionic's API.
 import pytest
 
 import bionic as bn
+from bionic.exception import EntityValueError
 
 
 def test_returns(builder):
@@ -37,6 +38,34 @@ def test_returns(builder):
     assert flow.get("five") == 5
     assert flow.get("six") == 6
     assert flow.get("seven") == 7
+
+
+def test_failing_returns(builder):
+    @builder
+    @bn.returns("a, b")
+    def wrong_number_of_values():
+        return 1, 2, 3
+
+    @builder
+    @bn.returns("c, d")
+    def not_a_sequence():
+        return 1
+
+    @builder
+    @bn.returns("(e, f), g")
+    def wrong_tuple_structure():
+        return 1, (2, 3)
+
+    flow = builder.build()
+
+    with pytest.raises(EntityValueError):
+        flow.get("a")
+
+    with pytest.raises(EntityValueError):
+        flow.get("c")
+
+    with pytest.raises(EntityValueError):
+        flow.get("e")
 
 
 def test_accepts(builder):

--- a/tests/test_flow/test_outputs.py
+++ b/tests/test_flow/test_outputs.py
@@ -6,7 +6,7 @@ import pandas.testing as pdt
 from ..helpers import RoundingProtocol
 
 import bionic as bn
-from bionic.exception import UndefinedEntityError
+from bionic.exception import EntityValueError, UndefinedEntityError
 
 
 @pytest.fixture(scope="function")
@@ -119,5 +119,16 @@ def test_wrong_number_of_outputs(builder):
         return (1, 2, 3)
 
     flow = builder.build()
-    with pytest.raises(ValueError):
+    with pytest.raises(EntityValueError):
+        flow.get("a")
+
+
+def test_non_sequence_outputs(builder):
+    @builder
+    @bn.outputs("a", "b")
+    def three_outputs():
+        return 1
+
+    flow = builder.build()
+    with pytest.raises(EntityValueError):
         flow.get("a")

--- a/tests/test_flow/test_protocols.py
+++ b/tests/test_flow/test_protocols.py
@@ -16,6 +16,7 @@ from ..helpers import df_from_csv_str, equal_frame_and_index_content
 import bionic as bn
 from bionic.exception import (
     EntitySerializationError,
+    EntityValueError,
     UnsupportedSerializedValueError,
 )
 from bionic.protocols import CombinedProtocol, PicklableProtocol
@@ -90,7 +91,7 @@ def test_non_jsonable_value_fails(builder):
         circular_ref_array.append(circular_ref_array)
         return circular_ref_array
 
-    with pytest.raises(RecursionError):
+    with pytest.raises(EntityValueError):
         builder.build().get("non_jsonable_value")
 
 
@@ -499,11 +500,11 @@ def test_type_protocol(builder):
     builder.set("float_val", 1.0)
     builder.set("str_val", "one")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         builder.set("int_val", "one")
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         builder.set("float_val", 1)
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         builder.set("str_val", 1.0)
 
     flow = builder.build()
@@ -522,7 +523,7 @@ def test_enum_protocol(builder):
     builder.set("color", "blue")
     assert builder.build().get("color") == "blue"
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         builder.set("color", "green")
 
 
@@ -632,18 +633,18 @@ def test_combined_protocol(builder):
     flow = builder.build().setting("value", 1)
 
     assert flow.get("must_be_one") == "one"
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         flow.get("must_be_two")
     assert flow.get("must_be_one_or_two") == "one"
 
     flow = flow.setting("value", 2)
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         flow.get("must_be_one")
     assert flow.get("must_be_two") == "two"
     assert flow.get("must_be_one_or_two") == "two"
 
     flow = flow.setting("value", 3)
-    with pytest.raises(AssertionError):
+    with pytest.raises(EntityValueError):
         flow.get("must_be_one_or_two")
 
 


### PR DESCRIPTION
These commits introduce a new exception type for protocol validation failures; improve the reporting of one specific error case; and add some new tests for reporting errors with tuple descriptors.