### PR TITLE
better parallel execution fail logging

### DIFF
--- a/bionic/executor.py
+++ b/bionic/executor.py
@@ -43,9 +43,9 @@ class AipExecutor:
             function=partial(fn, *args, **kwargs),
         )
         task.submit(gcs_fs=self._gcs_fs, aip_client=self._aip_client)
-        return ThreadPoolExecutor(max_workers=1).submit(
-            task.wait_for_results, self._gcs_fs, self._aip_client
-        )
+        return ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="aip-wait-results"
+        ).submit(task.wait_for_results, self._gcs_fs, self._aip_client)
 
     def _create_job_name(self, task_key):
         # AIP job names must be alphanumeric (including underscore) and start

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -263,14 +263,23 @@ class LogChecker:
         self._caplog.clear()
 
     def expect_regex(self, *expected_patterns):
-        actual_messages = self._pop_messages()
+        messages = self._pop_messages()
         for pattern in expected_patterns:
-            assert any(re.fullmatch(pattern, message) for message in actual_messages)
+            assert any(
+                re.fullmatch(pattern, message, flags=re.DOTALL) for message in messages
+            )
 
     def _pop_messages(self):
-        messages = [record.getMessage() for record in self._caplog.records]
+        messages = [self._format_message(record) for record in self._caplog.records]
         self._caplog.clear()
         return messages
+
+    @staticmethod
+    def _format_message(record):
+        message = record.getMessage()
+        if record.exc_text:
+            message = message + " " + record.exc_text
+        return message
 
 
 @pytest.fixture

--- a/tests/test_flow/test_persistence_aip.py
+++ b/tests/test_flow/test_persistence_aip.py
@@ -88,7 +88,6 @@ def test_aip_jobs(aip_builder, log_checker):
     )
 
 
-@pytest.mark.no_parallel
 def test_aip_fail(aip_builder, log_checker):
     builder = aip_builder
 
@@ -107,5 +106,5 @@ def test_aip_fail(aip_builder, log_checker):
         r"Submitting AI Platform task on .*x_plus_one.*x=1.*",
         r"Started AI Platform task: https://console.cloud.google.com/ai-platform/jobs/.*bionic_x_plus_one.*",
         r"Submitting AI Platform task .*TaskKey\(dnode=EntityNode\(name='x_plus_one'\), case_key=CaseKey\(x=1\)\).*",
-        r".*error while doing remote computation.*",
+        r".*error while doing remote computation for x_plus_one\(x=1\).*AipError.*",
     )


### PR DESCRIPTION
Use logger.exception to log parallel/aip job failure(s). Stack trace(s)
are printed and this would help debugging.