### PR TITLE
Add generic eviction code

### DIFF
--- a/bionic/core/task_execution.py
+++ b/bionic/core/task_execution.py
@@ -18,11 +18,12 @@ in the correct order; thus, the TaskRunnerEntry mostly contains data pertaining 
 task's relationship to other tasks.
 """
 
-import attr
 import copy
-import logging
-
 from enum import auto, Enum, IntEnum
+import logging
+from typing import Optional
+
+import attr
 
 from ..datatypes import Artifact, Result
 from ..exception import (
@@ -73,7 +74,7 @@ class TaskRunnerEntry:
 
         self.incoming_reqs = set()
         self.outgoing_reqs = set()
-        self.priority = EntryPriority.DEFAULT
+        self.priority = EntryPriority.NORMAL
 
     @property
     def stage(self):
@@ -206,6 +207,7 @@ class TaskRunnerEntry:
         # exactly the same value.)
         elif state.should_memoize:
             state._result = result
+
         else:
             self.context.temp_result_cache.save(result)
 
@@ -216,46 +218,9 @@ class TaskRunnerEntry:
 
         result = self.context.temp_result_cache.load(self.state.task_key)
         if result is not None:
-            if isinstance(result, VacatedResult):
-                descriptor = self.state.task_key.dnode.to_descriptor()
-                message = f"""
-                Attempted to access a memoized value for {descriptor} after it was
-                vacated; this should never happen unless you're using an undocumented
-                descriptor feature; otherwise, this is probably a bug in Bionic.
-                """
-                raise AssertionError(oneline(message))
             return result
 
         return self.state.get_cached_result(context)
-
-    def vacate(self):
-        """
-        Deletes any result memoized on this entry.
-
-        The purpose is to avoid holding values in memory if we know they won't be
-        needed. This is used for tuple-producing entries once all their followups
-        have been completed. We know we won't need the tuple values anymore (see NOTE
-        below), and we want the downstream entries to be the ones to decide if the
-        values stay in memory or not.
-
-        Does not affect anything memoized on the TaskState -- only on this entry itself.
-
-        NOTE We assume tuple entries will never be requested directly by user code,
-        so the only entries that need to access their values are the
-        automatically-created followup tasks. This assumption is not actually safe if
-        the user uses tuple descriptors, but these aren't currently documented. Once
-        we have file descriptors, the only tasks with followups will be the "crude"
-        pre-persisted values, which we won't document and which the user will have no
-        reason to access. Furthermore, at that point we should be able to simplify
-        the task architecture, so it may be easier to implement this "vacation" idea
-        more gracefully, such as by allowing an entry to become un-CACHED and then
-        get recomputed again.
-        """
-
-        if not self.context.temp_result_cache.contains(self.state.task_key):
-            return
-
-        self.context.temp_result_cache.save(VacatedResult(self.state.task_key))
 
     def __str__(self):
         return f"TaskRunnerEntry({self.state.task_key})"
@@ -313,16 +278,21 @@ class EntryRequirement:
     """
     Represents a requirement from one entry to another.
 
-    A requirement indicates that one entry (`src_entry`) can't make any further progress
-    until another entry (`dst_entry`) has reached a certain level of progress (`level`).
+    A requirement indicates that we need a particular entry (``dst_entry``) to reach a
+    certain level of progress (``level``). This could be because it's blocking some
+    other entry (``src_entry``), or for some external or a priori reason.
 
-    Note: `src_entry` can also be `None`, indicating some sort of external or a priori
-    requirement. On the other hand, `dst_entry` cannot be `None`.
+    An entry can be marked ``is_transient``, meaning it can safely be discarded once
+    ``dst_entry`` has reached the target ``level``. Otherwise, it also be discarded if
+    its ``src_entry`` has reached the (final) ``CACHED`` level. Once a requirement is
+    discarded, it's permissible for ``dst_entry`` to revert to a previous level. If a
+    requirement is not transient and has no source, it is assumed to be permanent.
     """
 
-    src_entry = attr.ib()
-    dst_entry = attr.ib()
-    level = attr.ib()
+    dst_entry: TaskRunnerEntry = attr.ib()
+    level: "EntryLevel" = attr.ib()
+    src_entry: Optional[TaskRunnerEntry] = attr.ib()
+    is_transient: bool = attr.ib()
 
     @property
     def is_met(self):
@@ -368,6 +338,10 @@ class EntryLevel(IntEnum):
         in the persistent cache, in memory on the TaskState, and/or in memory on this
         entry (depending on the cache settings). This is the final level: after this,
         there is no more work to do on this task.
+
+    Normally an entry will only make forward progress through these levels; however,
+    we do sometimes evict temporarily-memoized values, which can cause an entry to
+    regress from CACHED to PRIMED.
     """
 
     CREATED = auto()
@@ -381,16 +355,23 @@ class EntryPriority(IntEnum):
     Indicates a level of priority for a TaskRunnerEntry.
 
     When multiple entries are in the PENDING stage, an entry with higher priority will
-    always be activated before one with lower priority. There are currently only two
-    priorities: DEFAULT and HIGH.
+    always be activated before one with lower priority. There are currently three
+    priorities:
 
