### PR TITLE
Update deprecate gcloud github action

### DIFF
--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -42,7 +42,7 @@ jobs:
         # build failures.
         pip freeze
     - name: Set up gcloud
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true


### PR DESCRIPTION
This update should get rid of the following annotation warnings on our
CI runs.

```
Thank you for using setup-gcloud Action.
GoogleCloudPlatform/github-actions/setup-gcloud has been deprecated,
please switch to google-github-actions/setup-gcloud.
```