### PR TITLE
fix aip computation logging

### DIFF
--- a/bionic/core/flow_execution.py
+++ b/bionic/core/flow_execution.py
@@ -297,6 +297,15 @@ class TaskCompletionRunner:
                     new_task_completion_runner,
                     stripped_target_states,
                 )
+
+                def done_callback(callback_future):
+                    if not callback_future.cancelled():
+                        for target_entry in target_entries:
+                            self.task_key_logger.log_computed_aip(
+                                target_entry.state.task_key
+                            )
+
+                future.add_done_callback(done_callback)
             else:
                 future = self._bootstrap.process_executor.submit(
                     run_in_subprocess,
@@ -581,6 +590,9 @@ class TaskKeyLogger:
 
     def log_computed(self, task_key):
         self._log("Computed   %s", task_key)
+
+    def log_computed_aip(self, task_key):
+        self._log("Computed   %s using AIP", task_key)
 
 
 def dnode_without_drafts(dnode):

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -42,9 +42,9 @@ def parallel_execution_enabled(request):
         pytest.param("real-gcp", marks=pytest.mark.real_gcp),
     ],
 )
-def use_fake_gcp(request, fake_gcs_fs):
+def use_fake_gcp(request, fake_gcs_fs, caplog):
     if request.param == "fake-gcp":
-        with run_in_fake_gcp(fake_gcs_fs):
+        with run_in_fake_gcp(fake_gcs_fs, caplog):
             yield True
     else:
         yield False

--- a/tests/test_flow/fakes.py
+++ b/tests/test_flow/fakes.py
@@ -1,7 +1,7 @@
-from contextlib import contextmanager
-from functools import partial
 import io
 import logging
+from contextlib import contextmanager
+from functools import partial
 from pathlib import Path
 from unittest.mock import Mock
 from uuid import uuid4
@@ -167,13 +167,18 @@ class FakeGcsFs:
 
 
 @contextmanager
-def run_in_fake_gcp(fake_gcs_fs: FakeGcsFs):
+def run_in_fake_gcp(fake_gcs_fs: FakeGcsFs, caplog):
     """
     Use fake GCP by mocking out GCS and AIP.
     """
 
     def create_aip_job(body, parent):
-        run_aip(body["trainingInput"]["args"][3])
+        # AIP executions do not transmit logs to local instance of bionic.
+        # Emulate this behavior by setting the log level; this should filter out
+        # all (or almost all) the logs. Tests that check the log output will
+        # only test against logs which are printed locally.
+        with caplog.at_level(logging.CRITICAL):
+            run_aip(body["trainingInput"]["args"][3])
         return Mock()
 
     mock_aip_client = Mock()

--- a/tests/test_flow/test_logging.py
+++ b/tests/test_flow/test_logging.py
@@ -1,17 +1,30 @@
+import re
+
 import pytest
 
 import logging
 import threading
+import bionic as bn
 
 
 class LogChecker:
     def __init__(self, caplog):
         self._caplog = caplog
 
-    def expect(self, *expected_messages):
-        actual_messages = [record.getMessage() for record in self._caplog.records]
+    def expect_all(self, *expected_messages):
+        actual_messages = self._pop_messages()
         assert set(actual_messages) == set(expected_messages)
         self._caplog.clear()
+
+    def expect_regex(self, *expected_patterns):
+        actual_messages = self._pop_messages()
+        for pattern in expected_patterns:
+            assert any(re.fullmatch(pattern, message) for message in actual_messages)
+
+    def _pop_messages(self):
+        messages = [record.getMessage() for record in self._caplog.records]
+        self._caplog.clear()
+        return messages
 
 
 @pytest.fixture(scope="function")
@@ -44,7 +57,7 @@ def test_logging_details(builder, log_checker, parallel_execution_enabled):
 
     flow = builder.build()
     assert flow.get("x_plus_one") == 2