-    Currently, the only reason to prioritize one entry over another is because we may
-    want one entry's output to be saved to a persistent cache before another entry has
-    a chance to run (and possibly crash).
+    1. NORMAL: Most entries will have this priority.
+    2. HIGH: This is for entries that some meaningful side effect depends on. For
+       example, after computing a value, we want to make sure it gets persisted to disk
+       (if appropriate) before any other work happens.
+    3. TOP: This is for entries that some effect depends on *and* that depends on a
+       potentially large in-memory objet. For example, if we compute a tuple value, our
+       first priority should be to decompose it into smaller objects, allowing the
+       original tuple to be garbage-collected; until that happens, the individual
+       objects can't be garbage-collected either.
     """
 
-    DEFAULT = auto()
+    NORMAL = auto()
     HIGH = auto()
+    TOP = auto()
 
 
 # TODO Let's reorder the methods here with this order:
@@ -457,12 +438,12 @@ class TaskState:
         return self.desc_metadata.should_memoize
 
     @property
-    def should_persist(self):
-        return self.desc_metadata.should_persist and not self.output_would_be_missing()
+    def should_memoize_for_query(self):
+        return self.desc_metadata.should_memoize_for_query
 
     @property
-    def should_cache(self):
-        return self.should_memoize or self.should_persist
+    def should_persist(self):
+        return self.desc_metadata.should_persist and not self.output_would_be_missing()
 
     @property
     def is_cached(self):

--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -62,16 +62,23 @@ class DescriptorMetadata:
     doc: string
         A human-readable description of the descriptor.
     should_memoize: boolean
-        Whether the entity should be memoized.
+        Whether the value should be memoized for the lifetime of its Flow instance.
+    should_memoize_for_query: boolean
+        Whether the value should be memoized for the lifetime of a Flow.get() call.
+        (Only relevant if ``should_memoize`` is False.)
     should_persist: boolean
-        Whether the entity should be persisted.
-        used
+        Whether the value should be persisted.
+    is_composite: boolean
+        Whether the value contains other descriptor values. (If so, it's desirable to
+        get it out of memory quickly.)
     """
 
     protocol = attr.ib()
     doc = attr.ib()
     should_memoize = attr.ib(default=False)
+    should_memoize_for_query = attr.ib(default=False)
     should_persist = attr.ib(default=False)
+    is_composite = attr.ib(default=True)
 
 
 @attr.s(frozen=True)

--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -477,6 +477,9 @@ class EntityDeriver:
                 protocol=entity_def.protocol,
                 doc=entity_def.doc,
                 should_memoize=should_memoize,
+                # If we don't have any other caching enabled for this entity, we memoize
+                # it for the lifetime of the current query.
+                should_memoize_for_query=(not (should_memoize or should_persist)),
                 should_persist=should_persist,
             )
 
@@ -496,6 +499,7 @@ class EntityDeriver:
             return DescriptorMetadata(
                 protocol=TupleProtocol(len(dnode.children)),
                 doc=f"A Python tuple with {len(dnode.children)} values.",
+                is_composite=True,
             )
 
         else:


### PR DESCRIPTION
This generalizes our "vacate" code to make it safe to use on any
temporarily memoized value, not just drafts. Now temporarily memoized
values can be evicted from memory and recomputed later if necessarily.

(This commit doesn't change any behavior; it just makes it possible to
introduce changes later.)

Motivation
----------

There are two motivations for this:

1. I want to split out the persistent saving and loading operations into
separate tasks, so that instead of a persistent entity being computed
like this:

    <x>           -> x
    (draft value) -> (final value)

it will be computed like this:

    <x>           -> x/artifact -> x
    (draft value) -> (artifact) -> (final value)

The catch is, if `x` is not memoized, we want it to be loaded from disk
each time it's needed; that is, we want the loading function `x/artifact
-> x` to be recomputed each time. That means we need a way to evict `x`
from memory as soon as it gets used (but not any sooner!).

2. Recomputing uncached values each time they're used (described
[here](https://github.com/square/bionic/issues/296)).

Implementation
--------------

Both of these goals require us to be able to: compute an entry value;
hold it in memory long enough for a dependency to access it; delete it;
and then recompute it again if necessary. (Also, if the value is a
tuple, we need to make sure to keep it around just long enough for all
of its followup tasks to run. If it weren't for this extra constraint,
we could solve this by just computing these uncached values (and their
uncached dependencies) lazily each time; but that would mean any task
that produces a pair of values would always get run twice.)

Previously the only values we evicted from memory were draft values.
This was easy to do because we know that draft values are only ever
accessed by their followup tasks, so once the followups are done, it's
safe to delete the draft value forever. However, now we want
to delete values that might be accessed later, so we need to be able to
recompute them on demand. This required the following changes:

1. We need a mechanism to delete requirements that are no longer needed.
We delete a requirement if (a) the requirement's source entry is fully
completed (`CACHED`), or (b) the requirement is marked "transient" and
its destination is fully completed. ("Transient" requirements are for
things like followup tasks, where we need an entry to be completed but
there's no other entry waiting for it.)

2. We now have one extra priority level: some followup tasks are not
just `HIGH` but `TOP` priority. The idea here is that if you have a
tuple, it's more urgent to break it into smaller pieces than it is to
process those individual pieces. This approach helps us get those pieces
out of memory as early as possible.

3. We need to actually delete each temporarily-memoized value from
memory at the right time. This can be either right after a child task
uses the value, or right after computing a value that no one is waiting
for (which can happen with followup tasks). Note that we don't do this
eviction for actual entity values, because that would be a breaking
change; we still just do this for draft values. We use a new
`should_memoize_for_query` field on `DescriptorMetadata` to determine
which values we should do this for.