### PR TITLE
injectable gcs fs, allow fake gcs with parallel

### DIFF
--- a/bionic/aip/future.py
+++ b/bionic/aip/future.py
@@ -5,7 +5,6 @@ from concurrent.futures import Future as ConcurrentFuture, TimeoutError, Cancell
 from enum import Enum, auto
 
 from bionic.aip.client import get_aip_client
-from bionic.gcs import get_gcs_fs_without_warnings
 
 
 class AipError(Exception):
@@ -51,7 +50,8 @@ class Future(ConcurrentFuture):
 
     """
 
-    def __init__(self, project_name: str, job_id: str, output: str):
+    def __init__(self, gcs_fs, project_name: str, job_id: str, output: str):
+        self.gcs_fs = gcs_fs
         self.project_name = project_name
         self.job_id = job_id
         self.output = output
@@ -111,8 +111,7 @@ class Future(ConcurrentFuture):
             raise exc
 
         try:
-            gcs_fs = get_gcs_fs_without_warnings()
-            with gcs_fs.open(self.output, "rb") as f:
+            with self.gcs_fs.open(self.output, "rb") as f:
                 return pickle.load(f)
         except:  # NOQA
             logging.warning(

--- a/bionic/aip/main.py
+++ b/bionic/aip/main.py
@@ -11,10 +11,9 @@ from bionic.deps.optdep import import_optional_dependency
 from bionic.gcs import get_gcs_fs_without_warnings
 
 
-def _run(ipath):
+def _run(ipath, gcs_fs):
     cloudpickle = import_optional_dependency("cloudpickle")
 
-    gcs_fs = get_gcs_fs_without_warnings()
     with gcs_fs.open(ipath, "rb") as f:
         task = cloudpickle.load(f)
 
@@ -36,7 +35,7 @@ def run():
     This method is a proxy to _run which does the actual work. The proxy exists
     so that _run can be replaced for testing.
     """
-    _run(sys.argv[-1])
+    _run(sys.argv[-1], get_gcs_fs_without_warnings())
 
 
 def _set_up_logging(job_id, project_id):

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -317,6 +317,7 @@ class EntityDeriver:
             versioning_policy=self._compute_core_entity("core__versioning_policy"),
             aip_executor=self._compute_core_entity("core__aip_executor"),
             process_executor=self._compute_core_entity("core__process_executor"),
+            gcs_fs=self._compute_core_entity("core__persistent_cache__gcs__fs"),
             should_memoize_default=self._compute_core_entity(
                 "core__memoize_by_default"
             ),
@@ -693,8 +694,9 @@ class ExecutionCore:
     versioning_policy = attr.ib()
     aip_executor = attr.ib()
     process_executor = attr.ib()
-    should_memoize_default = attr.ib()
-    should_persist_default = attr.ib()
+    gcs_fs = attr.ib()
+    should_memoize_default = attr.ib(type=bool)
+    should_persist_default = attr.ib(type=bool)
     task_key_logging_level = attr.ib()
 
     def evolve(self, **kwargs):
@@ -709,6 +711,7 @@ BOOTSTRAP_CORE = ExecutionCore(
     ),
     aip_executor=None,
     process_executor=None,
+    gcs_fs=None,
     should_memoize_default=True,
     should_persist_default=False,
     task_key_logging_level=logging.DEBUG,

--- a/bionic/executor.py
+++ b/bionic/executor.py
@@ -26,8 +26,9 @@ class AipExecutor:
     in one place.
     """
 
-    def __init__(self, aip_config):
+    def __init__(self, aip_config, gcs_fs):
         self._aip_config = aip_config
+        self._gcs_fs = gcs_fs
 
     def submit(self, task_config, fn, *args, **kwargs):
         return Task(
@@ -38,6 +39,7 @@ class AipExecutor:
             # a letter and only accepts alphanumeric and underscore
             # characters.
             name="a" + str(uuid4()).replace("-", ""),
+            gcs_fs=self._gcs_fs,
             config=self._aip_config,
             task_config=task_config,
             function=partial(fn, *args, **kwargs),

--- a/bionic/gcs.py
+++ b/bionic/gcs.py
@@ -44,17 +44,10 @@ def get_gcs_fs_without_warnings(cache_value=True):
 def upload_to_gcs(path, url):
     """
     Copy a local path to GCS URL.
