### PR TITLE
Write AIP log entries to Stackdriver

### DIFF
--- a/bionic/aip/future.py
+++ b/bionic/aip/future.py
@@ -49,19 +49,17 @@ class Future(_Future):
 
     """
 
-    def __init__(self, project: str, job_id: str, output: str):
+    def __init__(self, project_name: str, job_id: str, output: str):
         # Scope the import to the class to avoid raising for anyone not using it.
-        discovery = import_optional_dependency(
-            "googleapiclient.discovery", raise_on_missing=True
-        )
-        self.project = project
+        discovery = import_optional_dependency("googleapiclient.discovery")
+        self.project_name = project_name
         self.job_id = job_id
         self.output = output
         self.aip = discovery.build("ml", "v1", cache_discovery=False)
 
     @property
     def name(self):
-        return f"projects/{self.project}/jobs/{self.job_id}"
+        return f"projects/{self.project_name}/jobs/{self.job_id}"
 
     def cancel(self):
         request = self.aip.projects().jobs().cancel(name=self.name)
@@ -89,7 +87,7 @@ class Future(_Future):
 
     def result(self, timeout: int = None):
         # Scope the import to this function to avoid raising for anyone not using it.
-        blocks = import_optional_dependency("blocks", raise_on_missing=True)
+        blocks = import_optional_dependency("blocks")
 
         # This will need an update to support other serializers.
         exc = self.exception(timeout)

--- a/bionic/aip/main.py
+++ b/bionic/aip/main.py
@@ -1,0 +1,78 @@
+"""
+This module is run as main in order to execute a task on a worker.
+"""
+
+import logging
+import os
+import sys
+
+from bionic.deps.optdep import import_optional_dependency
+
+
+def run():
+    # Scope the import to this function to avoid raising for anyone not using it.
+    blocks = import_optional_dependency("blocks")
+    cloudpickle = import_optional_dependency("cloudpickle")
+
+    ipath = sys.argv[-1]
+    fs = blocks.filesystem.GCSNativeFileSystem()
+    with fs.open(ipath, "rb") as f:
+        task = cloudpickle.load(f)
+
+    # Now that we have the task, set up logging.
+    _set_up_logging(task.job_id(), task.config.project_name)
+    logging.info(f"Read task from {ipath}")
+
+    result = task.function()
+
+    opath = task.output_uri()
+    logging.info(f"Uploading result to {opath}")
+    blocks.pickle(result, opath)
+    return
+
+
+def _set_up_logging(job_id, project_id):
+    # TODO This is the ID of the hyperparameter tuning trial currently
+    # running on this VM. This field is only set if the current
+    # training job is a hyperparameter tuning job. Conductor uses this
+    # environment variable but AIP documentation suggests us to use
+    # TF_CONFIG. Check whether we need to update this env variable.
+    # Find more details on TF_CONFIG at this link:
+    # https://cloud.google.com/ai-platform/training/docs/distributed-training-details
+    trial_id = os.environ.get("CLOUD_ML_TRIAL_ID", None)
+
+    glogging = import_optional_dependency("google.cloud.logging")
+
+    client = glogging.Client(project=project_id)
+    resource = glogging.resource.Resource(
+        type="ml_job",
+        # AIP expects a default task_name for the master cluster. We
+        # use a placeholder value till we start using clusters. Once we
+        # do, it should be configured based on the cluster.
+        labels=dict(job_id=job_id, project_id=project_id, task_name="master-replica-0"),
+    )
+    labels = None
+    if trial_id is not None:
+        # Enable grouping by trial when present.
+        labels = {"ml.googleapis.com/trial_id": trial_id}
+
+    # Enable only the cloud logger to avoid duplicate messages.
+    handler = glogging.handlers.handlers.CloudLoggingHandler(
+        client, resource=resource, labels=labels
+    )
+    root_logger = logging.getLogger()
+    # Remote the StreamHandler. Any logs logged by it shows up as error
+    # logs in Stackdriver.
+    root_logger.handlers = []
+    # We should ideally make this configurable, but till then, let's
+    # set the level to DEBUG to write all the logs. It's not hard to
+    # filter using log level on Stackdriver so it doesn't create too
+    # much noise anyway.
+    root_logger.setLevel(logging.DEBUG)
+    root_logger.addHandler(handler)
+    for logger_name in glogging.handlers.handlers.EXCLUDED_LOGGER_DEFAULTS:
+        logging.getLogger(logger_name).propagate = False
+
+
+if __name__ == "__main__":
+    run()

--- a/bionic/deps/extras.py
+++ b/bionic/deps/extras.py
@@ -32,7 +32,12 @@ extras["dask"] = ["dask[dataframe]"]
 extras["gcp"] = ["google-cloud-storage"]
 extras["parallel"] = ["cloudpickle", "loky"]
 extras["geopandas"] = ["geopandas"]
-extras["aip"] = ["google-api-python-client", "sq-blocks", "cloudpickle"]
+extras["aip"] = [
+    "google-api-python-client",
+    "google-cloud-logging",
+    "sq-blocks",
+    "cloudpickle",
+]
 
 extras["examples"] = combine(extras["standard"], ["scikit-learn"])
 extras["full"] = combine(*extras.values())

--- a/bionic/deps/optdep.py
+++ b/bionic/deps/optdep.py
@@ -29,6 +29,7 @@ def first_token_from_package_desc(desc):
 # aliases we use.
 alias_lists_by_package = {
     "google-cloud-storage": ["google.cloud.storage"],
+    "google-cloud-logging": ["google.cloud.logging"],
     "Pillow": ["PIL.Image"],
     "dask[dataframe]": ["dask.dataframe"],
     "google-api-python-client": ["googleapiclient.discovery"],

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1853,7 +1853,7 @@ def create_default_flow_state():
         return ProcessExecutor(core__parallel_execution__worker_count)
 
     builder.assign("core__aip_execution__enabled", False, persist=False)
-    builder.assign("core__aip_execution__gcp_project", None, persist=False)
+    builder.assign("core__aip_execution__gcp_project_name", None, persist=False)
     builder.assign(
         "core__aip_execution__docker_image_name", "bionic:latest", persist=False
     )
@@ -1861,11 +1861,11 @@ def create_default_flow_state():
     @builder
     @decorators.immediate
     def core__aip_execution__docker_image_uri(
-        core__aip_execution__gcp_project,
+        core__aip_execution__gcp_project_name,
         core__aip_execution__docker_image_name,
     ):
         image_name = core__aip_execution__docker_image_name
-        project = core__aip_execution__gcp_project
+        project = core__aip_execution__gcp_project_name
 
         if image_name is None or project is None:
             return None
@@ -1876,15 +1876,15 @@ def create_default_flow_state():
     @decorators.immediate
     def core__aip_execution__config(
         core__aip_execution__enabled,
-        core__aip_execution__gcp_project,
+        core__aip_execution__gcp_project_name,
         core__aip_execution__docker_image_uri,
         core__flow_name,
     ):
         if not core__aip_execution__enabled:
             return None
-        if core__aip_execution__gcp_project is None:
+        if core__aip_execution__gcp_project_name is None:
             error_message = """
