### PR TITLE
Improve ergonomics of matching on DescriptorNodes

### DIFF
--- a/bionic/cache_api.py
+++ b/bionic/cache_api.py
@@ -102,7 +102,7 @@ class CacheEntry:
     @property
     def entity(self):
         try:
-            return entity_dnode_from_descriptor(self._descriptor).to_entity_name()
+            return entity_dnode_from_descriptor(self._descriptor).assume_entity().name
         except ValueError:
             return None
 

--- a/bionic/core/flow_execution.py
+++ b/bionic/core/flow_execution.py
@@ -15,7 +15,6 @@ from .task_execution import (
     RemoteSubgraph,
     TaskRunnerEntry,
 )
-from ..descriptors import ast
 from ..utils.keyed_priority_stack import KeyedPriorityStack
 from ..utils.misc import SynchronizedSet
 
@@ -534,4 +533,4 @@ class TaskKeyLogger:
 
 
 def dnode_without_drafts(dnode):
-    return dnode.edit(lambda d: d.child if isinstance(d, ast.DraftNode) else d)
+    return dnode.edit(lambda d: d.child if d.is_draft() else d)

--- a/bionic/descriptors/parsing.py
+++ b/bionic/descriptors/parsing.py
@@ -60,7 +60,7 @@ def entity_dnode_from_descriptor(descriptor):
     """
 
     dnode = dnode_from_descriptor(descriptor)
-    if not isinstance(dnode, EntityNode):
+    if not dnode.is_entity():
         raise ValueError(f"Expected a valid entity name, but got {descriptor!r}")
     return dnode
 

--- a/bionic/flake8/check_dnode_match.py
+++ b/bionic/flake8/check_dnode_match.py
@@ -1,0 +1,219 @@
+"""
+This module contains a Flake8 plugin validating our use of `DescriptorNode.fail_match`.
+
+The goal is to check that we only call `fail_match` after exhaustively checking all
+cases, as in the following:
+
+    if dnode.is_entity():
+        ...
+
+    elif dnode.is_tuple():
+        ...
+
+    ...
+
+    else:
+        dnode.fail_match()
+
+The plugin requires this exact structure, although it doesn't care about what order the
+cases are handled in.
+
+The plugin's entry point is the Checker class; Flake8 loads this class based on the
+`flake8:local-plugins` config in `setup.cfg`, and then instantiates it with a parsed
+syntax tree for each file in our project.
+
+"""
+
+import ast
+from enum import Enum
+
+import attr
+
+from ..descriptors.ast import NodeTypeEnum
+from ..utils.misc import oneline
+
+
+EXPECTED_TESTED_METHOD_NAMES = {f"is_{type_enum.value}" for type_enum in NodeTypeEnum}
+N_EXPECTED_METHODS = len(EXPECTED_TESTED_METHOD_NAMES)
+
+
+class AstExpectationError(Exception):
+    pass
+
+
+class ErrorCode(Enum):
+    COMPLEX_CALL = "DNM100"
+    TOO_FEW_IFS = "DNM101"
+    COMPLEX_TEST = "DNM102"
+    MISSING_METHOD = "DNM103"
+
+
+@attr.s
+class Problem:
+    node = attr.ib()
+    error_code = attr.ib()
+    message = attr.ib()
+
+    def to_flake8_tuple(self):
+        return (
+            self.node.lineno,
+            self.node.col_offset,
+            f"{self.error_code.value} {self.message}",
+            None,
+        )
+
+
+class NodeCursor:
+    """
+    A wrapper for a Python AST node.
+
+    Allows you to walk up and down the AST while asserting what type of node you expect
+    at each step.
+    """
+
+    def __init__(self, node, parent):
+        self.node = node
+        self.parent = parent
+
+    def expect_parent(self, cls):
+        self._check(self.parent.node, cls)
+        return self.parent
+
+    def expect_field(self, name, cls):
+        value = getattr(self.node, name)
+        self._check(value, cls)
+        return NodeCursor(value, self)
+
+    def _check(self, value, cls):
+        if not isinstance(value, cls):
+            raise AstExpectationError()
+
+
+class MatchVisitor(ast.NodeVisitor):
+    """
+    Walks a Python AST and records any problems.
+
+    The superclass, ``ast.NodeVisitor``, recursively walks the AST; we just override two
+    methods:
+    - ``visit``, to keep our ``NodeCursor`` up to date,
+    - ``visit_Attribute``, to check for Attribute nodes corresponding to method calls
+    """
+
+    def __init__(self):
+        super(MatchVisitor, self).__init__()
+        self._cursor = None
+        self.problems = []
+
+    def visit(self, node):
+        self._cursor = NodeCursor(node, self._cursor)
+        super(MatchVisitor, self).visit(node)
+        self._cursor = self._cursor.parent
+
+    def visit_Attribute(self, node):
+        if node.attr == "fail_match":
+            self._check_fail_match_attribute_node(node)
+        self.generic_visit(node)
+
+    def _check_fail_match_attribute_node(self, node):
+        """
+        Checks the surrounding structure of an attribute node to make sure it looks
+        something like this:
+
+            # `If` node
+            - test: # `Call` node
+                func: # `Attribute` node
+                  attr: "is_entity"
+
+              orelse: # list of nodes
+                # `If` node
+                - test: # `Call` node
+                    func: # `Attribute` node
+                      attr: "is_tuple"
+
+                  orelse: # list of nodes
+
+                    ... # ... chain of If nodes ...
+
+                      orelse: # list of nodes
+                        # `Expr` node
+                        - value: # `Call` node
+                            func: # `Attribute` node
+                              attr: "fail_match"
+
+        Note that we start at the innermost `attr: "fail_match"` node and walk upwards
+        to check the surrounding code.
+        """
+
+        try:
+            cursor = self._cursor.expect_parent(ast.Call).expect_parent(ast.Expr)
+        except AstExpectationError:
+            self._log_problem(
+                ErrorCode.COMPLEX_CALL,
+                "`fail_match` should only appear in simple method call",
+            )
+            return
+
+        tested_method_names = set()
+        while True:
+            # We'll keep walking up the tree until we hit something other than an if
+            # statement.
+            try:
+                cursor = cursor.expect_parent(ast.If)
+            except AstExpectationError:
+                break
+
+            # If we do have an if statement, let's make sure it's a simple method call.
+            try:
+                method_name = (
+                    cursor.expect_field("test", ast.Call)
+                    .expect_field("func", ast.Attribute)
+                    .node.attr
+                )
+            except AstExpectationError:
+                message = f"""
+                expected `fail_match` after {N_EXPECTED_METHODS} simple if statements,
+                but line {cursor.node.lineno} is not a simple test
+                """
+                self._log_problem(ErrorCode.COMPLEX_TEST, oneline(message))
+                return
+
+            tested_method_names.add(method_name)
+
+        for missing_method_name in EXPECTED_TESTED_METHOD_NAMES.difference(
+            tested_method_names
+        ):
+            message = f"""
+            expected `fail_match` only after exhaustive tests, but case
+            {missing_method_name} was not tested
+            """
+            self._log_problem(ErrorCode.MISSING_METHOD, oneline(message))
+
+    def _log_problem(self, error_code, message):
+        self.problems.append(Problem(self._cursor.node, error_code, message))
+
+
+class Checker:
+    name = "flake8-bionic-dnode-match"
+    version = "0.1"
+
+    def __init__(self, tree):
+        self._tree = tree
+
+    def run(self):
+        visitor = MatchVisitor()
+        visitor.visit(self._tree)
+        for problem in visitor.problems:
+            yield problem.to_flake8_tuple()
+
+
+if __name__ == "__main__":
+    import sys
+    from pathlib import Path
+
+    filenames = sys.argv[1:]
+
+    for filename in filenames:
+        code = Path(filename).read_text()
+        tree = ast.parse(code)
+        for message in Checker(tree).run():
+            print(message)  # noqa: T001

--- a/bionic/provider.py
+++ b/bionic/provider.py
@@ -125,9 +125,9 @@ class ValueProvider(BaseProvider):
             assert not provider._has_any_values
 
             dnode = provider.attrs.out_dnode
-            assert isinstance(dnode, ast.DraftNode)
-            assert isinstance(dnode.child, ast.EntityNode)
-            names.append(dnode.child.to_entity_name())
+            assert dnode.is_draft()
+            assert dnode.child.is_entity()
+            names.append(dnode.child.assume_entity().name)
 
         return ValueProvider(names)
 
@@ -942,7 +942,7 @@ class TupleConstructionProvider(BaseDerivedProvider):
     """
 
     def __init__(self, out_dnode):
