### PR TITLE
Introduce Artifact class

### DIFF
--- a/bionic/core/task_execution.py
+++ b/bionic/core/task_execution.py
@@ -157,6 +157,7 @@ class TaskRunnerEntry:
                 task_key=task.key,
                 provenance=provenance,
                 value=None,
+                local_artifact=None,
                 value_is_missing=True,
             )
             value_hash = ""
@@ -185,6 +186,7 @@ class TaskRunnerEntry:
             task_key=task.key,
             provenance=provenance,
             value=value,
+            local_artifact=None,
         )
 
         if state.should_persist:

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -138,12 +138,22 @@ class Result:
     task_key = attr.ib()
     provenance = attr.ib()
     value = attr.ib()
-    file_path = attr.ib(default=None)
-    value_hash = attr.ib(default=None)
+    local_artifact = attr.ib()
     value_is_missing = attr.ib(default=False)
 
     def __repr__(self):
         return f"Result({self.task_key!r}, {self.value!r})"
+
+
+@attr.s(frozen=True)
+class Artifact:
+    """
+    Represents a serialized, file-like artifact, either on a local filesystem or in a
+    cloud object store.
+    """
+
+    url: str = attr.ib()
+    content_hash: str = attr.ib()
 
 
 class CaseKeySpace(ImmutableSequence):


### PR DESCRIPTION
We often pass around a URL and a file content hash together; this commit
groups them together into one class.

Aside from simplifying our code, my goal is to make it easier to pull
the serialization/deserialization code out of PersistentCache. To do
that we need to stop passing around Results and only use the fields that
matter to the cache, which are now just the Provenance and the Artifact.

I've named the hash field `content_hash` even though elsewhere we call
it `value_hash`. My thinking here is that we're moving to a world where
the persistent cache just deals in files and doesn't know about
in-memory values, so it makes more sense to talk about "content" than
"value".