### PR TITLE
Support versioning modes in random tests

### DIFF
--- a/bionic/core/task_execution.py
+++ b/bionic/core/task_execution.py
@@ -729,7 +729,7 @@ class TaskState:
                         function's behavior has changed, or @version(minor=)
                         to indicate that it has *not* changed.
                         """
-                    raise CodeVersioningError(oneline(message))
+                    raise CodeVersioningError(oneline(message), new_prov.descriptor)
                 # If the provenances nominally match, they must have essentially the
                 # same structure.
                 assert len(old_prov.dep_digests) == len(new_prov.dep_digests)

--- a/bionic/exception.py
+++ b/bionic/exception.py
@@ -28,7 +28,9 @@ class UnsupportedSerializedValueError(Exception):
 
 
 class CodeVersioningError(Exception):
-    pass
+    def __init__(self, message, bad_descriptor):
+        super(CodeVersioningError, self).__init__(message)
+        self.bad_descriptor = bad_descriptor
 
 
 class EntitySerializationError(Exception):


### PR DESCRIPTION
This extends the new random test system to support the `assist` and
`auto` versioning modes, bringing us much closer to being able to get
rid of the old fuzz tests. (These new tests also would have caught the
failure of assisted versioning to work on non-persisted values,
presumably.)

This required the following supporting changes:
- CodeVersioningError now has a `bad_descriptor` field which identifies
the function that needs to be fixed.
- We now define each function in the flow under test by generating
Python code (`output_value_fragment`) instead of just calling out to a
separate function; this makes changes in the definition visible in the
Python bytecode.
- In the model flow, persisted values can be marked "stale", which will
cause them to trigger a CodeVersioningError.