### PR TITLE
Replace gsutil and sq-blocks with fsspec

### DIFF
--- a/bionic/aip/task.py
+++ b/bionic/aip/task.py
@@ -6,8 +6,9 @@ import attr
 from typing import Callable, Optional
 
 from bionic.aip.client import get_aip_client
-from bionic.deps.optdep import import_optional_dependency
 from bionic.aip.future import Future
+from bionic.deps.optdep import import_optional_dependency
+from bionic.gcs import get_gcs_fs_without_warnings
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -100,13 +101,13 @@ class Task:
         return output
 
     def _stage(self):
-        # Scope the blocks import to this function to avoid raising for anyone not using it.
-        blocks = import_optional_dependency("blocks")
         cloudpickle = import_optional_dependency("cloudpickle")
 
         path = self.inputs_uri()
         logging.info(f"Staging task {self.name} at {path}")
-        with blocks.filesystem.GCSNativeFileSystem().open(path, "wb") as f:
+
+        gcs_fs = get_gcs_fs_without_warnings()
+        with gcs_fs.open(path, "wb") as f:
             cloudpickle.dump(self, f)
 
     def submit(self) -> Future:

--- a/bionic/deps/extras.py
+++ b/bionic/deps/extras.py
@@ -29,15 +29,17 @@ extras["standard"] = combine(extras["matplotlib"], extras["viz"])
 
 extras["dill"] = ["dill"]
 extras["dask"] = ["dask[dataframe]"]
-extras["gcp"] = ["google-cloud-storage", "fsspec", "gcsfs"]
+extras["gcp"] = ["fsspec", "gcsfs"]
 extras["parallel"] = ["cloudpickle", "loky"]
 extras["geopandas"] = ["geopandas"]
-extras["aip"] = [
-    "google-api-python-client",
-    "google-cloud-logging",
-    "sq-blocks",
-    "cloudpickle",
-]
+extras["aip"] = combine(
+    [
+        "google-api-python-client",
+        "google-cloud-logging",
+        "cloudpickle",
+    ],
+    extras["gcp"],
+)
 
 extras["examples"] = combine(extras["standard"], ["scikit-learn"])
 extras["full"] = combine(*extras.values())

--- a/bionic/deps/extras.py
+++ b/bionic/deps/extras.py
@@ -29,7 +29,7 @@ extras["standard"] = combine(extras["matplotlib"], extras["viz"])
 
 extras["dill"] = ["dill"]
 extras["dask"] = ["dask[dataframe]"]
