### PR TITLE
Add AIP based execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # An example docker image that can be used to test the AIP integration
-FROM python:3.7
+FROM python:3.8
 
 WORKDIR /code
 
@@ -15,4 +15,3 @@ RUN python setup.py egg_info && \
 COPY . ./
 
 RUN pip install -e .
-

--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -12,6 +12,7 @@ from .decorators import (  # noqa: F401
     changes_per_run,
     accepts,
     returns,
+    aip_task_config,
 )
 
 from . import protocol  # noqa: F401

--- a/bionic/aip/future.py
+++ b/bionic/aip/future.py
@@ -31,6 +31,14 @@ class State(Enum):
     def is_cancelled(self):
         return self in {State.CANCELLING, State.CANCELLED}
 
+    def is_finished(self):
+        return self in {
+            State.SUCCEEDED,
+            State.FAILED,
+            State.CANCELLING,
+            State.CANCELLED,
+        }
+
 
 class Future(_Future):
     """This future represents a job running on AI platform
@@ -77,7 +85,7 @@ class Future(_Future):
 
     def done(self):
         state, _ = self._get_state_and_error()
-        return state is State.SUCCEEDED or state.is_cancelled()
+        return state.is_finished()
 
     def result(self, timeout: int = None):
         # Scope the import to this function to avoid raising for anyone not using it.

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -299,3 +299,4 @@ class FunctionAttributes:
 
     code_fingerprint = attr.ib()
     changes_per_run = attr.ib()
+    aip_task_config = attr.ib()

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -10,6 +10,7 @@ These are the decorators we expose to Bionic users.  They are used as follows:
 
 """
 
+from .aip.task import TaskConfig as AipTaskConfig
 from .datatypes import CodeVersion
 from .decoration import decorator_updating_accumulator
 from .descriptors.parsing import dnode_from_descriptor, entity_dnode_from_descriptor
@@ -434,6 +435,41 @@ def returns(out_descriptor):
     out_dnode = dnode_from_descriptor(out_descriptor)
     return decorator_updating_accumulator(
         lambda acc: acc.wrap_provider(NewOutputDescriptorProvider, out_dnode)
+    )
+
+
+def aip_task_config(machine, worker_count=None, worker_machine=None):
+    """
+    Indicates that the decorated function should be computed in AIP.
+    This decorator requires AIP based distributed execution to be enabled, which
+    can be done by setting ``core__aip_execution__enabled`` core entity.
+
+    This decorator is currently experimental and does not have any additional
+    user-facing documentation. It may change in non-backwards-compatible ways.
+
+    Parameters
+    ----------
+    machine: String
+        The machine type that should be used to compute the function on AIP.
+    worker_count: String, optional
+        The number of workers that should be used to compute the function on AIP.
+    worker_machine: String, optional
+        The machine type that should be used by the worker nodes.
+
+    Returns
+    -------
+    Function:
+        A decorator which can be applied to an entity function.
+    """
+
+    config = AipTaskConfig(
+        machine=machine,
+        worker_count=worker_count,
+        worker_machine=worker_machine,
+    )
+
+    return decorator_updating_accumulator(
+        lambda acc: acc.wrap_provider(AttrUpdateProvider, "aip_task_config", config)
     )
 
 

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -196,7 +196,8 @@ class EntityDeriver:
             versioning_policy=self._bootstrap_singleton_entity(
                 "core__versioning_policy"
             ),
-            executor=self._bootstrap_singleton_entity("core__executor"),
+            aip_executor=self._bootstrap_singleton_entity("core__aip_executor"),
+            process_executor=self._bootstrap_singleton_entity("core__process_executor"),
             should_memoize_default=self._bootstrap_singleton_entity(
                 "core__memoize_by_default"
             ),
@@ -496,7 +497,8 @@ class Bootstrap:
 
     persistent_cache = attr.ib()
     versioning_policy = attr.ib()
-    executor = attr.ib()
+    aip_executor = attr.ib()
+    process_executor = attr.ib()
     should_memoize_default = attr.ib()
     should_persist_default = attr.ib()
 

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -43,11 +43,13 @@ class ProviderAttributes:
         code_version=None,
         orig_flow_name=None,
         changes_per_run=None,
+        aip_task_config=None,
     ):
         self.out_dnode = out_dnode
         self.code_version = code_version
         self.orig_flow_name = orig_flow_name
         self.changes_per_run = changes_per_run
+        self.aip_task_config = aip_task_config
 
 
 class BaseProvider:
@@ -64,6 +66,7 @@ class BaseProvider:
         return FunctionAttributes(
             code_fingerprint=self.get_code_fingerprint(case_key),
             changes_per_run=self.attrs.changes_per_run,
+            aip_task_config=self.attrs.aip_task_config,
         )
 
     def get_code_fingerprint(self, case_key):

--- a/bionic/utils/misc.py
+++ b/bionic/utils/misc.py
@@ -365,6 +365,21 @@ class SynchronizedSet:
         self.values = set()
         self.lock = threading.Lock()
 