-
-    This method is a proxy for _upload_to_gcs which does the actual work.
-    The proxy exists so that _upload_to_gcs can be replaced for testing.
     """
-    _upload_to_gcs(path, url)
-
-
-def _upload_to_gcs(path, url):
-    fs = get_gcs_fs_without_warnings()
+    gcs_fs = get_gcs_fs_without_warnings()
     if path.is_dir():
-        fs.put(str(path), url, recursive=True)
+        gcs_fs.put(str(path), url, recursive=True)
     else:
         # If the GCS URL is a folder, we want to write the file in the folder.
         # There seems to be a bug in fsspec due to which, the file is uploaded
@@ -68,4 +61,4 @@ def _upload_to_gcs(path, url):
         # details and tracking this issue.
         if url.endswith("/"):
             url = url + path.name
-        fs.put_file(str(path), url)
+        gcs_fs.put_file(str(path), url)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,9 +93,6 @@ def pytest_collection_modifyitems(config, items):
                 if "no_parallel" in item.keywords or not also_run_parallel:
                     continue
 
-            if "fake_gcp" in item.keywords:
-                continue
-
         elif "needs_parallel" in item.keywords:
             continue
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,7 +8,6 @@ import pandas as pd
 from pandas import testing as pdt
 
 import bionic as bn
-from bionic.gcs import get_gcs_fs_without_warnings
 
 
 # TODO This name is cumbersome; maybe one of these shorter names?
@@ -230,25 +229,6 @@ def longest_regex_prefix_match(regex, string, flags=0):
     match = re.search(regex[:max_succ_ix], string, flags=flags)
     assert match is not None
     return match
-
-
-def gcs_fs_wipe_path(url):
-    assert "BNTESTDATA" in url
-    fs = get_gcs_fs_without_warnings()
-    fs.rm(url, recursive=True)
-
-
-def gcs_fs_path_exists(url):
-    fs = get_gcs_fs_without_warnings()
-    return fs.exists(url)
-
-
-def gcs_fs_download(url, path):
-    fs = get_gcs_fs_without_warnings()
-    if fs.isdir(url):
-        fs.get(url, str(path), recursive=True)
-    else:
-        fs.get_file(url, str(path))
 
 
 def local_wipe_path(path_str):

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -1,22 +1,17 @@
 import getpass
 import random
 from multiprocessing.managers import SyncManager
+from typing import Optional
 
 import pytest
 
 import bionic as bn
-from .fakes import FakeGcsFs, instrument_gcs_fs, run_in_fake_gcp
+from bionic.gcs import get_gcs_fs_without_warnings
+from .fakes import FakeGcsFs, fake_aip_client
 from ..helpers import (
     SimpleCounter,
     ResettingCallCounter,
-    gcs_fs_wipe_path,
-    gcs_fs_path_exists,
 )
-
-
-@pytest.fixture
-def fake_gcs_fs():
-    return FakeGcsFs()
 
 
 # Parameterizing a fixture adds the parameter in the test name at the end,
@@ -29,7 +24,7 @@ def fake_gcs_fs():
         pytest.param("parallel", marks=pytest.mark.parallel),
     ],
 )
-def parallel_execution_enabled(request):
+def parallel_execution_enabled(request) -> bool:
     return request.param == "parallel"
 
 
@@ -42,21 +37,8 @@ def parallel_execution_enabled(request):
         pytest.param("real-gcp", marks=pytest.mark.real_gcp),
     ],
 )
-def use_fake_gcp(request, fake_gcs_fs, caplog):
-    if request.param == "fake-gcp":
-        with run_in_fake_gcp(fake_gcs_fs, caplog):
-            yield True
-    else:
-        yield False
-
-
-# This replaces the global GCS filesystem with an instrumented version. Note that we
-# depend on `use_fake_gcp`, so we can end up wrapping either the real or the fake
-# filesystem.
-@pytest.fixture
-def instrumented_gcs_fs(use_fake_gcp, make_list):
-    with instrument_gcs_fs(make_list) as inst_gcs_fs:
-        yield inst_gcs_fs
+def use_fake_gcp(request) -> bool:
+    return request.param == "fake-gcp"
 
 
 # We provide this at the top level because we want everyone using FlowBuilder
@@ -71,9 +53,9 @@ def builder(parallel_execution_enabled, tmp_path):
 
 # This is a different multiprocessing manager than the one we use in
 # ExternalProcessLoggingManager. This one is responsible for sharing test
-# objects between processes. It's only used in make_counter and make_list
-# fixtures. The purpose here is to not pollute the manager that bionic uses.
-# I also don't want to replace the manager that bionic creates with a test
+# objects between processes. It's only used in make_counter, make_list and
+# make_dict fixtures. The purpose here is to not pollute the manager that bionic
+# uses. I also don't want to replace the manager that bionic creates with a test
 # one.
 class PytestManager(SyncManager):
     pass
@@ -121,7 +103,26 @@ def make_list(process_manager):
 
 
 @pytest.fixture
-def gcs_builder(builder, tmp_gcs_url_prefix):
+def make_dict(process_manager):
+    def _make_dict():
+        if process_manager is None:
+            return {}
+        else:
+            return process_manager.dict()
+
+    return _make_dict
+
+
+@pytest.fixture
+def gcs_fs(use_fake_gcp, make_dict):
+    if use_fake_gcp:
+        return FakeGcsFs(make_dict)
+    else:
+        return get_gcs_fs_without_warnings()
+
+
+@pytest.fixture
+def gcs_builder(builder, tmp_gcs_url_prefix, use_fake_gcp, gcs_fs):
     URL_PREFIX = "gs://"
     assert tmp_gcs_url_prefix.startswith(URL_PREFIX)
     gcs_path = tmp_gcs_url_prefix[len(URL_PREFIX) :]
@@ -133,19 +134,33 @@ def gcs_builder(builder, tmp_gcs_url_prefix):
     builder.set("core__persistent_cache__gcs__object_path", object_path)
     builder.set("core__persistent_cache__gcs__enabled", True)
 
+    if use_fake_gcp:
+        builder.set("core__persistent_cache__gcs__fs", gcs_fs)
+    else:
+        # Since gcs is enabled, if core__persistent_cache__gcs__fs is not set,
+        # the builder should use get_gcs_fs_without_warnings() by default.
+        # The passed in gcs_fs is used in other places, verify that it is
+        # not a fake.
+        assert gcs_fs == get_gcs_fs_without_warnings()
+
     return builder
 
 
 @pytest.fixture
-def aip_builder(gcs_builder, gcp_project):
+def aip_builder(gcs_builder, gcp_project, use_fake_gcp, gcs_fs, caplog, monkeypatch):
     gcs_builder.set("core__aip_execution__enabled", True)
     gcs_builder.set("core__aip_execution__gcp_project_name", gcp_project)
+
+    if use_fake_gcp:
+        monkeypatch.setattr(
+            "bionic.aip.client._cached_aip_client", fake_aip_client(gcs_fs, caplog)
+        )
 
     return gcs_builder
 
 
 @pytest.fixture
-def gcp_project(request, use_fake_gcp):
+def gcp_project(request, use_fake_gcp) -> str:
     if use_fake_gcp:
         return "fake-project"
     project = request.config.getoption("--project")
@@ -153,30 +168,32 @@ def gcp_project(request, use_fake_gcp):
     return project
 
 
-@pytest.fixture
-def gcs_url_stem(request, use_fake_gcp):
-    if use_fake_gcp:
-        return "gs://fake-bucket"
+@pytest.fixture(scope="session")
+def real_gcs_url_stem(request) -> Optional[str]:
     url = request.config.getoption("--bucket")
-    assert url.startswith("gs://")
+    if url is not None:
+        assert url.startswith("gs://")
     return url
 
 
-@pytest.fixture
-def session_tmp_gcs_url_prefix(gcs_url_stem, use_fake_gcp):
+@pytest.fixture(scope="session")
+def real_gcs_session_tmp_url_prefix(real_gcs_url_stem) -> Optional[str]:
     """
     Sets up and tears down a temporary "directory" on GCS to be shared by all
