### PR TITLE
Add fake AIP tests

### DIFF
--- a/bionic/aip/main.py
+++ b/bionic/aip/main.py
@@ -32,6 +32,9 @@ def run():
 
 
 def _set_up_logging(job_id, project_id):
+    if os.environ.get("BIONIC_NO_STACKDRIVER", False):
+        return
+
     # TODO This is the ID of the hyperparameter tuning trial currently
     # running on this VM. This field is only set if the current
     # training job is a hyperparameter tuning job. Conductor uses this

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,14 @@
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def set_env_variables(monkeypatch):
+    # We don't want to set up Stackdriver logging for local tests.
+    monkeypatch.setenv("BIONIC_NO_STACKDRIVER", "True")
+    yield
+    monkeypatch.delenv("BIONIC_NO_STACKDRIVER")
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--slow", action="store_true", default=False, help="run slow tests"

--- a/tests/test_flow/fakes.py
+++ b/tests/test_flow/fakes.py
@@ -1,0 +1,58 @@
+from functools import partial
+import logging
+from uuid import uuid4
+
+from bionic.aip.future import Future as AipFuture
+from bionic.aip.task import Task as AipTask
+
+
+class FakeAipFuture(AipFuture):
+    """
+    A mock implementation of Future that finished successfully.
+    """
+
+    def __init__(self, project_name: str, job_id: str, output: str):
+        self.project_name = project_name
+        self.job_id = job_id
+        self.output = output
+
+    def _get_state_and_error(self):
+        from bionic.aip.future import State
+
+        return State.SUCCEEDED, ""
+
+
+class FakeAipTask(AipTask):
+    """
+    A mock implementation of Task that runs the job locally using a
+    subprocess instead of running it on AIP.
+    """
+
+    def submit(self) -> AipFuture:
+        self._stage()
+        spec = self._ai_platform_job_spec()
+
+        logging.info(f"Submitting test {self.config.project_name}: {self}")
+        import subprocess
+
+        subprocess.check_call(spec["trainingInput"]["args"])
+        return FakeAipFuture(self.config.project_name, self.job_id(), self.output_uri())
+
+
+class FakeAipExecutor:
+    """
+    A mock version of AipExecutor to submit FakeTasks that uses
+    subprocess to execute the tasks instead of using AIP. Useful for
+    running tests locally without using AIP.
+    """
+
+    def __init__(self, aip_config):
+        self._aip_config = aip_config
+
+    def submit(self, task_config, fn, *args, **kwargs):
+        return FakeAipTask(
+            name="a" + str(uuid4()).replace("-", ""),
+            config=self._aip_config,
+            task_config=task_config,
+            function=partial(fn, *args, **kwargs),
+        ).submit()

--- a/tests/test_flow/test_persistence_aip.py
+++ b/tests/test_flow/test_persistence_aip.py
@@ -4,13 +4,36 @@ import bionic as bn
 
 
 # This is detected by pytest and applied to all the tests in this module.
-pytestmark = [pytest.mark.needs_aip]
+pytestmark = [pytest.mark.no_parallel]
 
 
-@pytest.mark.no_parallel
-# TODO: Add a test that runs this test locally using a subprocess.
+@pytest.mark.needs_aip
 def test_aip_jobs(aip_builder):
     builder = aip_builder
+
+    builder.assign("x", 2)
+    builder.assign("y", 3)
+
+    @builder
+    @bn.aip_task_config("n1-standard-4")
+    def a(x, y):
+        return x * y
+
+    @builder
+    @bn.aip_task_config("n1-standard-8")
+    def b(x, y):
+        return x + y
+
+    @builder
+    def c(a, b):
+        return a - b  # 6 (2 * 3) - 5 (2 + 3)
+
+    assert builder.build().get("c") == 1
+
+
+@pytest.mark.needs_gcs
+def test_fake_aip_jobs(fake_aip_builder):
+    builder = fake_aip_builder
 
     builder.assign("x", 2)
     builder.assign("y", 3)


### PR DESCRIPTION
This change adds a fake AIP test that executes AIP tasks using
subprocesses instead of dispatching them to AIP. Like the real AIP
tasks, the fake still uses GCS for caching and needs a bucket to run.