### PR TITLE
Remove Query class

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -130,41 +130,20 @@ class Task:
 
 
 @attr.s(frozen=True)
-class Query:
-    """
-    Represents a request for a specific entity value.
-    """
-
-    task_key = attr.ib()
-    protocol = attr.ib()
-    provenance = attr.ib()
-
-    @property
-    def dnode(self):
-        return self.task_key.dnode
-
-    @property
-    def case_key(self):
-        return self.task_key.case_key
-
-    def __repr__(self):
-        return f"Query({self.task_key}, {self.provenance!r})"
-
-
-@attr.s(frozen=True)
 class Result:
     """
     Represents one value for one entity.
     """
 
-    query = attr.ib()
+    task_key = attr.ib()
+    provenance = attr.ib()
     value = attr.ib()
     file_path = attr.ib(default=None)
     value_hash = attr.ib(default=None)
     value_is_missing = attr.ib(default=False)
 
     def __repr__(self):
-        return f"Result({self.query!r}, {self.value!r})"
+        return f"Result({self.task_key!r}, {self.value!r})"
 
 
 class CaseKeySpace(ImmutableSequence):

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -657,7 +657,7 @@ class EntityDeriver:
                     f"""
                 Bootstrap entity {entity_name!r} could not be computed because
                 the following entities are declared but not set:
-                {", ".join(result.query.case_key.missing_names)}
+                {", ".join(result.task_key.case_key.missing_names)}
                 """
                 )
             )

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1245,7 +1245,7 @@ class Flow:
                 # missing values.
                 assert len(orig_result_group) > 0
                 missing_result = orig_result_group[0]
-                missing_names = missing_result.query.case_key.missing_names
+                missing_names = missing_result.task_key.case_key.missing_names
                 message = f"""
                 Entity {name} could not be computed because the following entities are
                 declared but have no values set:
@@ -1272,12 +1272,12 @@ class Flow:
                         ancestor_name
                     ] = ancestor_result_group.key_space
                     for ancestor_result in ancestor_result_group:
-                        ancestor_case_key = ancestor_result.query.case_key
+                        ancestor_case_key = ancestor_result.task_key.case_key
                         ancestor_values_by_case_key_by_name[ancestor_name][
                             ancestor_case_key
                         ] = ancestor_result.value
 
-                orig_case_keys = [result.query.case_key for result in result_group]
+                orig_case_keys = [result.task_key.case_key for result in result_group]
                 index = pd.MultiIndex.from_tuples(
                     tuples=[
                         tuple(


### PR DESCRIPTION
I've removed the Query class: everything that was previously using the
class now uses just the subset of components (TaskKey, Provenance,
Protocol) that it needs. In many cases, just the Provenance is
sufficient.

The primary motivation here is that I want to pull the logic for
serializing/deserializing values to/from disk out of the PersistentCache
class in order to have separate file descriptor nodes, at which point
the cache won't care about protocols and it won't make sense for them to
be part of its API. More generally, it was always a little weird for to
be passing a protocol around as part of a query, since it's only needed
in one place.

A secondary advantage is that this frees up the term "query" to be used
for something else -- maybe we can use "query" to describe one call to
`flow.get`? (As in, "this value is cached for the duration of the
query".)