### PR TITLE
Speed up fake AIP tests

### DIFF
--- a/bionic/aip/task.py
+++ b/bionic/aip/task.py
@@ -34,16 +34,26 @@ class Config:
     Attributes
     ----------
     uuid: str
-        The globally unique job name on AI platform
+        The globally unique job name on AI platform.
     image_uri: str
-        The full address on gcr of the docker image for the tasks
+        The full address on gcr of the docker image for the tasks.
     project: str
-        The GCP project where the jobs will be run
+        The GCP project where the jobs will be run.
+    poll_period_seconds: float
+        How many seconds to wait between polling calls to AIP while waiting for jobs
+        to complete.
+    account: str, optional
+        The GCP service account to use. Corresponds to AIP's
+        `TrainingInput.serviceAccount`.
+    network: str, optional
+        The name of the Google Compute Engine network with which jobs are peered.
+        Corresponds to AIP's `TrainingInput.network`.
     """
 
     uuid: str
     image_uri: str
     project_name: str
+    poll_period_seconds: float
     account: Optional[str] = None
     network: Optional[str] = None
 
@@ -135,7 +145,7 @@ class Task:
     def wait_for_results(self, gcs_fs, aip_client):
         state, error = self._get_state_and_error(aip_client)
         while state.is_executing():
-            time.sleep(10)
+            time.sleep(self.config.poll_period_seconds)
             state, error = self._get_state_and_error(aip_client)
             logging.info(f"Future for {self.job_id} has state {state}")
 

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1898,6 +1898,7 @@ def create_default_flow_config():
     builder.assign(
         "core__aip_execution__docker_image_name", "bionic:latest", persist=False
     )
+    builder.assign("core__aip_execution__poll_period_seconds", 10, persist=False)
 
     @builder
     @decorators.immediate
@@ -1919,6 +1920,7 @@ def create_default_flow_config():
         core__aip_execution__enabled,
         core__aip_execution__gcp_project_name,
         core__aip_execution__docker_image_uri,
+        core__aip_execution__poll_period_seconds,
         core__flow_name,
     ):
         if not core__aip_execution__enabled:
@@ -1940,6 +1942,7 @@ def create_default_flow_config():
             uuid=f"{core__flow_name}_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
             project_name=core__aip_execution__gcp_project_name,
             image_uri=core__aip_execution__docker_image_uri,
+            poll_period_seconds=core__aip_execution__poll_period_seconds,
         )
 
     @builder

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -172,6 +172,7 @@ def aip_builder(gcs_builder, gcp_project, use_fake_gcp, gcs_fs, tmp_path):
     gcs_builder.set("core__aip_execution__gcp_project_name", gcp_project)
 
     if use_fake_gcp:
+        gcs_builder.set("core__aip_execution__poll_period_seconds", 0.1)
         gcs_builder.set("core__aip_client", FakeAipClient(gcs_fs, tmp_path))
 
     return gcs_builder


### PR DESCRIPTION
These tests currently take 30 seconds because we have a fixed 10-second
polling period, which makes sense for real AIP but not for our fake
version. I've made this period configurable and set it to 0.1 seconds
for fake AIP.