-extras["gcp"] = ["google-cloud-storage"]
+extras["gcp"] = ["google-cloud-storage", "fsspec", "gcsfs"]
 extras["parallel"] = ["cloudpickle", "loky"]
 extras["geopandas"] = ["geopandas"]
 extras["aip"] = [

--- a/bionic/deps/optdep.py
+++ b/bionic/deps/optdep.py
@@ -28,12 +28,10 @@ def first_token_from_package_desc(desc):
 # For packages that we don't import by the exact package name, these are
 # aliases we use.
 alias_lists_by_package = {
-    "google-cloud-storage": ["google.cloud.storage"],
     "google-cloud-logging": ["google.cloud.logging"],
     "Pillow": ["PIL.Image"],
     "dask[dataframe]": ["dask.dataframe"],
     "google-api-python-client": ["googleapiclient.discovery"],
-    "sq-blocks": ["blocks"],
 }
 
 # Now we contruct a new data structure to allow us to give helpful error

--- a/bionic/filecopier.py
+++ b/bionic/filecopier.py
@@ -5,7 +5,7 @@ Contains the ``FileCopier`` class, which is essentially a file path with a usefu
 
 import subprocess
 
-from bionic.gcs import gsutil_cp
+from bionic.gcs import upload_to_gcs
 
 
 class FileCopier:
@@ -27,8 +27,7 @@ class FileCopier:
         Copies file that FileCopier represents to `destination`
 
         This supports both local and GCS destinations. For the former, we follow cp's
-        conventions and for the latter we follow gsutil cp's conventions. For
-        example, trying to copy a file locally to a non-existent directory will fail.
+        conventions and for the latter we follow fsspec put's conventions.
 
         Parameters
         ----------
@@ -39,7 +38,7 @@ class FileCopier:
 
         #  handle gcs
         if str(destination).startswith("gs://"):
-            gsutil_cp(str(self.src_file_path), str(destination))
+            upload_to_gcs(self.src_file_path, str(destination))
         else:
             subprocess.check_call(
                 ["cp", "-R", str(self.src_file_path), str(destination)]

--- a/bionic/filecopier.py
+++ b/bionic/filecopier.py
@@ -27,7 +27,9 @@ class FileCopier:
         Copies file that FileCopier represents to `destination`
 
         This supports both local and GCS destinations. For the former, we follow cp's
-        conventions and for the latter we follow fsspec put's conventions.
+        conventions and for the latter we follow fsspec's put / put_file APIs which
+        can be found at
+        https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.
 
         Parameters
         ----------

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -42,7 +42,7 @@ from .deriver import EntityDeriver, entity_is_internal
 from .descriptors.parsing import entity_dnode_from_descriptor
 from . import decorators, decoration
 from .filecopier import FileCopier
-from .gcs import copy_to_gcs
+from .gcs import upload_to_gcs
 from .utils.misc import (
     group_pairs,
     check_exactly_one_present,
@@ -1374,7 +1374,7 @@ class Flow:
 
         if dst_file_path_str.startswith("gs:/"):
             # The path object combines // into /, so we revert it here
-            copy_to_gcs(str(src_file_path), dst_file_path_str.replace("gs:/", "gs://"))
+            upload_to_gcs(src_file_path, dst_file_path_str.replace("gs:/", "gs://"))
         else:
             shutil.copyfile(str(src_file_path), dst_file_path_str)
 

--- a/bionic/gcs.py
+++ b/bionic/gcs.py
@@ -14,7 +14,7 @@ _cached_gcs_fs = None
 
 
 def get_gcs_fs_without_warnings(cache_value=True):
-    # TODO It's not expensive to create gcs filesystem, but caching this enables
+    # TODO It's not expensive to create the gcs filesystem, but caching this enables
     # us to mock the cached gcs_fs with a mock implementation in tests. We should
     # change the tests to inject the filesystem in a different way and get rid of
     # this caching.

--- a/bionic/gcs.py
+++ b/bionic/gcs.py
@@ -6,7 +6,6 @@ import subprocess
 import warnings
 
 from .deps.optdep import import_optional_dependency
-from .utils.urls import bucket_and_object_names_from_gs_url
 
 import logging
 
@@ -81,66 +80,6 @@ def copy_to_gcs(src, dst):
     client = get_gcs_client_without_warnings()
     blob = client.get_bucket(bucket).blob(path)
     blob.upload_from_filename(src)
-
-
-class GcsTool:
-    """
-    A helper object providing utility methods for accessing GCS.  Maintains
-    a GCS client, and a prefix defining a default namespace to read/write on.
-    """
-
-    _GS_URL_PREFIX = "gs://"
-
-    def __init__(self, url):
-        if url.endswith("/"):
-            url = url[:-1]
-        self.url = url
-        bucket_name, object_prefix = bucket_and_object_names_from_gs_url(url)
-
-        self._bucket_name = bucket_name
-        self._object_prefix = object_prefix
-        self._init_client()
-
-    def __getstate__(self):
-        # Copy the object's state from self.__dict__ which contains
-        # all our instance attributes. Always use the dict.copy()
-        # method to avoid modifying the original state.
-        state = self.__dict__.copy()
-        # Remove the unpicklable entries.
-        del state["_client"]
-        del state["_bucket"]
-        return state
-
-    def __setstate__(self, state):
-        # Restore instance attributes.
-        self.__dict__.update(state)
-        # Restore the client and bucket.
-        self._init_client()
-
-    def _init_client(self):
-        self._client = get_gcs_client_without_warnings()
-        self._bucket = self._client.get_bucket(self._bucket_name)
-
-    def blob_from_url(self, url):
-        object_name = self._validated_object_name_from_url(url)
-        return self._bucket.blob(object_name)
-
-    def url_from_object_name(self, object_name):
-        return self._GS_URL_PREFIX + self._bucket.name + "/" + object_name
-
-    def blobs_matching_url_prefix(self, url_prefix):
-        obj_prefix = self._validated_object_name_from_url(url_prefix)
-        return self._bucket.list_blobs(prefix=obj_prefix)
-
-    @staticmethod
-    def gsutil_cp(src_url, dst_url):
-        gsutil_cp(src_url, dst_url)
-
-    def _validated_object_name_from_url(self, url):
-        bucket_name, object_name = bucket_and_object_names_from_gs_url(url)
-        assert bucket_name == self._bucket.name
-        assert object_name.startswith(self._object_prefix)
-        return object_name
 
 
 def gsutil_cp(src_url, dst_url):

--- a/bionic/persistence.py
+++ b/bionic/persistence.py
@@ -864,7 +864,7 @@ class GcsFilesystem:
     """
     Wrapper around fsspec's GCS "FileSystem" that validates the bucket
     and object_prefix. It also exposes extra APIs, namely, search,
-    write_bytes, and read_bytes for conveniece and consistency with
+    write_bytes, and read_bytes for convenience and consistency with
     LocalFilesystem.
     """
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -562,6 +562,8 @@ Bionic will load data from the GCS cache whenever it's not in the local cache,
 and will write back to both caches.  Note that the upload time will make each
 entity computation a bit slower.
 
+.. TODO: Does fsspec require gsutil?
+
 In order to use GCS caching, you must have the `gsutil`_ tool installed, and
 you must have GCP credentials configured.  You should also use ``pip install
 'bionic[gcp]'`` to install the required Python libraries.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -562,13 +562,11 @@ Bionic will load data from the GCS cache whenever it's not in the local cache,
 and will write back to both caches.  Note that the upload time will make each
 entity computation a bit slower.
 
-.. TODO: Does fsspec require gsutil?
-
-In order to use GCS caching, you must have the `gsutil`_ tool installed, and
+In order to use GCS caching, you must have the `gcloud`_ cli tool installed, and
 you must have GCP credentials configured.  You should also use ``pip install
 'bionic[gcp]'`` to install the required Python libraries.
 
-.. _gsutil: https://cloud.google.com/storage/docs/gsutil
+.. _gcloud: https://cloud.google.com/sdk/gcloud
 
 .. _protocols :
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -65,14 +65,20 @@ For each release, we list the following types of change (in this order):
 - **Development Changes**: Significant changes to Bionic's development process, such
   as changes to our Pytest configuration or our Continuous Integration ("CI").
 
-.. Upcoming Version (Not Yet Released)
-.. -----------------------------------
+Upcoming Version (Not Yet Released)
+-----------------------------------
 
 .. Record any notable changes in this section. When we update the current version,
    add a new version heading below, and then comment out the heading above until more
    changes are added. This way, the "Upcoming Version" section will be never be visible
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
+
+Improvements
+............
+
+- Bionic no longer requires `gsutil <https://cloud.google.com/storage/docs/gsutil>`_
+  for GCS caching, and as a result, GCS caching now works with Python 3.8.
 
 0.9.0 (Oct 8, 2020)
 --------------------

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 from textwrap import dedent
 import re
-import subprocess
 import shutil
 
 from decorator import decorate
@@ -9,6 +8,7 @@ import pandas as pd
 from pandas import testing as pdt
 
 import bionic as bn
+from bionic.gcs import get_gcs_fs_without_warnings
 
 
 # TODO This name is cumbersome; maybe one of these shorter names?
@@ -232,13 +232,23 @@ def longest_regex_prefix_match(regex, string, flags=0):
     return match
 
 
-def gsutil_wipe_path(url):
+def gcs_fs_wipe_path(url):
     assert "BNTESTDATA" in url
-    subprocess.check_call(["gsutil", "-q", "-m", "rm", "-rf", url])
+    fs = get_gcs_fs_without_warnings()
+    fs.rm(url, recursive=True)
 
 
-def gsutil_path_exists(url):
-    return subprocess.call(["gsutil", "ls", url]) == 0
+def gcs_fs_path_exists(url):
+    fs = get_gcs_fs_without_warnings()
+    return fs.exists(url)
+
+
+def gcs_fs_download(url, path):
+    fs = get_gcs_fs_without_warnings()
+    if fs.isdir(url):
+        fs.get(url, str(path), recursive=True)
+    else:
+        fs.get_file(url, str(path))
 
 
 def local_wipe_path(path_str):

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -9,8 +9,8 @@ from .fakes import run_in_fake_gcp, FakeGCS
 from ..helpers import (
     SimpleCounter,
     ResettingCallCounter,
-    gsutil_wipe_path,
-    gsutil_path_exists,
+    gcs_fs_wipe_path,
+    gcs_fs_path_exists,
 )
 
 
@@ -163,7 +163,7 @@ def gcs_wipe_path(use_fake_gcp, fake_gcs):
         if use_fake_gcp:
             fake_gcs.wipe_path(url)
         else:
-            gsutil_wipe_path(url)
+            gcs_fs_wipe_path(url)
 
     return _gcs_wipe_path
 
@@ -182,7 +182,7 @@ def session_tmp_gcs_url_prefix(gcs_url_stem, use_fake_gcp):
     # This emits a stderr warning because the URL doesn't exist.  That's
     # annoying but I wasn't able to find a straightforward way to avoid it.
     if not use_fake_gcp:
-        assert not gsutil_path_exists(gs_url)
+        assert not gcs_fs_path_exists(gs_url)
 
     yield gs_url
 
@@ -191,7 +191,7 @@ def session_tmp_gcs_url_prefix(gcs_url_stem, use_fake_gcp):
     # *and* doesn't clean all of them up. If this changes, we may need to start
     # handling this more gracefully.
     if not use_fake_gcp:
-        gsutil_wipe_path(gs_url)
+        gcs_fs_wipe_path(gs_url)
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -202,5 +202,6 @@ def tmp_gcs_url_prefix(session_tmp_gcs_url_prefix, request):
     # This is an open issue with gsutil but till it's fixed, we are going
     # to change the node name to not have any wildcard characters.
     # https://github.com/GoogleCloudPlatform/gsutil/issues/290
+    # gcsfs seems to have the same problem.
     node_name = request.node.name.replace("[", "_").replace("]", "")
     return session_tmp_gcs_url_prefix + node_name + "/"

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -5,7 +5,7 @@ from multiprocessing.managers import SyncManager
 import pytest
 
 import bionic as bn
-from .fakes import run_in_fake_gcp, FakeGCS
+from .fakes import run_in_fake_gcp, FakeGcsFs
 from ..helpers import (
     SimpleCounter,
     ResettingCallCounter,
@@ -15,8 +15,8 @@ from ..helpers import (
 
 
 @pytest.fixture
-def fake_gcs():
-    return FakeGCS()
+def fake_gcs_fs():
+    return FakeGcsFs()
 
 
 # Parameterizing a fixture adds the parameter in the test name at the end,
@@ -42,9 +42,9 @@ def parallel_execution_enabled(request):
         pytest.param("real-gcp", marks=pytest.mark.real_gcp),
     ],
 )
-def use_fake_gcp(request, fake_gcs):
+def use_fake_gcp(request, fake_gcs_fs):
     if request.param == "fake-gcp":
-        with run_in_fake_gcp(fake_gcs):
+        with run_in_fake_gcp(fake_gcs_fs):
             yield True
     else:
         yield False
@@ -151,21 +151,6 @@ def gcs_url_stem(request, use_fake_gcp):
     url = request.config.getoption("--bucket")
     assert url.startswith("gs://")
     return url
-
-
-@pytest.fixture
-def gcs_wipe_path(use_fake_gcp, fake_gcs):
-    """
-    Removes all files with the specified url.
-    """
-
-    def _gcs_wipe_path(url):
-        if use_fake_gcp:
-            fake_gcs.wipe_path(url)
-        else:
-            gcs_fs_wipe_path(url)
-
-    return _gcs_wipe_path
 
 
 @pytest.fixture

--- a/tests/test_flow/fakes.py
+++ b/tests/test_flow/fakes.py
@@ -1,12 +1,9 @@
-import io
-import logging
-import os
 from contextlib import contextmanager
 from functools import partial
-from glob import glob
+import io
+import logging
 from pathlib import Path
 from unittest.mock import Mock
-
 from uuid import uuid4
 
 from bionic import gcs
@@ -167,123 +164,6 @@ class FakeGcsFs:
                 del self._files_by_url[file_url]
         else:
             del self._files_by_url[url]
-
-
-class FakeBlob:
-    def __init__(self, bucket, name, blobs):
-        assert not name.startswith("/")
-        self.bucket = bucket
-        self.name = name
-        self.blobs = blobs
-
-    def upload_from_string(self, data):
-        self.blobs[self._url] = data
-
-    def download_as_string(self):
-        return self.blobs[self._url]
-
-    def upload_from_filename(self, filename):
-        self.upload_from_string(open(filename, "r").read())
-
-    def download_to_filename(self, filename):
-        open(filename, "w").write(self.download_as_string())
-
-    def exists(self):
-        return self._url in self.blobs
-
-    def delete(self):
-        del self.blobs[self._url]
-
-    @property
-    def _url(self):
-        return f"gs://{self.bucket}/{self.name}"
-
-
-class FakeBucket:
-    def __init__(self, name, blobs):
-        self.name = name
-        self.blobs = blobs
-
-    def blob(self, blob_name):
-        return FakeBlob(self.name, blob_name, self.blobs)
-
-    def get_blob(self, blob_name):
-        return self.blob(blob_name)
-
-    def list_blobs(self, prefix):
-        assert not prefix.startswith("gs://")
-        return [
-            FakeBlob(self.name, k.replace(f"gs://{self.name}/", "", 1), self.blobs)
-            for (k, v) in self.blobs.items()
-            if k.startswith(f"gs://{self.name}/{prefix}")
-        ]
-
-
-class FakeGCS:
-    def __init__(self):
-        self.blobs = {}
-
-    def get_bucket(self, bucket):
-        return FakeBucket(bucket, self.blobs)
-
-    def wipe_path(self, url):
-        urls_to_remove = [k for k in self.blobs.keys() if k.startswith(url)]
-        for k in urls_to_remove:
-            del self.blobs[k]
-
-    # Allows the blob to be used like a file object.
-    # Used for mocking out blocks.filesystem.GCSNativeFileSystem.
-    @contextmanager
-    def open_blob(self, path, mode):
-        f = io.BytesIO(self.blobs.get(path, b""))
-        yield f
-        self.blobs[path] = f.getvalue()
-
-    def block_pickle(self, result, path):
-        self.blobs[path] = result
-
-    def block_unpickle(self, path):
-        return self.blobs[path]
-
-    def gsutil_cp(self, src_url, dst_url):
-        """
-        Emulate gsutil with the cp command.
-        """
-        if src_url.startswith("gs://"):
-            assert dst_url.startswith("/")
-            if src_url in self.blobs:
-                assert not dst_url.endswith("/")
-                open(dst_url, "wb").write(self.blobs[src_url])
-            else:
-                # When copying from a bucket directory to a file path, the
-                # directory is copied over. For example, the following:
-                #
-                #   gsutil cp -r gs://my-bucket/data dir
-                #
-                # results in files with names like dir/data/a/b/c.
-
-                last_component = src_url.rsplit("/", 1)[1]
-                directory = Path(dst_url, last_component)
-                directory.mkdir(parents=True, exist_ok=True)
-                for url, data in self.blobs.items():
-                    if not url.startswith(src_url):
-                        continue
-                    filename = url.rsplit("/", 1)[1]
-                    open(Path(directory, filename), "wb").write(data)
-        else:
-            assert src_url.startswith("/")
-            assert dst_url.startswith("gs://")
-            if os.path.isfile(src_url):
-                data = open(src_url, "rb").read()
-                if dst_url.endswith("/"):
-                    filename = os.path.basename(src_url)
-                    self.blobs[f"{dst_url}{filename}"] = data
-                else:
-                    self.blobs[dst_url] = data
-            else:
-                for filename in glob(f"{src_url}/**"):
-                    data = open(filename, "rb").read()
-                    self.blobs[filename.replace(src_url, dst_url, 1)] = data
 
 
 @contextmanager

--- a/tests/test_flow/test_cache_api.py
+++ b/tests/test_flow/test_cache_api.py
@@ -4,12 +4,11 @@ import json
 
 import bionic as bn
 from bionic import interpret
-from bionic.gcs import get_gcs_client_without_warnings
+from bionic.gcs import get_gcs_fs_without_warnings
 from bionic.utils.urls import (
     path_from_url,
     is_file_url,
     is_gcs_url,
-    bucket_and_object_names_from_gs_url,
 )
 
 
@@ -89,11 +88,8 @@ def read_bytes_from_url(url):
         path = path_from_url(url)
         return path.read_bytes()
     elif is_gcs_url(url):
-        gcs_client = get_gcs_client_without_warnings()
-        bucket_name, object_name = bucket_and_object_names_from_gs_url(url)
-        bucket = gcs_client.get_bucket(bucket_name)
-        blob = bucket.get_blob(object_name)
-        return blob.download_as_string()
+        gcs_fs = get_gcs_fs_without_warnings()
+        return gcs_fs.cat_file(url)
     else:
         raise AssertionError(f"Unexpected scheme in URL: {url}")
 

--- a/tests/test_flow/test_copy.py
+++ b/tests/test_flow/test_copy.py
@@ -5,8 +5,7 @@ from pathlib import Path
 
 import dask.dataframe as dd
 
-from bionic.gcs import gsutil_cp
-from ..helpers import df_from_csv_str, equal_frame_and_index_content
+from ..helpers import df_from_csv_str, equal_frame_and_index_content, gcs_fs_download
 
 import bionic as bn
 
@@ -79,7 +78,7 @@ def test_copy_file_to_gcs_dir(flow, tmp_path, tmp_gcs_url_prefix):
     flow.get("f", mode="FileCopier").copy(destination=tmp_gcs_url_prefix)
     cloud_url = tmp_gcs_url_prefix + "f.json"
     local_path = tmp_path / "f.json"
-    gsutil_cp(cloud_url, local_path)
+    gcs_fs_download(cloud_url, local_path)
     assert json.loads(local_path.read_bytes()) == 5
 
 
@@ -88,7 +87,7 @@ def test_copy_file_to_gcs_file(flow, tmp_path, tmp_gcs_url_prefix):
     cloud_url = tmp_gcs_url_prefix + "f.json"
     flow.get("f", mode="FileCopier").copy(destination=cloud_url)
     local_path = tmp_path / "f.json"
-    gsutil_cp(cloud_url, local_path)
+    gcs_fs_download(cloud_url, local_path)
     assert json.loads(local_path.read_bytes()) == 5
 
 
@@ -108,11 +107,12 @@ def test_copy_dask_to_gcs_dir(
     tmp_path, tmp_gcs_url_prefix, expected_dask_df, dask_flow
 ):
     cloud_url = tmp_gcs_url_prefix + "output"
+    local_path = tmp_path / "output"
 
     dask_flow.get("dask_df", mode="FileCopier").copy(destination=cloud_url)
 
-    gsutil_cp(cloud_url, tmp_path)
-    actual = dd.read_parquet(tmp_path / "output")
+    gcs_fs_download(cloud_url, local_path)
+    actual = dd.read_parquet(local_path)
     assert equal_frame_and_index_content(actual.compute(), expected_dask_df.compute())
 
 

--- a/tests/test_flow/test_persistence_gcs.py
+++ b/tests/test_flow/test_persistence_gcs.py
@@ -18,6 +18,7 @@ from ..helpers import (
     df_from_csv_str,
     equal_frame_and_index_content,
     local_wipe_path,
+    gcs_fs_wipe_path,
 )
 from bionic.exception import CodeVersioningError
 
@@ -40,7 +41,7 @@ def preset_gcs_builder(gcs_builder):
     return builder
 
 
-def test_gcs_caching(preset_gcs_builder, make_counter, gcs_wipe_path):
+def test_gcs_caching(preset_gcs_builder, make_counter):
     call_counter = make_counter()
     builder = preset_gcs_builder
 
@@ -63,7 +64,7 @@ def test_gcs_caching(preset_gcs_builder, make_counter, gcs_wipe_path):
     assert flow.setting("x", 4).get("xy") == 12
     assert call_counter.times_called() == 0
 
-    gcs_wipe_path(gcs_cache_url)
+    gcs_fs_wipe_path(gcs_cache_url)
     flow = builder.build()
 
     assert flow.get("xy") == 6
@@ -77,7 +78,7 @@ def test_gcs_caching(preset_gcs_builder, make_counter, gcs_wipe_path):
     assert flow.setting("x", 4).get("xy") == 12
     assert call_counter.times_called() == 0
 
-    gcs_wipe_path(gcs_cache_url)
+    gcs_fs_wipe_path(gcs_cache_url)
     local_wipe_path(local_cache_path_str)
     flow = builder.build()
 


### PR DESCRIPTION
This change replaces [gsutil](https://cloud.google.com/storage/docs/gsutil) and [sq-blocks](https://github.com/square/blocks) with [fsspec](https://filesystem-spec.readthedocs.io/en/latest/index.html). We had problems
with gsutil like breaking changes with Python 3.8 (GCP team asked us to
follow a [fix](https://github.com/GoogleCloudPlatform/gsutil/pull/1107) but now it is under question too), and we always wanted to
deprecate sq-blocks in favor of whatever rest of the Bionic code uses
to communicate with GCS.

fsspec has a really nice interface and has a lot of proven implementations
like [gcsfs](https://github.com/dask/gcsfs) and [s3fs](https://github.com/dask/s3fs). If or rather when we decide to support s3, it would be
easy to use fsspec at that point too.