### PR TITLE
Bump version: 0.9.0 → 0.9.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.9.1
 commit = True
 tag = False
 

--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -18,4 +18,4 @@ from .decorators import (  # noqa: F401
 from . import protocol  # noqa: F401
 from . import util  # noqa: F401
 
-__version__ = u"0.9.0"
+__version__ = u"0.9.1"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = u"2019, Square"
 author = u"Janek Klawe"
 
 # The short X.Y version
-version = u"0.9.0"
+version = u"0.9.1"
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -65,14 +65,17 @@ For each release, we list the following types of change (in this order):
 - **Development Changes**: Significant changes to Bionic's development process, such
   as changes to our Pytest configuration or our Continuous Integration ("CI").
 
-Upcoming Version (Not Yet Released)
------------------------------------
+.. Upcoming Version (Not Yet Released)
+.. -----------------------------------
 
 .. Record any notable changes in this section. When we update the current version,
    add a new version heading below, and then comment out the heading above until more
    changes are added. This way, the "Upcoming Version" section will be never be visible
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
+
+0.9.1 (Oct 15, 2020)
+--------------------
 
 Improvements
 ............

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requirements = [
 
 setup(
     name="bionic",
-    version="0.9.0",
+    version="0.9.1",
     description=(
         "A Python framework for building, running, and sharing data science "
         "workflows"


### PR DESCRIPTION
Ran all the GCS and AIP tests this time. Here is the screenshot of the new release notes page.

<img width="750" alt="Screen Shot 2020-10-15 at 12 30 48 PM" src="https://user-images.githubusercontent.com/2109428/96160404-e9ee3680-0ee3-11eb-8235-75805c56d9e7.png">
