### PR TITLE
Cache object hashes within CodeHasher

### DIFF
--- a/bionic/code_hasher.py
+++ b/bionic/code_hasher.py
@@ -61,90 +61,108 @@ class CodeHasher:
     """
 
     def __init__(self, suppress_warnings):
-        self._hash = hashlib.new("md5")
         self._suppress_warnings = suppress_warnings
         # This is used to detect circular references.
         self._object_depths_by_id = {}
+        # This caches the hashed values for objects we have already
+        # hashed.
+        self._obj_hash_digests_by_id = {}
+        # This stores the objects that we have hashed. If we don't
+        # store the objects, the objects can get garbage-collected,
+        # and new objects can reuse the same object id as the
+        # garbage-collected objects. Doing so ensures that the ids
+        # for the hashes we cache are not reused.
+        # See this stack overflow post for more details:
+        # https://stackoverflow.com/questions/35173479/why-do-different-methods-of-same-object-have-the-same-id
+        self._encountered_objects_by_id = {}
 
     @classmethod
     def hash(cls, obj, suppress_warnings=False):
         hasher = cls(suppress_warnings)
-        hasher._check_and_ingest(obj=obj)
-        return hasher._hash.hexdigest()
+        return hasher.hash_for_obj(obj)
 
-    def hexdigest(self):
-        return self._hash.hexdigest()
+    def hash_for_obj(self, obj):
+        return str(self._check_and_hash(obj))
 
-    def update(self, obj):
-        return self._check_and_ingest(obj)
-
-    def _ingest_raw_prefix_and_bytes(self, type_prefix, obj_bytes=b""):
-        self._hash.update(type_prefix.value)
-        self._hash.update(get_size_as_bytes(obj_bytes))
-        self._hash.update(PREFIX_SEPARATOR)
-        self._hash.update(obj_bytes)
-
-    def _check_and_ingest(self, obj, code_context=None):
+    def _check_and_hash(self, obj, code_context=None):
         """
-        Checks for circular references before calling the _ingest
-        method, which does the actual encoding.
+        Checks for circular references and cached hashes before calling
+        the _just_hash method, which does the actual encoding and
+        returns the hashed value of the `obj`.
         """
         obj_id = id(obj)
+        self._encountered_objects_by_id[obj_id] = obj
+
+        # If the hash is already cached, return the cached value.
+        if obj_id in self._obj_hash_digests_by_id:
+            return self._obj_hash_digests_by_id[obj_id]
 
         # If the obj is already being hashed, break the circular ref by
         # analyzing the depth of the value instead.
-        if obj_id in self._object_depths_by_id:
-            obj = self._object_depths_by_id[obj_id]
-            self._ingest_raw_prefix_and_bytes(
+        elif obj_id in self._object_depths_by_id:
+            hash_accumulator = hashlib.new("md5")
+            obj_depth = self._object_depths_by_id[obj_id]
+            add_to_hash(
+                hash_accumulator=hash_accumulator,
                 type_prefix=TypePrefix.CIRCULAR_REF,
-                obj_bytes=str(self._object_depths_by_id[obj_id]).encode(),
+                obj_bytes=str(obj_depth).encode(),
             )
-            return
+            obj_hash_digest_in_bytes = hash_accumulator.digest()
 
-        self._object_depths_by_id[obj_id] = len(self._object_depths_by_id)
-        self._ingest(obj, code_context)
-        del self._object_depths_by_id[obj_id]
+        # Compute the hash otherwise.
+        else:
+            self._object_depths_by_id[obj_id] = len(self._object_depths_by_id)
+            obj_hash_digest_in_bytes = self._just_hash(obj, code_context)
+            del self._object_depths_by_id[obj_id]
 
-    def _ingest(self, obj, code_context):
+        self._obj_hash_digests_by_id[obj_id] = obj_hash_digest_in_bytes
+        return obj_hash_digest_in_bytes
+
+    def _just_hash(self, obj, code_context):
+        hash_accumulator = hashlib.new("md5")
+        self._update_hash(hash_accumulator, obj, code_context)
+        return hash_accumulator.digest()
+
+    def _update_hash(self, hash_accumulator, obj, code_context):
         """
         Contains the logic that analyzes the objects and encodes them
