### PR TITLE
Exact call counts in random tests

### DIFF
--- a/tests/test_flow/test_persistence_random.py
+++ b/tests/test_flow/test_persistence_random.py
@@ -132,6 +132,16 @@ class ModelFlowHarness:
         if model_exception is None:
             assert flow_value == model_value
 
+            if expect_exact_call_count_matches:
+                assert sorted(self._descriptors_computed_by_flow) == sorted(
+                    self._descriptors_computed_by_model
+                )
+            else:
+                assert set(self._descriptors_computed_by_flow) == set(
+                    self._descriptors_computed_by_model
+                )
+            self._clear_called_descriptors()
+
         else:
             assert flow_exception.__class__ == model_exception.__class__
 
@@ -167,18 +177,6 @@ class ModelFlowHarness:
                 # up exactly.
                 expect_exact_call_count_matches=False,
             )
-            # Note that after the above call, the call counts have been cleared, so the
-            # check below will do nothing.
-
-        if expect_exact_call_count_matches:
-            assert sorted(self._descriptors_computed_by_flow) == sorted(
-                self._descriptors_computed_by_model
-            )
-        else:
-            assert set(self._descriptors_computed_by_flow) == set(
-                self._descriptors_computed_by_model
-            )
-        self._clear_called_descriptors()
 
     # This is just used for debugging.
     def save_dag(self, filename):

--- a/tests/test_flow/test_persistence_random.py
+++ b/tests/test_flow/test_persistence_random.py
@@ -212,7 +212,10 @@ class ModelFlowHarness:
 
         if not binding.has_persisted_values:
             dep_values = [
-                self._compute_model_value(dep_entity_name)
+                self._compute_model_value(
+                    dep_entity_name,
+                    memoized_values_by_entity_name=memoized_values_by_entity_name,
+                )
                 for dep_entity_name in binding.dep_entity_names
             ]
             values_by_entity_name = binding.compute_and_save_values(dep_values)


### PR DESCRIPTION
This adds checks to our random tests to make sure each function is called the correct number times (not just whether it's called at all). Details in the commits.