-    log_checker.expect(
+    log_checker.expect_all(
         "Accessed   x(x=1) from definition",
         "Computing  x_plus_one(x=1) ...",
         "Computed   x_plus_one(x=1)",
@@ -56,13 +69,13 @@ def test_logging_details(builder, log_checker, parallel_execution_enabled):
         # This is different from serial execution because we don't pass
         # in-memory cache to the subprocesses. The subprocess loads the
         # entities from disk cache instead.
-        log_checker.expect(
+        log_checker.expect_all(
             "Loaded     x_plus_one(x=1) from disk cache",
             "Computing  x_plus_two(x=1) ...",
             "Computed   x_plus_two(x=1)",
         )
     else:
-        log_checker.expect(
+        log_checker.expect_all(
             "Accessed   x_plus_one(x=1) from in-memory cache",
             "Computing  x_plus_two(x=1) ...",
             "Computed   x_plus_two(x=1)",
@@ -77,15 +90,15 @@ def test_logging_details(builder, log_checker, parallel_execution_enabled):
     # To clarify: we do access it for looking at the cache, but it's
     # taken from the case key where it is loaded by default and is not
     # counted as definition access in the flow.
-    log_checker.expect("Loaded     x_plus_one(x=1) from disk cache")
+    log_checker.expect_all("Loaded     x_plus_one(x=1) from disk cache")
 
     flow = builder.build()
     assert flow.get("x_plus_two") == 3
-    log_checker.expect("Loaded     x_plus_two(x=1) from disk cache")
+    log_checker.expect_all("Loaded     x_plus_two(x=1) from disk cache")
 
     flow = flow.setting("x_plus_one", 3)
     assert flow.get("x_plus_two") == 4
-    log_checker.expect(
+    log_checker.expect_all(
         "Accessed   x_plus_one(x_plus_one=3) from definition",
         "Computing  x_plus_two(x_plus_one=3) ...",
         "Computed   x_plus_two(x_plus_one=3)",
@@ -112,9 +125,52 @@ def test_log_unpickleable_value(builder, log_checker):
 
     assert builder.build().get("log_unpickleable_value") == 5
 
-    log_checker.expect(
+    log_checker.expect_all(
         "Computing  log_unpickleable_value() ...",
         "Cannot pickle me",
         "Logging unpickleable class: Cannot pickle me",
         "Computed   log_unpickleable_value()",
+    )
+
+
+@pytest.mark.no_parallel
+@pytest.mark.needs_aip
+def test_log_aip(aip_builder, log_checker):
+    builder = aip_builder
+
+    builder.assign("x", 1)
+
+    @builder
+    @bn.aip_task_config("n1-standard-4")
+    def x_plus_one(x):
+        return x + 1
+
+    @builder
+    @bn.aip_task_config("n1-standard-8")
+    def x_plus_two(x_plus_one):
+        return x_plus_one + 1
+
+    flow = builder.build()
+
+    assert flow.get("x_plus_one") == 2
+
+    log_checker.expect_regex(
+        r"Accessed   x\(x=1\) from definition",
+        r"Uploading x\(x=1\) to GCS ...",
+        r"Staging task .* at gs://.*",
+        r"Submitting .*x_plus_one.*",
+        r"Started task on AI Platform: https://console.cloud.google.com/ai-platform/jobs/.*",
+        r"Computed   x_plus_one\(x=1\) using AIP",
+    )
+
+    assert flow.get("x_plus_two") == 3
+
+    # Unfortunately, the string "Loaded     x_plus_one(x=1) from disk cache" is
+    # printed in AIP logs but not locally.
+
+    log_checker.expect_regex(
+        r"Staging task .* at gs://.*",
+        r"Submitting .*x_plus_two.*",
+        r"Started task on AI Platform: https://console.cloud.google.com/ai-platform/jobs/.*",
+        r"Computed   x_plus_two\(x=1\) using AIP",
     )


### PR DESCRIPTION
Temporary fix for AIP logging. Entities that use AIP will show `computed ...` instead of `Downloading ... from GCS`.

Note that this does not fix all problems. For example, if an AIP entity depends on another previously computed entity X, then it may not show the logs saying that it has downloaded X from GCS. This fix also does not show print all the logs from AIP.

One possible long-term fix is to pass these logging information through stackdriver.