-    of our tests.
+    of our tests. Not applicable for fake GCS.
     """
+
+    if real_gcs_url_stem is None:
+        yield None
+        return
+
+    gcs_fs = get_gcs_fs_without_warnings()
 
     random_hex_str = "%016x" % random.randint(0, 2 ** 64)
     path_str = f"{getpass.getuser()}/BNTESTDATA/{random_hex_str}"
 
-    gs_url = gcs_url_stem + "/" + path_str + "/"
-    # This emits a stderr warning because the URL doesn't exist.  That's
-    # annoying but I wasn't able to find a straightforward way to avoid it.
-    if not use_fake_gcp:
-        assert not gcs_fs_path_exists(gs_url)
+    gs_url = real_gcs_url_stem + "/" + path_str + "/"
+    assert not gcs_fs.exists(gs_url)
 
     yield gs_url
 
@@ -184,13 +201,16 @@ def session_tmp_gcs_url_prefix(gcs_url_stem, use_fake_gcp):
     # Currently every test using this fixture does write some objects under this URL,
     # *and* doesn't clean all of them up. If this changes, we may need to start
     # handling this more gracefully.
-    if not use_fake_gcp:
-        gcs_fs_wipe_path(gs_url)
+    gcs_fs.rm(gs_url, recursive=True)
 
 
-@pytest.fixture(scope="function")
-def tmp_gcs_url_prefix(session_tmp_gcs_url_prefix, request):
+@pytest.fixture
+def tmp_gcs_url_prefix(use_fake_gcp, real_gcs_session_tmp_url_prefix, request) -> str:
     """A temporary "directory" on GCS for a single test."""
+    if use_fake_gcp:
+        return "gs://fake-bucket/BNTESTDATA/"
+
+    assert real_gcs_session_tmp_url_prefix is not None
 
     # `gsutil` doesn't support wildcard characters which are `[]` here.
     # This is an open issue with gsutil but till it's fixed, we are going
@@ -198,4 +218,18 @@ def tmp_gcs_url_prefix(session_tmp_gcs_url_prefix, request):
     # https://github.com/GoogleCloudPlatform/gsutil/issues/290
     # gcsfs seems to have the same problem.
     node_name = request.node.name.replace("[", "_").replace("]", "")
-    return session_tmp_gcs_url_prefix + node_name + "/"
+    return real_gcs_session_tmp_url_prefix + node_name + "/"
+
+
+@pytest.fixture
+def clear_test_gcs_data(tmp_gcs_url_prefix, gcs_fs):
+    """
+    Deletes all GCS data specific to a single test.
+    """
+
+    assert "BNTESTDATA" in tmp_gcs_url_prefix
+
+    def _clear_test_gcs_data():
+        gcs_fs.rm(tmp_gcs_url_prefix, recursive=True)
+
+    return _clear_test_gcs_data

--- a/tests/test_flow/test_copy.py
+++ b/tests/test_flow/test_copy.py
@@ -1,16 +1,14 @@
-import pytest
-
 import json
 from pathlib import Path
 
 import dask.dataframe as dd
-
-from ..helpers import df_from_csv_str, equal_frame_and_index_content, gcs_fs_download
+import pytest
 
 import bionic as bn
+from ..helpers import df_from_csv_str, equal_frame_and_index_content
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def preset_builder(builder):
     builder.assign("x", 2)
     builder.assign("y", 3)
@@ -22,12 +20,12 @@ def preset_builder(builder):
     return builder
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def flow(preset_builder):
     return preset_builder.build()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def expected_dask_df():
     df_value = df_from_csv_str(
         """
