### PR TITLE
Extract temporary in-memory caching to central object

### DIFF
--- a/bionic/core/task_execution.py
+++ b/bionic/core/task_execution.py
@@ -142,7 +142,6 @@ class TaskRunnerEntry:
 
         state = self.state
         task = state.task
-        provenance = state._provenance
         protocol = state.desc_metadata.protocol
 
         assert state.is_initialized
@@ -163,7 +162,6 @@ class TaskRunnerEntry:
         if state.output_would_be_missing():
             result = Result(
                 task_key=task.key,
-                provenance=provenance,
                 value=None,
                 local_artifact=None,
                 value_is_missing=True,
@@ -192,7 +190,6 @@ class TaskRunnerEntry:
         protocol.validate_for_dnode(task.key.dnode, value)
         result = Result(
             task_key=task.key,
-            provenance=provenance,
             value=value,
             local_artifact=None,
         )
@@ -500,7 +497,6 @@ class TaskState:
         value = self._value_from_local_artifact(local_artifact)
         result = Result(
             task_key=self.task_key,
-            provenance=self._provenance,
             value=value,
             local_artifact=local_artifact,
         )

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -136,6 +136,7 @@ class Result:
     """
 
     task_key = attr.ib()
+    # TODO It looks like this field is unused; can we remove it?
     provenance = attr.ib()
     value = attr.ib()
     local_artifact = attr.ib()

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -136,8 +136,6 @@ class Result:
     """
 
     task_key = attr.ib()
-    # TODO It looks like this field is unused; can we remove it?
-    provenance = attr.ib()
     value = attr.ib()
     local_artifact = attr.ib()
     value_is_missing = attr.ib(default=False)

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -13,7 +13,7 @@ from .descriptors.parsing import entity_dnode_from_descriptor
 from .descriptors import ast
 from .deps.optdep import import_optional_dependency
 from .exception import UndefinedEntityError
-from .core.flow_execution import TaskCompletionRunner, TaskKeyLogger
+from .core.flow_execution import ExecutionContext, TaskCompletionRunner, TaskKeyLogger
 from .core.task_execution import TaskState
 from .protocols import TupleProtocol, NonSerializableObjectProtocol
 from .provider import (
@@ -667,12 +667,12 @@ class EntityDeriver:
             self._get_or_create_task_state_for_key(task.key) for task in dinfo.tasks
         ]
 
-        task_key_logger = TaskKeyLogger(self._core)
-        task_runner = TaskCompletionRunner(
-            core=self._core,
+        exec_context = ExecutionContext(
             flow_instance_uuid=self._flow_instance_uuid,
-            task_key_logger=task_key_logger,
+            core=self._core,
+            task_key_logger=TaskKeyLogger(self._core),
         )
+        task_runner = TaskCompletionRunner(exec_context)
         results = task_runner.run(requested_task_states)
         assert len(results) == len(requested_task_states)
 

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -13,7 +13,12 @@ from .descriptors.parsing import entity_dnode_from_descriptor
 from .descriptors import ast
 from .deps.optdep import import_optional_dependency
 from .exception import UndefinedEntityError
-from .core.flow_execution import ExecutionContext, TaskCompletionRunner, TaskKeyLogger
+from .core.flow_execution import (
+    ExecutionContext,
+    MemoryResultCache,
+    TaskCompletionRunner,
+    TaskKeyLogger,
+)
 from .core.task_execution import TaskState
 from .protocols import TupleProtocol, NonSerializableObjectProtocol
 from .provider import (
@@ -671,6 +676,7 @@ class EntityDeriver:
             flow_instance_uuid=self._flow_instance_uuid,
             core=self._core,
             task_key_logger=TaskKeyLogger(self._core),
+            temp_result_cache=MemoryResultCache(),
         )
         task_runner = TaskCompletionRunner(exec_context)
         results = task_runner.run(requested_task_states)


### PR DESCRIPTION
This PR introduces an ExecutionContext class that bundles together a few commonly-used-together objects, and then moves our temporary result caching off of the individual TaskRunnerEntries and onto the ExecutionContext. More details in the commit messages.