### PR TITLE
Bump version: 0.8.3 → 0.8.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.3
+current_version = 0.8.4
 commit = True
 tag = False
 

--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -18,4 +18,4 @@ from .decorators import (  # noqa: F401
 from . import protocol  # noqa: F401
 from . import util  # noqa: F401
 
-__version__ = u"0.8.3"
+__version__ = u"0.8.4"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = u"2019, Square"
 author = u"Janek Klawe"
 
 # The short X.Y version
-version = u"0.8.3"
+version = u"0.8.4"
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -65,14 +65,17 @@ For each release, we list the following types of change (in this order):
 - **Development Changes**: Significant changes to Bionic's development process, such
   as changes to our Pytest configuration or our Continuous Integration ("CI").
 
-Upcoming Version (Not Yet Released)
------------------------------------
+.. Upcoming Version (Not Yet Released)
+.. -----------------------------------
 
 .. Record any notable changes in this section. When we update the current version,
    add a new version heading below, and then comment out the heading above until more
    changes are added. This way, the "Upcoming Version" section will be never be visible
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
+
+0.8.4 (Oct 8, 2020)
+--------------------
 
 New Features
 ............

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
 
 setup(
     name="bionic",
-    version="0.8.3",
+    version="0.8.4",
     description=(
         "A Python framework for building, running, and sharing data science "
         "workflows"


### PR DESCRIPTION
Screenshot of new release notes (everything looks correct)

<img width="761" alt="Screen Shot 2020-10-08 at 2 23 00 PM" src="https://user-images.githubusercontent.com/2109428/95498475-db4ad100-0971-11eb-801e-f9f1f92434e3.png">
