### PR TITLE
Improve error messages from log regex tests

### DIFF
--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -1,6 +1,5 @@
 import getpass
 import random
-import re
 from multiprocessing.managers import SyncManager
 from typing import Optional
 
@@ -11,6 +10,7 @@ import bionic as bn
 from bionic.gcs import get_gcs_fs_without_warnings
 from .fakes import FakeGcsFs, FakeAipClient
 from ..helpers import (
+    assert_messages_match_regexes,
     SimpleCounter,
     ResettingCallCounter,
 )
@@ -264,11 +264,11 @@ class LogChecker:
         self._caplog.clear()
 
     def expect_regex(self, *expected_patterns):
-        messages = self._pop_messages()
-        for pattern in expected_patterns:
-            assert any(
-                re.fullmatch(pattern, message, flags=re.DOTALL) for message in messages
-            )
+        assert_messages_match_regexes(
+            self._pop_messages(),
+            expected_patterns,
+            allow_unmatched_messages=True,
+        )
 
     def _pop_messages(self):
         messages = [self._format_message(record) for record in self._caplog.records]

--- a/tests/test_flow/test_persistence_aip.py
+++ b/tests/test_flow/test_persistence_aip.py
@@ -67,7 +67,7 @@ def test_aip_jobs(aip_builder, log_checker):
     log_checker.expect_regex(
         r"Staging AI Platform task .* at gs://.*bionic_y1.*",
         r"Started AI Platform task: https://console.cloud.google.com/ai-platform/jobs/.*bionic_y1.*",
-        r"Submitting AI Platform task .*TaskKey\(dnode=EntityNode\(name='y1'\), case_key=CaseKey\(x1=1\)\).*",
+        r"Submitting AI Platform task .*\(name='y1'\).*CaseKey\(x1=1\).*",
         r"Computed   y1\(x1=1\) using AI Platform",
         r"Downloading y1\(x1=1\) from GCS \.\.\.",
     )
@@ -78,7 +78,7 @@ def test_aip_jobs(aip_builder, log_checker):
         r"Loaded     y1\(x1=1\) from disk cache",
         r"Staging AI Platform task .* at gs://.*bionic_y2.*",
         r"Started AI Platform task: https://console.cloud.google.com/ai-platform/jobs/.*bionic_y2.*",
-        r"Submitting AI Platform task .*TaskKey\(dnode=EntityNode\(name='y2'\), case_key=CaseKey\(x1=1\)\).*",
+        r"Submitting AI Platform task .*\(name='y2'\).*CaseKey\(x1=1\).*",
         r"Computed   y2\(x1=1\) using AI Platform",
         r"Downloading y2\(x1=1\) from GCS \.\.\.",
         r"Computed   y3\(x1=1\)",
@@ -103,8 +103,7 @@ def test_aip_fail(aip_builder, log_checker):
 
     log_checker.expect_regex(
         r"Staging AI Platform task .* at gs://.*bionic_x_plus_one.*",
-        r"Submitting AI Platform task on .*x_plus_one.*x=1.*",
         r"Started AI Platform task: https://console.cloud.google.com/ai-platform/jobs/.*bionic_x_plus_one.*",
-        r"Submitting AI Platform task .*TaskKey\(dnode=EntityNode\(name='x_plus_one'\), case_key=CaseKey\(x=1\)\).*",
+        r"Submitting AI Platform task .*\(name='x_plus_one'\).*CaseKey\(x=1\).*",
         r".*error while doing remote computation for x_plus_one\(x=1\).*AipError.*",
     )


### PR DESCRIPTION
When `LogChecker.expect_regex` fails, it now prints a list of the
messages and regexes that failed to match; this makes failures much
easier to debug.