### PR TITLE
Compute cache flags before TaskState creation

### DIFF
--- a/bionic/core/flow_execution.py
+++ b/bionic/core/flow_execution.py
@@ -81,7 +81,6 @@ class TaskCompletionRunner:
                 self._bootstrap.process_executor.start_logging()
 
             for state in states:
-                state.set_up_caching_flags(self._bootstrap)
                 entry = self._get_or_create_entry_for_state(state)
                 self._add_requirement(
                     src_entry=None, dst_entry=entry, level=EntryLevel.CACHED

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -14,6 +14,24 @@ class EntityDefinition:
     to do with the entity's "contract": the assumptions other parts of the system can
     make about its value. However, this does *not* include the way the entity's value
     is determined; this is configured separately and can be changed more easily.
+
+    Attributes
+    ----------
+    name: string
+        The name of the entity.
+    protocol: Protocol
+        The protocol to use when serializing and deserializing entity values on disk.
+    doc: string
+        A human-readable description of the entity.
+    optional_should_memoize: boolean or None
+        Whether the entity should be memoized, or None if the global default should be
+        used.
+    optional_should_persist: boolean or None
+        Whether the entity should be persisted, or None if the global default should be
+        used
+    needs_caching: boolean
+        Indicates that some kind of caching needs to be enabled for this entity (either
+        persistence or memoization).
     """
 
     name = attr.ib()
@@ -22,6 +40,38 @@ class EntityDefinition:
     optional_should_memoize = attr.ib()
     optional_should_persist = attr.ib()
     needs_caching = attr.ib(default=False)
+
+
+@attr.s(frozen=True)
+class DescriptorMetadata:
+    """
+    Holds extra data we might need when working with a descriptor.
+
+    Similar to an EntityDefinition, but can apply to non-entity descriptors, and also
+    incorporates information from the global configuration. (For example,
+    EntityDefinition has an `optional_should_memoize` field which describes the
+    user's memoization preferences, if any; this class has a `should_memoize` field
+    which describes what we'll actually do, based on both user preferences and the
+    global configuration.)
+
+    Attributes
+    ----------
+    protocol: Protocol
+        The protocol to use when serializing and deserializing descriptor values on
+        disk.
+    doc: string
+        A human-readable description of the descriptor.
+    should_memoize: boolean
+        Whether the entity should be memoized.
+    should_persist: boolean
+        Whether the entity should be persisted.
+        used
+    """
+
+    protocol = attr.ib()
+    doc = attr.ib()
+    should_memoize = attr.ib(default=False)
+    should_persist = attr.ib(default=False)
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
This change computes the persistence and memoization flags *before*
creating the task graph rather than after. This will allow us to
have the task structure depend on these settings; in particular, I want
to have descriptors and tasks specifically for cached files, but that means I
need to know whether an entity is persisted before I create its tasks.

To do this, instead of fetching or generating an EntityDefinition for
each task, we instead create a DescriptorMetadata object that contains
the finalized caching flags. (This name also resolves the awkwardness of
having an EntityDefinition for things that aren't entities.)

I also switched the order of the `_prevalidate_base_dnodes` and
`_set_up_bootstrap` steps, because our metadata objects now depend
whether they're computed before or after the bootstrap; we need to make
sure to do the bootstrap setup before we construct all the other nodes.

There should be no functional changes.