### PR TITLE
Remove warning emitted by our tests

### DIFF
--- a/bionic/code_references.py
+++ b/bionic/code_references.py
@@ -191,20 +191,18 @@ def get_referenced_objects(code, context):
                 # module using the import statement. If a user is importing
                 # modules inside a function, they probably don't want to import
                 # the module until the function execution time.
-                message = oneline(
-                    f"""
-                Bionic found a code reference in file ${code.co_filename} at line
-                ${lineno} that imports ${op.argval} module when hashing
-                ${code.co_name}. Changes inside the module will likely not be
-                detected. To detect changes inside the module, import it globally
-                instead.
+                message = f"""
+                Entity function in file {code.co_filename} imports the
+                '{op.argval}' module at line {lineno};
+                Bionic will not be able to automatically detect any changes to this
+                module.
+                To enable automatic detection of changes, import the module at the
+                global level (outside the function) instead.
 
-                You can also suppress this warning by removing the
-                `suppress_bytecode_warnings` override from the `@version`
-                decorator on the corresponding function.
-                """
-                )
-                warnings.warn(message)
+                To suppress this warning, remove the `suppress_bytecode_warnings`
+                override from the `@version` decorator on the corresponding function.
+                f"""
+                warnings.warn(oneline(message))
                 set_tos(None)
             elif op.opname in ["LOAD_METHOD", "LOAD_ATTR"]:
                 if isinstance(tos, PlaceholderTos):

--- a/tests/test_code_references.py
+++ b/tests/test_code_references.py
@@ -1,3 +1,5 @@
+import pytest
+
 import logging
 
 from bionic.code_references import get_code_context, get_referenced_objects
@@ -33,7 +35,8 @@ def test_empty_references():
 
         return warnings
 
-    assert get_references(x) == []
+    with pytest.warns(UserWarning, match=".*imports the 'warnings' module.*"):
+        assert get_references(x) == []
 
 
 def test_global_references():


### PR DESCRIPTION
Also reword the module import warning message from code_references.py