### PR TITLE
test_reload.py use tmp cache dir

### DIFF
--- a/tests/test_flow/test_reload.py
+++ b/tests/test_flow/test_reload.py
@@ -40,30 +40,8 @@ def write_module(tmp_module_path):
     sys.dont_write_bytecode = dont_write_bytecode
 
 
-@pytest.fixture
-def write_flow_module(write_module):
-    def _write_flow_module(x):
-        write_module(
-            "flow_module",
-            f"""
-                import bionic as bn
-
-                builder = bn.FlowBuilder('flow')
-                builder.assign('x', {x})
-
-                @builder
-                def x_doubled(x):
-                    return x*2
-
-                flow = builder.build()
-            """,
-        )
-
-    return _write_flow_module
-
-
 @pytest.fixture(params=["reload", "reloading"])
-def reload_method(request):
+def reload_method_name(request):
     return request.param
 
 
@@ -77,12 +55,32 @@ class FlowTester:
     before the reload.
     """
 
-    def __init__(self, reload_method):
-        from flow_module import flow
-
-        self.flow = flow
+    def __init__(self, reload_method_name, tmp_path, write_module):
+        self.flow = None
         self.expected_results_by_flow = {}
-        self.reload_method = reload_method
+        self.reload_method_name = reload_method_name
+        self.cache_dir = str(tmp_path / "BNTESTDATA")
+        self.write_module = write_module
+
+    def write_flow_module(self, body):
+        header = f"""
+            import bionic as bn
+
+            builder = bn.FlowBuilder('flow')
+            builder.set('core__persistent_cache__flow_dir', '{self.cache_dir}')
+        """
+        footer = """
+            flow = builder.build()
+        """
+        self.write_module(
+            "flow_module",
+            dedent(header) + "\n" + dedent(body) + "\n" + dedent(footer),
+        )
+
+        if self.flow is None:
+            from flow_module import flow
+
+            self.flow = flow
 
     def expect_values(self, **kwargs):
         expected = dict(kwargs)
@@ -91,10 +89,7 @@ class FlowTester:
             self._verify_flow_contents(f, r)
 
     def reload_flow(self):
-        if self.reload_method == "reload":
-            self.flow.reload()
-        else:
-            self.flow = self.flow.reloading()
+        self.flow = getattr(self.flow, self.reload_method_name)()
 
     def get(self, name):
         return self.flow.get(name)
@@ -105,151 +100,183 @@ class FlowTester:
         assert {k: getattr(flow.get, k)() for k in results_map.keys()} == results_map
 
 
-def test_no_change(write_flow_module, reload_method):
-    write_flow_module(1)
-    tester = FlowTester(reload_method)
-    tester.expect_values(x=1, x_doubled=2)
-
-    tester.reload_flow()
-    tester.expect_values(x=1, x_doubled=2)
+@pytest.fixture
+def flow_tester(reload_method_name, tmp_path, write_module):
+    return FlowTester(reload_method_name, tmp_path, write_module)
 
 
-def test_change_entity_value(write_flow_module, reload_method):
-    write_flow_module(1)
-    tester = FlowTester(reload_method)
-    tester.expect_values(x=1, x_doubled=2)
+def test_no_change(flow_tester):
+    flow_tester.write_flow_module(
+        """
+            builder.assign('x', 1)
 
-    write_flow_module(2)
-    tester.reload_flow()
-    tester.expect_values(x=2, x_doubled=4)
+            @builder
+            def x_doubled(x):
+                return x * 2
+        """
+    )
+
+    flow_tester.expect_values(x=1, x_doubled=2)
+
+    flow_tester.reload_flow()
+    flow_tester.expect_values(x=1, x_doubled=2)
 
 
-def test_change_entity_name(write_module, reload_method):
+def test_change_assignment(flow_tester):
+    flow_tester.write_flow_module(
+        """
+            builder.assign('x', 1)
+
+            @builder
+            def x_doubled(x):
+                return x * 2
+        """
+    )
+    flow_tester.expect_values(x=1, x_doubled=2)
+
+    flow_tester.write_flow_module(
+        """
+            builder.assign('x', 2)
+
+            @builder
+            def x_doubled(x):
+                return x * 2
+        """
+    )
+    flow_tester.reload_flow()
+    flow_tester.expect_values(x=2, x_doubled=4)
+
+
+def test_change_entity_name(flow_tester):
     def write_flow_module(z: int):
-        write_module(
-            "flow_module",
+        flow_tester.write_flow_module(
             f"""
-                import bionic as bn
-
-                builder = bn.FlowBuilder('flow')
                 builder.assign('x', 1)
 
                 @builder
                 def x_plus_{z}(x):
                     return x + {z}
