### PR TITLE
Run GCS tests using real GCS in CI

### DIFF
--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -41,17 +41,23 @@ jobs:
         # This prints out all installed package versions, which may help for debugging
         # build failures.
         pip freeze
+    - name: Set up gcloud
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      with:
+        service_account_key: ${{ secrets.GCP_SA_KEY }}
+        export_default_credentials: true
     - name: Lint with flake8 and black
       run: |
         flake8
         black --check .
     - name: Run baseline tests
+      # Running GCS tests in CI costs less than a dollar per day on average.
       run: |
-        pytest
+        pytest --bucket=${{ secrets.GCP_BUCKET }}
     - name: Run extra tests (sharded)
       # Running each test on each Python version is expensive, so we compromise: we run
       # the baseline tests above on each version, since they're fast and hopefully
       # comprehensive enough to shake out any version-specific bugs; and we run each of
       # the other tests on just one Python version, reducing the total build time.
       run: |
-        pytest --parallel --slow -m 'not baseline' --num-shards 3 --shard-id ${{matrix.shard-id}}
+        pytest --bucket=${{ secrets.GCP_BUCKET }} --parallel --slow -m 'not baseline' --num-shards 3 --shard-id ${{matrix.shard-id}}

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -65,14 +65,19 @@ For each release, we list the following types of change (in this order):
 - **Development Changes**: Significant changes to Bionic's development process, such
   as changes to our Pytest configuration or our Continuous Integration ("CI").
 
-.. Upcoming Version (Not Yet Released)
-.. -----------------------------------
+Upcoming Version (Not Yet Released)
+-----------------------------------
 
 .. Record any notable changes in this section. When we update the current version,
    add a new version heading below, and then comment out the heading above until more
    changes are added. This way, the "Upcoming Version" section will be never be visible
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
+
+Development Changes
+...................
+
+- Our CI now also runs all GCS tests using the real GCS.
 
 0.9.1 (Oct 15, 2020)
 --------------------


### PR DESCRIPTION
This change uses `setup-gcloud` GitHub Action to set up gcloud on CI
and runs the GCS tests using both fake and actual GCS.

This was a lot easier to use than I expected. You just need to add the
service account key to secrets and use it to authenticate. For more
information on how to use it, please check the
[readme](https://github.com/GoogleCloudPlatform/github-actions/blob/master/setup-gcloud/README.md).

I also verified that this works by checking that the CI build doesn't
skip GCS tests. I can also see the cached files inside the new bionic
bucket in our team's project when the CI is running.

Screenshot of docs change:
<img width="604" alt="Screen Shot 2020-10-21 at 5 47 56 PM" src="https://user-images.githubusercontent.com/2109428/96791020-b456bb00-13c5-11eb-8330-b783df5e8630.png">