@@ -40,7 +38,7 @@ def expected_dask_df():
     return dd.from_pandas(df_value, npartitions=1)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dask_flow(builder, expected_dask_df):
     @builder
     @bn.protocol.dask
@@ -48,6 +46,21 @@ def dask_flow(builder, expected_dask_df):
         return expected_dask_df
 
     return builder.build()
+
+
+@pytest.fixture
+def override_gcs_for_copy_if_fake_gcp(use_fake_gcp, gcs_fs, monkeypatch):
+    """
+    A flow has an instance of GCS filesystem if GCS caching is enabled. But we
+    still need to support the case where the user wants to upload the results to
+    GCS even though GCS caching is disabled for the flow. Hence, the
+    upload_to_gcs method does not use the flow's GCS filesystem in case GCS
+    caching is disabled. If we have a fake GCS filesystem, we have to patch it
+    manually.
+    """
+
+    if use_fake_gcp:
+        monkeypatch.setattr("bionic.gcs.get_gcs_fs_without_warnings", lambda: gcs_fs)
 
 
 def test_copy_file_to_existing_local_dir(flow, tmp_path):
@@ -74,20 +87,24 @@ def test_copy_file_to_local_file_using_str(flow, tmp_path):
 
 
 @pytest.mark.needs_gcs
