### PR TITLE
Remove TODOs

### DIFF
--- a/bionic/code_hasher.py
+++ b/bionic/code_hasher.py
@@ -37,8 +37,6 @@ PREFIX_SEPARATOR = b"$"
 
 
 # List of things we should do before releasing Smart Caching:
-# - dedup references
-# - caching individual object hashes for a CodeHasher run
 # - hash classes
 # - Throw an exception for unhandled bytecode instruction type
 # - investigate if we can hash module or package versions


### PR DESCRIPTION
We use `func.__code__.co_code` to detect any changes to the function
code and hash of references to detect any changes to the code the
function uses. We don't need to hash the same reference multiple times
to detect changes to references. This change dedups the references to
avoid unneeded work for detecting changes.