-        assert isinstance(out_dnode, ast.TupleNode)
+        assert out_dnode.is_tuple()
 
         super(TupleConstructionProvider, self).__init__(
             out_dnode=out_dnode,
@@ -963,7 +963,7 @@ class TupleDeconstructionProvider(BaseDerivedProvider):
     """
 
     def __init__(self, out_dnode, dep_dnode):
-        assert isinstance(dep_dnode, ast.TupleNode)
+        assert dep_dnode.is_tuple()
         assert out_dnode in dep_dnode.children
 
         super(TupleDeconstructionProvider, self).__init__(

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,5 +16,12 @@ per-file-ignores =
     # Allow print statements in example code.
     example/*:T001
 
+# NOTE On my MacBook this plugin adds about 1 extra second to Flake8's runtime, making
+# it about 5s total. That's not trivial, so it might not be worth it to have this
+# enabled all the time.
+[flake8:local-plugins]
+extension =
+  DNM1 = bionic.flake8.check_dnode_match:Checker
+
 [tool:pytest]
 filterwarnings=ignore::DeprecationWarning

--- a/tests/test_flow/test_persistence_random.py
+++ b/tests/test_flow/test_persistence_random.py
@@ -6,7 +6,6 @@ import attr
 import numpy as np
 import re
 
-from bionic.descriptors import ast
 from bionic.descriptors.parsing import dnode_from_descriptor
 from bionic.exception import CodeVersioningError
 from bionic.utils.misc import single_element, single_unique_element
@@ -340,14 +339,14 @@ class ModelBinding:
         if out_dnode is None:
             out_dnode = self.out_dnode
 
-        if isinstance(out_dnode, ast.EntityNode):
-            entity_name = out_dnode.to_entity_name()
+        if out_dnode.is_entity():
+            entity_name = out_dnode.assume_entity().name
             entity = single_element(
                 entity for entity in self.out_entities if entity.name == entity_name
             )
             return entity.value_code_fragment()
 
-        elif isinstance(out_dnode, ast.TupleNode):
+        elif out_dnode.is_tuple():
             return " ".join(
                 f"({self.value_code_fragment_for_returns(child_dnode)}),"
                 for child_dnode in out_dnode.children


### PR DESCRIPTION
There are two commits here:

1. Add convenience methods to `DescriptorNode` to make it easier to write code that depends on what subtype you're dealing with. Basically I want to remove all the `isinstance` checks we have now.

2. Add a `flake8` plugin to catch situations where you're trying to exhaustively check all subtypes, but you miss one.