+    def __getstate__(self):
+        # Copy the object's state from self.__dict__ which contains
+        # all our instance attributes. Always use the dict.copy()
+        # method to avoid modifying the original state.
+        state = self.__dict__.copy()
+        # Remove the unpicklable entries.
+        del state["lock"]
+        return state
+
+    def __setstate__(self, state):
+        # Restore instance attributes.
+        self.__dict__.update(state)
+        # Restore the lock.
+        self.lock = threading.Lock()
+
     def add(self, value):
         """
         Adds the value and returns True if the value isn't present in the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,9 @@ def pytest_addoption(parser):
         "--bucket", action="store", help="URL to GCS bucket to use for tests"
     )
     parser.addoption(
+        "--project", action="store", help="GCP project to use for AIP tests"
+    )
+    parser.addoption(
         "--parallel",
         action="store_true",
         default=False,
@@ -23,7 +26,9 @@ def pytest_configure(config):
     # These markers are added manually.
     add_mark("slow", "runs slowly")
     add_mark("needs_gcs", "requires GCS to run")
+    add_mark("needs_aip", "requires AIP execution to run")
     add_mark("needs_parallel", "requires parallel execution to run")
+    add_mark("no_parallel", "does not run with parallel execution")
     add_mark(
         "allows_parallel",
         "can run with parallel execution even when that's not explicitly enabled",
@@ -41,6 +46,11 @@ def pytest_collection_modifyitems(config, items):
     has_gcs = config.getoption("--bucket")
     skip_needs_gcs = pytest.mark.skip(reason="only runs when --bucket is set")
 
+    has_aip = config.getoption("--project") and has_gcs
+    skip_needs_aip = pytest.mark.skip(
+        reason="only runs when --bucket and --project are set"
+    )
+
     also_run_parallel = config.getoption("--parallel")
 
     items_to_keep = []
@@ -51,8 +61,13 @@ def pytest_collection_modifyitems(config, items):
         if "needs_gcs" in item.keywords and not has_gcs:
             item.add_marker(skip_needs_gcs)
 
+        if "needs_aip" in item.keywords and not has_aip:
+            item.add_marker(skip_needs_aip)
+
         if "parallel" in item.keywords:
-            if not (also_run_parallel or "allows_parallel" in item.keywords):
+            if "no_parallel" in item.keywords or not (
+                also_run_parallel or "allows_parallel" in item.keywords
+            ):
                 continue
         elif "needs_parallel" in item.keywords:
             continue

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -105,6 +105,21 @@ def gcs_builder(builder, tmp_gcs_url_prefix):
     return builder
 
 
+@pytest.fixture(scope="function")
+def aip_builder(gcs_builder, gcp_project):
+    gcs_builder.set("core__aip_execution__enabled", True)
+    gcs_builder.set("core__aip_execution__gcp_project", gcp_project)
+
+    return gcs_builder
+
+
+@pytest.fixture(scope="session")
+def gcp_project(request):
+    project = request.config.getoption("--project")
+    assert project is not None
+    return project
+
+
 @pytest.fixture(scope="session")
 def gcs_url_stem(request):
     url = request.config.getoption("--bucket")

--- a/tests/test_flow/test_persistence_aip.py
+++ b/tests/test_flow/test_persistence_aip.py
@@ -1,0 +1,32 @@
+import pytest
+
+import bionic as bn
+
+
+# This is detected by pytest and applied to all the tests in this module.
+pytestmark = [pytest.mark.needs_aip]
+
+
+@pytest.mark.no_parallel
+# TODO: Add a test that runs this test locally using a subprocess.
+def test_aip_jobs(aip_builder):
+    builder = aip_builder
+
+    builder.assign("x", 2)
+    builder.assign("y", 3)
+
+    @builder
+    @bn.aip_task_config("n1-standard-4")
+    def a(x, y):
+        return x * y
+
+    @builder
+    @bn.aip_task_config("n1-standard-8")
+    def b(x, y):
+        return x + y
+
+    @builder
+    def c(a, b):
+        return a - b  # 6 (2 * 3) - 5 (2 + 3)
+
+    assert builder.build().get("c") == 1


### PR DESCRIPTION
This change adds the capability in Bionic to use AIP based execution.
Unlike parallel execution, not all tasks are computed in parallel.
Instead, you specify which entities to compute on AIP using the
`@aip_process` decorator.

This change builds on top of #249 and uses the `aip` package from that
change. Since it is still a PoC, we haven't documented this behavior or
added it to the release notes.

I also ran the new test using AIP (instead of the test implementation)
and it worked!
<img width="1425" alt="Screen Shot 2020-09-10 at 4 31 31 PM" src="https://user-images.githubusercontent.com/2109428/92801010-398c9000-f383-11ea-909d-f1e8aecd6ade.png">

Note that stackdriver logging is not implemented yet. I'll add that in
a separate PR.