### PR TITLE
Fix redundant gcs downloads

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -74,6 +74,12 @@ Upcoming Version (Not Yet Released)
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
 
+Bug Fixes
+.........
+
+- The previous release introduced a bug where files were downloaded from GCS more often
+  than necessary; this is fixed.
+
 Development Changes
 ...................
 
@@ -81,6 +87,12 @@ Development Changes
 
 0.9.1 (Oct 15, 2020)
 --------------------
+
+New Bugs
+........
+
+- This release downloaded files from GCS more frequently than necessary (i.e., even when
+  a local copy was already present).
 
 Improvements
 ............

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -5,7 +5,7 @@ from multiprocessing.managers import SyncManager
 import pytest
 
 import bionic as bn
-from .fakes import run_in_fake_gcp, FakeGcsFs
+from .fakes import FakeGcsFs, instrument_gcs_fs, run_in_fake_gcp
 from ..helpers import (
     SimpleCounter,
     ResettingCallCounter,
@@ -48,6 +48,15 @@ def use_fake_gcp(request, fake_gcs_fs, caplog):
             yield True
     else:
         yield False
+
+
+# This replaces the global GCS filesystem with an instrumented version. Note that we
+# depend on `use_fake_gcp`, so we can end up wrapping either the real or the fake
+# filesystem.
+@pytest.fixture
+def instrumented_gcs_fs(use_fake_gcp, make_list):
+    with instrument_gcs_fs(make_list) as inst_gcs_fs:
+        yield inst_gcs_fs
 
 
 # We provide this at the top level because we want everyone using FlowBuilder


### PR DESCRIPTION
This fixes the bug that @simonafk found where we download too many times from GCS, and also updates the tests to catch this type of bug in the future. There are more details in the individual commit messages.

I think this obviates the main fix in https://github.com/square/bionic/pull/281/files, but that PR still has some useful logging test changes that are probably worth keeping.