### PR TITLE
Revert "Restrict cattrs version on Python 3.6"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,7 @@ with open("README.md") as readme_file:
 
 requirements = [
     "attrs>=20.1",
-    # Version 1.1.0 of cattrs dropped support for Python 3.6, so if we're on that
-    # version of Python, we also need an earlier version of cattrs.
-    "cattrs < 1.1.0; python_version <  '3.7'",
-    "cattrs;         python_version >= '3.7'",
+    "cattrs",
     "PyYAML",
     "numpy",
     "pandas",


### PR DESCRIPTION
This reverts commit 9866f0e0a4eda1eeee5e534813a0847baf22f143.

The commit above was added because the latest version of cattrs dropped
support for Python 3.6. cattrs now uses python_requires so that Python
3.6 will fall back to an older version. Hence, the commit above is no
longer necessary. It also breaks Dockerfile script.