### PR TITLE
Janek/rename bootstrap

### DIFF
--- a/bionic/cache_api.py
+++ b/bionic/cache_api.py
@@ -43,7 +43,7 @@ class Cache:
         # These private accesses are a bit gross, but I'm not sure it's worth adding
         # more layers of APIs to avoid them.
         self._deriver.get_ready()
-        persistent_cache = self._deriver._bootstrap.persistent_cache
+        persistent_cache = self._deriver._core.persistent_cache
 
         stores = [
             store

--- a/bionic/core/flow_execution.py
+++ b/bionic/core/flow_execution.py
@@ -68,14 +68,10 @@ class TaskCompletionRunner:
 
     @property
     def _parallel_execution_enabled(self):
-        if self._core is None:
-            return False
         return self._core.process_executor is not None
 
     @property
     def _aip_execution_enabled(self):
-        if self._core is None:
-            return False
         return self._core.aip_executor is not None
 
     def run(self, states):
@@ -525,12 +521,11 @@ class TaskKeyLogger:
     """
 
     def __init__(self, core):
-        self._level = logging.INFO if core is not None else logging.DEBUG
+        self._level = core.task_key_logging_level
 
-        executor = core.process_executor if core is not None else None
-        if executor is not None:
+        if core.process_executor is not None:
             self._already_logged_entity_case_key_pairs = (
-                executor.create_synchronized_set()
+                core.process_executor.create_synchronized_set()
             )
         else:
             # TODO: When AIP execution is enabled, we will send this

--- a/bionic/core/task_execution.py
+++ b/bionic/core/task_execution.py
@@ -588,15 +588,6 @@ class TaskState:
             return
 
         # First,  set up the provenance.
-        if core is None:
-            # If we're still in the bootstrap resolution phase, we don't have
-            # any versioning policy, so we don't attempt anything fancy.
-            treat_bytecode_as_functional = False
-        else:
-            treat_bytecode_as_functional = (
-                core.versioning_policy.treat_bytecode_as_functional
-            )
-
         dep_provenance_digests_by_task_key = {
             dep_key: dep_state._get_digest()
             for dep_key, dep_state in zip(self.task.dep_keys, self.dep_states)
@@ -606,7 +597,9 @@ class TaskState:
             task_key=self.task_key,
             code_fingerprint=self.func_attrs.code_fingerprint,
             dep_provenance_digests_by_task_key=dep_provenance_digests_by_task_key,
-            treat_bytecode_as_functional=treat_bytecode_as_functional,
+            treat_bytecode_as_functional=(
+                core.versioning_policy.treat_bytecode_as_functional
+            ),
             can_functionally_change_per_run=self.func_attrs.changes_per_run,
             flow_instance_uuid=flow_instance_uuid,
         )


### PR DESCRIPTION
This renames the `Bootstrap` class to `ExecutionCore` (first commit), and then initializes this object with a default instance instead of `None` (second commit), which helps us avoid having a bunch of null checks in our code. This default value is referred to as the "bootstrap core" -- i.e., the core used for the bootstrapping process, which computes the real core.