-def test_copy_file_to_gcs_dir(flow, tmp_path, tmp_gcs_url_prefix):
+def test_copy_file_to_gcs_dir(
+    flow, tmp_path, tmp_gcs_url_prefix, override_gcs_for_copy_if_fake_gcp, gcs_fs
+):
     flow.get("f", mode="FileCopier").copy(destination=tmp_gcs_url_prefix)
     cloud_url = tmp_gcs_url_prefix + "f.json"
     local_path = tmp_path / "f.json"
-    gcs_fs_download(cloud_url, local_path)
+    gcs_fs.get_file(cloud_url, local_path)
     assert json.loads(local_path.read_bytes()) == 5
 
 
 @pytest.mark.needs_gcs
-def test_copy_file_to_gcs_file(flow, tmp_path, tmp_gcs_url_prefix):
+def test_copy_file_to_gcs_file(
+    flow, tmp_path, tmp_gcs_url_prefix, override_gcs_for_copy_if_fake_gcp, gcs_fs
+):
     cloud_url = tmp_gcs_url_prefix + "f.json"
     flow.get("f", mode="FileCopier").copy(destination=cloud_url)
     local_path = tmp_path / "f.json"
-    gcs_fs_download(cloud_url, local_path)
+    gcs_fs.get_file(cloud_url, local_path)
     assert json.loads(local_path.read_bytes()) == 5
 
 
@@ -104,14 +121,19 @@ def test_copy_dask_to_dir(tmp_path, expected_dask_df, dask_flow):
 
 @pytest.mark.needs_gcs
 def test_copy_dask_to_gcs_dir(
-    tmp_path, tmp_gcs_url_prefix, expected_dask_df, dask_flow
+    tmp_path,
+    tmp_gcs_url_prefix,
+    expected_dask_df,
+    dask_flow,
+    override_gcs_for_copy_if_fake_gcp,
+    gcs_fs,
 ):
     cloud_url = tmp_gcs_url_prefix + "output"
     local_path = tmp_path / "output"
 
     dask_flow.get("dask_df", mode="FileCopier").copy(destination=cloud_url)
 
-    gcs_fs_download(cloud_url, local_path)
+    gcs_fs.get(cloud_url, str(local_path), recursive=True)
     actual = dd.read_parquet(local_path)
     assert equal_frame_and_index_content(actual.compute(), expected_dask_df.compute())
 


### PR DESCRIPTION
Allow GCS filesystem instances to be injectable and stored in the flow.
For testing, injecting instead of global patching allows fake GCS to be
shared for multiprocessing.