### PR TITLE
Optionally disable query-scoped caching

### DIFF
--- a/bionic/deriver.py
+++ b/bionic/deriver.py
@@ -329,6 +329,9 @@ class EntityDeriver:
             should_persist_default=self._compute_core_entity(
                 "core__persist_by_default"
             ),
+            should_memoize_for_query_if_uncached=self._compute_core_entity(
+                "core__temp_memoize_if_uncached"
+            ),
             task_key_logging_level=logging.INFO,
         )
         self._core_is_final = True
@@ -473,13 +476,16 @@ class EntityDeriver:
                 logger.warn(oneline(message))
                 should_persist = False
 
+            should_memoize_for_query = (
+                self._core.should_memoize_for_query_if_uncached
+                and not (should_memoize or should_persist)
+            )
+
             return DescriptorMetadata(
                 protocol=entity_def.protocol,
                 doc=entity_def.doc,
                 should_memoize=should_memoize,
-                # If we don't have any other caching enabled for this entity, we memoize
-                # it for the lifetime of the current query.
-                should_memoize_for_query=(not (should_memoize or should_persist)),
+                should_memoize_for_query=should_memoize_for_query,
                 should_persist=should_persist,
             )
 
@@ -707,6 +713,7 @@ class ExecutionCore:
     gcs_fs = attr.ib()
     should_memoize_default = attr.ib(type=bool)
     should_persist_default = attr.ib(type=bool)
+    should_memoize_for_query_if_uncached = attr.ib(type=bool)
     task_key_logging_level = attr.ib()
 
     def evolve(self, **kwargs):
@@ -724,6 +731,7 @@ BOOTSTRAP_CORE = ExecutionCore(
     gcs_fs=None,
     should_memoize_default=True,
     should_persist_default=False,
+    should_memoize_for_query_if_uncached=False,
     task_key_logging_level=logging.DEBUG,
 )
 

--- a/bionic/flow.py
+++ b/bionic/flow.py
@@ -1757,6 +1757,7 @@ def create_default_flow_config():
 
     builder.assign("core__memoize_by_default", True, persist=False)
     builder.assign("core__persist_by_default", True, persist=False)
+    builder.assign("core__temp_memoize_if_uncached", True, persist=False)
     builder.assign("core__persistent_cache__global_dir", "bndata", persist=False)
     builder.assign("core__versioning_mode", "manual", persist=False)
 

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -1473,10 +1473,20 @@ def test_non_memoized_complex_tuples_are_garbage_collected(builder, make_tracked
     assert builder.build().get("x_plus_two") == 3
 
 
-# When an entity has both persistence and memoization disabled, we memoize it just
-# for the duration of the get() call.
-def test_uncached_values_cached_for_query_duration(builder, make_counter):
+# When an entity has both persistence and memoization disabled, we memoize it just for
+# the duration of the get() call. However, we may want to disable this behavior in the
+# future; for the time being it's configurable (but undocumented).
+@pytest.mark.parametrize("disable_query_caching", [False, True])
+def test_uncached_values_cached_for_query_duration(
+    builder, make_counter, disable_query_caching
+):
     x_counter = make_counter()
+
+    if disable_query_caching:
+        builder.set("core__temp_memoize_if_uncached", False)
+        expected_x_calls_per_query = 2
+    else:
+        expected_x_calls_per_query = 1
 
     builder.set("core__persist_by_default", False)
     builder.set("core__memoize_by_default", False)
@@ -1503,7 +1513,7 @@ def test_uncached_values_cached_for_query_duration(builder, make_counter):
     flow = builder.build()
 
     assert flow.get("y_x_cubed") == 24
-    assert x_counter.times_called() == 1
+    assert x_counter.times_called() == expected_x_calls_per_query
 
     assert flow.get("y_x_cubed") == 24
-    assert x_counter.times_called() == 1
+    assert x_counter.times_called() == expected_x_calls_per_query


### PR DESCRIPTION
I added a new (undocumented) config entity that disables temporary
query-scoped caching. This means resolving [this issue](#296) is just a matter of
updating this entity's default value. All we need to do now is advertise
the proposed change and make sure it won't break anyone's code.