### PR TITLE
Use system language for flake8 pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,15 @@ repos:
     rev: 3.8.3
     hooks:
     -   id: flake8
+        # Pre-commit does some static analysis by caching packages (can
+        # be found in ~/.cache/pre-commit/). When used in a virtualenv
+        # (like pyenv), flake8 does not work correctly withthe default
+        # language and the custom dnode match linter breaks.
+        # To get around this, pre-commit devs recommend to use it as a
+        # "system" hook (default is "local"). See
+        # https://github.com/pre-commit/pre-commit-hooks/issues/157
+        # for more information on this issue.
+        language: system
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0


### PR DESCRIPTION
Looks like pre-commit does some static analysis by caching package (which shows
up in ~/.cache/pre-commit for me). This breaks with flake8 for the new
custom linter. It seems like pylint has the same problem with missing
modules as I have with flake8, with the missing modules due to different
virtualenvs. One of the recommended options from pre-commit devs (found
in [this issue](https://github.com/pre-commit/pre-commit-hooks/issues/157)) is to use system language in the hooks to get around this
problem. You can find the documentation for system language [here](https://pre-commit.com/#system).