### PR TITLE
Shard tests

### DIFF
--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -18,6 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
+        include:
+          - python-version: 3.6
+            shard-id: 0
+          - python-version: 3.7
+            shard-id: 1
+          - python-version: 3.8
+            shard-id: 2
+
 
     steps:
     - uses: actions/checkout@v2
@@ -37,6 +45,13 @@ jobs:
       run: |
         flake8
         black --check .
-    - name: Test with pytest
+    - name: Run baseline tests
       run: |
-        pytest --parallel --slow
+        pytest
+    - name: Run extra tests (sharded)
+      # Running each test on each Python version is expensive, so we compromise: we run
+      # the baseline tests above on each version, since they're fast and hopefully
+      # comprehensive enough to shake out any version-specific bugs; and we run each of
+      # the other tests on just one Python version, reducing the total build time.
+      run: |
+        pytest --parallel --slow -m 'not baseline' --num-shards 3 --shard-id ${{matrix.shard-id}}

--- a/bionic/deps/extras.py
+++ b/bionic/deps/extras.py
@@ -45,6 +45,7 @@ extras["full"] = combine(*extras.values())
 extras["dev"] = combine(
     [
         "pytest",
+        "pytest-shard",
         "black",
         "flake8",
         "flake8-print",


### PR DESCRIPTION
I've separated our tests into "baseline" (the ones that run by default) and "non-baseline" (the ones activated by command line args), and I've sharded the non-baseline tests so that each one only runs on one Python version. This reduces the total latency of our CI by about 15 minutes.

More details in commit messages.