-        into bytes that are added to the hash.
+        into bytes that are added to the hash_accumulator.
         """
         if isinstance(obj, bytes):
-            self._ingest_raw_prefix_and_bytes(
-                type_prefix=TypePrefix.BYTES, obj_bytes=obj
-            )
+            add_to_hash(hash_accumulator, type_prefix=TypePrefix.BYTES, obj_bytes=obj)
 
         elif isinstance(obj, bytearray):
-            self._ingest_raw_prefix_and_bytes(
-                type_prefix=TypePrefix.BYTEARRAY, obj_bytes=obj
+            add_to_hash(
+                hash_accumulator, type_prefix=TypePrefix.BYTEARRAY, obj_bytes=obj
             )
 
         elif obj is None:
-            self._ingest_raw_prefix_and_bytes(
-                type_prefix=TypePrefix.NONE, obj_bytes=b"None"
-            )
+            add_to_hash(hash_accumulator, type_prefix=TypePrefix.NONE)
 
         elif isinstance(obj, int):
-            self._ingest_raw_prefix_and_bytes(
+            add_to_hash(
+                hash_accumulator,
                 type_prefix=TypePrefix.INT,
                 obj_bytes=str(obj).encode(),
             )
 
         elif isinstance(obj, float):
-            self._ingest_raw_prefix_and_bytes(
+            add_to_hash(
+                hash_accumulator,
                 type_prefix=TypePrefix.FLOAT,
                 obj_bytes=str(obj).encode(),
             )
 
         elif isinstance(obj, str):
-            self._ingest_raw_prefix_and_bytes(
+            add_to_hash(
+                hash_accumulator,
                 type_prefix=TypePrefix.STRING,
                 obj_bytes=obj.encode(),
             )
 
         elif isinstance(obj, bool):
-            self._ingest_raw_prefix_and_bytes(
+            add_to_hash(
+                hash_accumulator,
                 type_prefix=TypePrefix.BOOL,
                 obj_bytes=str(obj).encode(),
             )
@@ -157,32 +175,51 @@ class CodeHasher:
             else:
                 type_prefix = TypePrefix.TUPLE
             obj_bytes = str(len(obj)).encode()
-            self._ingest_raw_prefix_and_bytes(
+            add_to_hash(
+                hash_accumulator,
                 type_prefix=type_prefix,
                 obj_bytes=obj_bytes,
             )
             for elem in obj:
-                self._check_and_ingest(elem, code_context)
+                add_to_hash(
+                    hash_accumulator,
+                    type_prefix=TypePrefix.HASH,
+                    obj_bytes=self._check_and_hash(elem, code_context),
+                )
 
         elif isinstance(obj, dict):
-            self._ingest_raw_prefix_and_bytes(
+            add_to_hash(
+                hash_accumulator,
                 type_prefix=TypePrefix.DICT,
                 obj_bytes=str(len(obj)).encode(),
             )
             for key, elem in obj.items():
-                self._check_and_ingest(key, code_context)
-                self._check_and_ingest(elem, code_context)
+                add_to_hash(
+                    hash_accumulator,
+                    type_prefix=TypePrefix.HASH,
+                    obj_bytes=self._check_and_hash(key, code_context),
+                )
+                add_to_hash(
+                    hash_accumulator,
+                    type_prefix=TypePrefix.HASH,
+                    obj_bytes=self._check_and_hash(elem, code_context),
+                )
 
         elif isinstance(obj, ReferenceProxy):
-            self._ingest_raw_prefix_and_bytes(
+            add_to_hash(
+                hash_accumulator,
                 type_prefix=TypePrefix.REF_PROXY,
                 obj_bytes=obj.val.encode(),
             )
 
         elif inspect.isbuiltin(obj):
-            self._ingest_raw_prefix_and_bytes(type_prefix=TypePrefix.BUILTIN)
+            add_to_hash(hash_accumulator, type_prefix=TypePrefix.BUILTIN)
             builtin_name = "%s.%s" % (obj.__module__, obj.__name__)
-            self._check_and_ingest(builtin_name)
+            add_to_hash(
+                hash_accumulator,
+                type_prefix=TypePrefix.HASH,
+                obj_bytes=self._check_and_hash(builtin_name, code_context),
+            )
 
         elif inspect.isroutine(obj):
             # TODO: See if we can get the version of the module and
@@ -190,32 +227,39 @@ class CodeHasher:
             if (
                 obj.__module__ is not None and obj.__module__.startswith("bionic")
             ) or is_internal_file(obj.__code__.co_filename):
-                self._ingest_raw_prefix_and_bytes(
-                    type_prefix=TypePrefix.INTERNAL_ROUTINE
-                )
+                add_to_hash(hash_accumulator, type_prefix=TypePrefix.INTERNAL_ROUTINE)
                 routine_name = "%s.%s" % (obj.__module__, obj.__name__)
-                self._check_and_ingest(routine_name)
+                add_to_hash(
+                    hash_accumulator,
+                    type_prefix=TypePrefix.HASH,
+                    obj_bytes=self._check_and_hash(routine_name),
+                )
             else:
-                self._ingest_raw_prefix_and_bytes(type_prefix=TypePrefix.ROUTINE)
+                add_to_hash(hash_accumulator, type_prefix=TypePrefix.ROUTINE)
                 code_context = get_code_context(obj)
-                self._check_and_ingest(obj.__defaults__, code_context)
-                self._ingest_code(obj.__code__, code_context)
+                add_to_hash(
+                    hash_accumulator,
+                    type_prefix=TypePrefix.HASH,
+                    obj_bytes=self._check_and_hash(obj.__defaults__, code_context),
+                )
+                self._update_hash_for_code(hash_accumulator, obj.__code__, code_context)
 
         elif inspect.iscode(obj):
-            self._ingest_raw_prefix_and_bytes(type_prefix=TypePrefix.CODE)
-            self._ingest_code(obj, code_context)
+            add_to_hash(hash_accumulator, type_prefix=TypePrefix.CODE)
+            self._update_hash_for_code(hash_accumulator, obj, code_context)
 
         elif inspect.isclass(obj):
             # TODO: Hashing classes is next on our roadmap. Let's hash
             # the name for now.
-            self._ingest_raw_prefix_and_bytes(
+            add_to_hash(
+                hash_accumulator,
                 type_prefix=TypePrefix.CLASS,
                 obj_bytes=obj.__name__.encode(),
             )
 
         else:
             # TODO: Verify that we hash all Python constant types.
-            self._ingest_raw_prefix_and_bytes(type_prefix=TypePrefix.DEFAULT)
+            add_to_hash(hash_accumulator, type_prefix=TypePrefix.DEFAULT)
             if not self._suppress_warnings:
                 # TODO: What else can we tell about this object to the user?
                 # Can we add line number, filename and object name?
@@ -237,10 +281,14 @@ class CodeHasher:
                 )
                 warnings.warn(message)
 
-    def _ingest_code(self, code, code_context):
+    def _update_hash_for_code(self, hash_accumulator, code, code_context):
         assert code_context is not None
 
-        self._check_and_ingest(code.co_code)
+        add_to_hash(
+            hash_accumulator,
+            type_prefix=TypePrefix.HASH,
+            obj_bytes=self._check_and_hash(code.co_code),
+        )
 
         # TODO: Maybe there is a way using which we can differentiate
         # between lambda variable names and string constants that end
@@ -250,13 +298,21 @@ class CodeHasher:
             for const in code.co_consts
             if not (isinstance(const, str) and const.endswith(".<lambda>"))
         ]
-        self._check_and_ingest(consts, code_context)
+        add_to_hash(
+            hash_accumulator,
+            type_prefix=TypePrefix.HASH,
+            obj_bytes=self._check_and_hash(consts, code_context),
+        )
 
         references = get_referenced_objects(code, code_context)
         # TODO: We should skip any referenced code objects since
         # they can't be analyzed with the current code's
         # code_context.
-        self._check_and_ingest(references, code_context)
+        add_to_hash(
+            hash_accumulator,
+            type_prefix=TypePrefix.HASH,
+            obj_bytes=self._check_and_hash(references, code_context),
+        )
 
 
 class TypePrefix(Enum):
@@ -289,9 +345,17 @@ class TypePrefix(Enum):
     BUILTIN = b"AP"
     CLASS = b"AQ"
     REF_PROXY = b"AR"
+    HASH = b"AS"
     DEFAULT = b"ZZ"
 
 
 def get_size_as_bytes(obj_bytes):
     assert isinstance(obj_bytes, (bytes, bytearray))
     return str(len(obj_bytes)).encode()
+
+
+def add_to_hash(hash_accumulator, type_prefix, obj_bytes=b""):
+    hash_accumulator.update(type_prefix.value)
+    hash_accumulator.update(get_size_as_bytes(obj_bytes))
+    hash_accumulator.update(PREFIX_SEPARATOR)
+    hash_accumulator.update(obj_bytes)

--- a/tests/test_code_references.py
+++ b/tests/test_code_references.py
@@ -239,6 +239,7 @@ def test_complex_function():
     import numpy as np
     import matplotlib.pyplot as plt
     from sklearn import linear_model
+    from sklearn.metrics import r2_score
 
     # Function for predicting future values :
     def get_regression_predictions(input_features, intercept, slope):
@@ -292,9 +293,8 @@ def test_complex_function():
             my_engine_size, regr.intercept_[0], regr.coef_[0][0]
         )
         logging.info("Estimated Emission :", estimatd_emission)
-        # Checking various accuracy:
-        from sklearn.metrics import r2_score
 
+        # Checking various accuracy:
         test_x = np.array(test[["ENGINESIZE"]])
         test_y = np.array(test[["CO2EMISSIONS"]])
         test_y_ = regr.predict(test_x)
@@ -346,4 +346,5 @@ def test_complex_function():
         logging.info,
         np.mean,
         logging.info,
+        r2_score,
     ]


### PR DESCRIPTION
This change keeps track of all the object hashes for a CodeHasher
instance and avoids hashing the same object multiple times using it.
We scope the object hashes to a CodeHasher instance instead of globally
to avoid using a stale hash in case an object change by the time we
hash it again.