-
-                flow = builder.build()
             """,
         )
 
     write_flow_module(1)
-    tester = FlowTester(reload_method)
-    tester.expect_values(x=1, x_plus_1=2)
+    flow_tester.expect_values(x=1, x_plus_1=2)
 
     write_flow_module(2)
-    tester.reload_flow()
-    tester.expect_values(x=1, x_plus_2=3)
+    flow_tester.reload_flow()
+    flow_tester.expect_values(x=1, x_plus_2=3)
     with pytest.raises(UndefinedEntityError):
-        tester.get("x_plus_1")
+        flow_tester.get("x_plus_1")
 
 
-def test_change_version(write_module, reload_method):
+def test_change_version(flow_tester):
     def write_flow_module(x: int, y: int):
-        write_module(
-            "flow_module",
+        flow_tester.write_flow_module(
             f"""
-                import bionic as bn
-
-                builder = bn.FlowBuilder('flow')
-
                 @builder
                 @bn.version(major={x}, minor={y})
                 def total():
                     return {x} + {y}
-
-                flow = builder.build()
             """,
         )
 
     write_flow_module(10, 1)
-    tester = FlowTester(reload_method)
-    tester.expect_values(total=11)
+    flow_tester.expect_values(total=11)
 
     # Major version remains unchanged, cached value is returned
     write_flow_module(10, 2)
-    tester.reload_flow()
-    tester.expect_values(total=11)
+    flow_tester.reload_flow()
+    flow_tester.expect_values(total=11)
 
     # Major version changed, a new result is computed
     write_flow_module(20, 2)
-    tester.reload_flow()
-    tester.expect_values(total=22)
+    flow_tester.reload_flow()
+    flow_tester.expect_values(total=22)
 
 
-def test_assist_versioning_mode(write_module, reload_method):
+def test_assist_versioning_mode(flow_tester):
     def write_flow_module(x: int):
-        write_module(
-            "flow_module",
+        flow_tester.write_flow_module(
             f"""
-                import bionic as bn
-
-                builder = bn.FlowBuilder('flow')
                 builder.set('core__versioning_mode', 'assist')
+
+                @builder
+                def one():
+                    return 1
+
+                @builder
+                def x():
+                    return {x}
+            """,
+        )
+
+    write_flow_module(1)
+    flow_tester.expect_values(one=1, x=1)
+
+    write_flow_module(1)
+    flow_tester.reload_flow()
+    flow_tester.expect_values(one=1, x=1)
+
+    write_flow_module(2)
+    flow_tester.reload_flow()
+    flow_tester.expect_values(one=1)
+    with pytest.raises(CodeVersioningError):
+        flow_tester.get("x")
+
+
+def test_auto_versioning_mode(flow_tester):
+    def write_flow_module(x: int):
+        flow_tester.write_flow_module(
+            f"""
+                builder.set('core__versioning_mode', 'auto')
+
+                @builder
+                def one():
+                    return 1
 
                 @builder
                 def x():
                     return {x}
 
                 @builder
-                def one():
-                    return 1
-
-                flow = builder.build()
+                def x_doubled(x):
+                    return x * 2
             """,
         )
 
     write_flow_module(1)
-    tester = FlowTester(reload_method)
-    tester.expect_values(one=1, x=1)
-
-    write_flow_module(1)
-    tester.reload_flow()
-    tester.expect_values(one=1, x=1)
+    flow_tester.expect_values(one=1, x=1, x_doubled=2)
 
     write_flow_module(2)
-    tester.reload_flow()
-    tester.expect_values(one=1)
-    with pytest.raises(CodeVersioningError):
-        tester.get("x")
+    flow_tester.reload_flow()
+    flow_tester.expect_values(one=1, x=2, x_doubled=4)
+
+    write_flow_module(3)
+    flow_tester.reload_flow()
+    flow_tester.expect_values(one=1, x=3, x_doubled=6)
 
 
 # Test nondeterministic function marked with the changes_per_run decorator
-def test_changes_per_run_decorator(write_module, reload_method):
+def test_changes_per_run_decorator(flow_tester):
     def write_flow_module():
-        write_module(
-            "flow_module",
+        flow_tester.write_flow_module(
             """
-                import bionic as bn
                 from random import random
 
-                builder = bn.FlowBuilder('flow')
                 builder.assign('x', 1)
 
                 @builder
                 @bn.changes_per_run
                 def r():
                     return random()
-
-                flow = builder.build()
             """,
         )
 
     write_flow_module()
-    tester = FlowTester(reload_method)
-    tester.expect_values(x=1)
-    r = tester.get("r")
+    flow_tester.expect_values(x=1)
+    r = flow_tester.get("r")
 
     write_flow_module()
-    tester.reload_flow()
-    tester.expect_values(x=1)
-    assert tester.get("r") != r
+    flow_tester.reload_flow()
+    flow_tester.expect_values(x=1)
+    assert flow_tester.get("r") != r


### PR DESCRIPTION
test_reload.py to use temporary pytest directory, which are unique for each test run, for caching so that tests do not interfere with each other.