### PR TITLE
Avoid retaining tuple values

### DIFF
--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -294,7 +294,7 @@ class EntityDeriver:
                 name=dnode.to_descriptor(),
                 protocol=TupleProtocol(len(dnode.children)),
                 doc=f"A Python tuple with {len(dnode.children)} values.",
-                optional_should_memoize=True,
+                optional_should_memoize=False,
                 optional_should_persist=False,
             )
 


### PR DESCRIPTION
This adds special logic for discarding tuples values memoized at the
entry level as soon as we know we won't need them anymore. This unblocks
the activation of tuple descriptoprs by solving a problem with code
like this:

    @builder
    @bn.memoize(False)
    @bn.returns('a, b')
    def _(...):
        ...

While `a` and `b` will be correctly persisted and not memoized, the
tuple `a, b` will be memoized for the duration of the `get` call. If
`a` or `b` is large, this may be a problem for users. This problem does
not occur if we use `@bn.outputs` instead of `@bn.returns`, but once we
activate tuple descriptors internally they will both use the `returns`
under the hood, which would cause regression in behavior if this fix
weren't in place.