### PR TITLE
Remove the FakeCloudStore class

### DIFF
--- a/bionic/persistence.py
+++ b/bionic/persistence.py
@@ -18,7 +18,6 @@ from .datatypes import CodeFingerprint, Artifact
 from .utils.files import (
     ensure_dir_exists,
     ensure_parent_dir_exists,
-    recursively_copy_path,
 )
 from .utils.misc import hash_simple_obj_to_hex, oneline
 from .utils.urls import (
@@ -751,32 +750,6 @@ class GcsCloudStore:
             self._fs.get_dir(url, path)
         else:
             self._fs.get_file(url, path)
-
-
-class FakeCloudStore(LocalStore):
-    """
-    A mock version of the GcsCloudStore that's actually backed by local files.
-    Useful for running tests without setting up a GCS connection, which is
-    slow and requires some configuration.
-    """
-
-    def __init__(self, root_path_str):
-        super(FakeCloudStore, self).__init__(root_path_str)
-
-    def generate_unique_url_prefix(self, provenance):
-        return url_from_path(self.generate_unique_dir_path(provenance))
-
-    def upload(self, path, url):
-        src_path = path
-        dst_path = path_from_url(url)
-
-        recursively_copy_path(src_path, dst_path)
-
-    def download(self, path, url):
-        src_path = path_from_url(url)
-        dst_path = path
-
-        recursively_copy_path(src_path, dst_path)
 
 
 class LocalFilesystem:

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -146,6 +146,20 @@ def gcs_builder(builder, tmp_gcs_url_prefix, use_fake_gcp, gcs_fs):
     return builder
 
 
+# Unlike gcs_builder, which is parametrized to be either real or fake, this builder is
+# always fake.
+@pytest.fixture
+def fake_gcs_builder(builder, make_dict):
+    builder = builder.build().to_builder()
+
+    builder.set("core__persistent_cache__gcs__bucket_name", "some-bucket")
+    builder.set("core__persistent_cache__gcs__object_path", "")
+    builder.set("core__persistent_cache__gcs__enabled", True)
+    builder.set("core__persistent_cache__gcs__fs", FakeGcsFs(make_dict))
+
+    return builder
+
+
 @pytest.fixture
 def aip_builder(gcs_builder, gcp_project, use_fake_gcp, gcs_fs, caplog, monkeypatch):
     gcs_builder.set("core__aip_execution__enabled", True)

--- a/tests/test_flow/test_persistence_fuzz.py
+++ b/tests/test_flow/test_persistence_fuzz.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 from random import Random
 
 from bionic.exception import CodeVersioningError
-from bionic.persistence import FakeCloudStore
 from bionic import interpret
 import bionic as bn
 
@@ -386,10 +385,8 @@ class Fuzzer:
 
 
 @pytest.fixture(scope="function")
-def fuzzer(builder, make_list, tmp_path):
-    fake_cloud_store = FakeCloudStore(str(tmp_path / "BNTESTDATA_FAKE_CLOUD"))
-    builder.set("core__persistent_cache__cloud_store", fake_cloud_store)
-    return Fuzzer(builder, make_list)
+def fuzzer(fake_gcs_builder, make_list, tmp_path):
+    return Fuzzer(fake_gcs_builder, make_list)
 
 
 foreach_mode = pytest.mark.parametrize("versioning_mode", ["manual", "assist", "auto"])


### PR DESCRIPTION
Now that we have FakeGcsFs, we might as well use that instead of
maintaining two different fake GCS abstractions.