-                core__aip_execution__gcp_project is None, but needs a
+                core__aip_execution__gcp_project_name is None, but needs a
                 value. AIP uses project to verify IAM permissions.
             """
             raise AssertionError(oneline(error_message))
@@ -1897,7 +1897,7 @@ def create_default_flow_state():
             raise AssertionError(oneline(error_message))
         return AipConfig(
             uuid=f"{core__flow_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
-            project=core__aip_execution__gcp_project,
+            project_name=core__aip_execution__gcp_project_name,
             image_uri=core__aip_execution__docker_image_uri,
         )
 

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -108,7 +108,7 @@ def gcs_builder(builder, tmp_gcs_url_prefix):
 @pytest.fixture(scope="function")
 def aip_builder(gcs_builder, gcp_project):
     gcs_builder.set("core__aip_execution__enabled", True)
-    gcs_builder.set("core__aip_execution__gcp_project", gcp_project)
+    gcs_builder.set("core__aip_execution__gcp_project_name", gcp_project)
 
     return gcs_builder
 


### PR DESCRIPTION
This change writes the log entries from the AIP execution to
Stackdriver. It uses the google-cloud-logging library to write those
logs, similar to how Conductor (a Square internal library) does it. The
only difference is that we don't use environment variables for the
`job_id` or the `project`.