### PR TITLE
Hash class code in CodeHasher

### DIFF
--- a/bionic/code_hasher.py
+++ b/bionic/code_hasher.py
@@ -22,6 +22,7 @@ CACHE_SCHEMA_VERSION to update cache scheme.
 from enum import Enum
 import hashlib
 import inspect
+import types
 import warnings
 
 from .code_references import (
@@ -266,6 +267,12 @@ class CodeHasher:
                         inspect.ismethoddescriptor(m_value)
                         or inspect.isgetsetdescriptor(m_value)
                         or m_name in {"__class__", "__dict__", "__members__"}
+                        # TODO Remove this when hashing properties.
+                        or isinstance(m_value, property)
+                        # TODO These should be handled the same way as properties.
+                        or isinstance(m_value, types.DynamicClassAttribute)
+                        # TODO Remove this when hashing attr classes.
+                        or m_name == "__attrs_attrs__"
                     )
                 ]
                 add_to_hash(

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -333,8 +333,8 @@ won’t detect changes of the following types:
    global variables that have simple types (int, string, bool, bytes, etc.), but
    it will ignore changes for other types of variables.
 
-3. **Python Classes**: Bionic won’t detect changes to the code of Python classes.
-   [#classes_hash]_
+3. **Python Classes**: Bionic detects some but not all changes to the code of
+   Python classes.
 
 4. **Runtime Code**: Bionic doesn’t actually run any code when inspecting it, so
    it won’t recursively inspect functions that are referenced dynamically. If a
@@ -368,8 +368,6 @@ risk factors listed above.
 
 .. [#bytecode_hash] And any global variables and other functions they reference,
   and so on.
-
-.. [#classes_hash] However, we expect to change this in an upcoming release.
 
 
 Disabling Persistent Caching

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -81,8 +81,8 @@ Improvements
   <bionic.outputs>` decorator), those entities and the function itself are now
   all visualized with the same color.
 - When "assisted" or "fully automatic" :ref:`versioning <automatic-versioning>`
-  is enabled, Bionic now inspects not just entity functions, but also any
-  functions they reference.
+  is enabled, Bionic now inspects not just entity functions and values, but also
+  any functions they reference and the classes of entity values.
 
 0.9.2 (Oct 26, 2020)
 --------------------

--- a/tests/test_code_hasher.py
+++ b/tests/test_code_hasher.py
@@ -15,7 +15,6 @@ global_var_10_copy = 10
 global_var_20 = 20
 
 
-# TODO: Add tests for classes once we hash classes.
 def test_code_hasher():
     def barray(value):
         return bytearray(value, "utf8")
@@ -144,6 +143,55 @@ def test_code_hasher():
             def innermost():
                 logging.info(v, w)
 
+    class ClassDefault:
+        v = 1
+
+    class ClassWithInit:
+        v = 1
+
+        def __init__(self):
+            self.a = 1
+
+    class ClassWithDifferentInit:
+        v = 1
+
+        def __init__(self):
+            self.a = 2
+
+    class ClassWithInnerClass:
+        v = 1
+
+        def __init__(self):
+            self.a = 1
+
+        class InnerClass:
+            def __init__(self):
+                self.i = 1
+
+    class ClassWithDifferentInnerClass:
+        v = 1
+
+        def __init__(self):
+            self.a = 1
+
+        class InnerClass:
+            def __init__(self):
+                self.i = 2
+
+    class ClassWithMethod:
+        def v(self):
+            return 1
+
+    class ClassWithClassMethod1:
+        @classmethod
+        def v(cls):
+            return 10
+
+    class ClassWithClassMethod2:
+        @classmethod
+        def v(cls):
+            return 20
+
     values = [
         b"",
         b"123",
@@ -219,6 +267,14 @@ def test_code_hasher():
         f_docstring2,
         fib,
         nested,
+        ClassDefault,
+        ClassWithInit,
+        ClassWithDifferentInit,
+        ClassWithInnerClass,
+        ClassWithDifferentInnerClass,
+        ClassWithMethod,
+        ClassWithClassMethod1,
+        ClassWithClassMethod2,
     ]
 
     values_with_complex_types = [
@@ -318,6 +374,40 @@ def test_function_references():
         return ref20()
 
     check_hash_equivalence([[f1, f2], [f3]])
+
+
+def test_class_references():
+    # References change in dunder methods.
+    class C1:
+        def __init__(self):
+            self.v = global_var_10
+
+    class C2:
+        def __init__(self):
+            self.v = global_var_10_copy
+
+    class C3:
+        def __init__(self):
+            self.v = global_var_20
+
+    check_hash_equivalence([[C1, C2], [C3]])
+
+    # References change in normal methods.
+    class C1:
+        def my(self):
+            return global_var_10
+
+    class C2:
+        def my(self):
+            return global_var_10_copy
+
+    class C3:
+        def my(self):
+            return global_var_20
+
+    check_hash_equivalence([[C1, C2], [C3]])
+
+    check_hash_equivalence([[type(1), type(2)], [type("str1"), type("str2")]])
 
 
 def test_changes_in_references():

--- a/tests/test_code_hasher.py
+++ b/tests/test_code_hasher.py
@@ -275,6 +275,9 @@ def test_code_hasher():
         ClassWithMethod,
         ClassWithClassMethod1,
         ClassWithClassMethod2,
+        TypePrefix,
+        TypePrefix.BYTES,
+        TypePrefix.BYTEARRAY,
     ]
 
     values_with_complex_types = [
@@ -300,15 +303,16 @@ def test_code_hasher():
 
 
 def test_complex_type_warning():
-    val = threading.Lock()
+    lock = threading.Lock()
+    cond = threading.Condition()
     with pytest.warns(
         UserWarning,
         match="Found a complex object",
     ):
-        assert CodeHasher.hash(val) == CodeHasher.hash(TypePrefix.DEFAULT)
+        assert CodeHasher.hash(lock) == CodeHasher.hash(cond)
 
     with pytest.warns(None) as warnings:
-        assert CodeHasher.hash(val, True) == CodeHasher.hash(TypePrefix.DEFAULT, True)
+        assert CodeHasher.hash(lock, True) == CodeHasher.hash(cond, True)
     assert len(warnings) == 0
 
 

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -814,6 +814,94 @@ def test_indirect_versioning_auto(builder, make_counter):
     assert f_call_counter.times_called() == 0
 
 
+def test_versioning_auto_class_changes(builder, make_counter):
+    call_counter = make_counter()
+
+    # PicklableProtocol cannot pickle IntWrapper class because it is
+    # defined inside the test function. We instead use this custom
+    # protocol that wraps the PicklableProtocol to be able to serialize
+    # IntWrapper.
+    class IntWrapperProtocol(bn.protocols.PicklableProtocol):
+        def write(self, wrapper, path):
+            assert isinstance(wrapper, IntWrapper)
+            super().write(wrapper.value, path)
+
+        def read(self, path):
+            return IntWrapper(super().read(path))
+
+    class IntWrapper:
+        def __init__(self, value):
+            self.value = value
+
+        def __str__(self):
+            return f"IntWrapper: value={self.value}"
+
+    builder.set("core__versioning_mode", "auto")
+
+    builder.assign("x", 2)
+    builder.assign("y", 3)
+
+    @builder
+    @IntWrapperProtocol()
+    def wrapped_f(x, y):
+        return IntWrapper(x + y)
+
+    @builder
+    def f(wrapped_f):
+        call_counter.mark()
+        return wrapped_f.value
+
+    assert builder.build().get("f") == 5
+    assert builder.build().get("f") == 5
+    assert call_counter.times_called() == 1
+
+    builder.delete("wrapped_f")
+
+    @builder  # noqa: F811
+    @IntWrapperProtocol()
+    def wrapped_f(x, y):  # noqa: F811
+        return IntWrapper(x * y)
+
+    assert builder.build().get("f") == 6
+    assert call_counter.times_called() == 1
+
+    builder.delete("wrapped_f")
+
+    # No changes in the wrapper class.
+    class IntWrapper:  # noqa: F811
+        def __init__(self, value):
+            self.value = value
+
+        def __str__(self):
+            return f"IntWrapper: value={self.value}"
+
+    @builder  # noqa: F811
+    @IntWrapperProtocol()
+    def wrapped_f(x, y):  # noqa: F811
+        return IntWrapper(x * y)
+
+    assert builder.build().get("f") == 6
+    assert call_counter.times_called() == 0
+
+    builder.delete("wrapped_f")
+
+    # Make a change in the __str__ method.
+    class IntWrapper:  # noqa: F811
+        def __init__(self, value):
+            self.value = value
+
+        def __str__(self):
+            return f"value={self.value}"
+
+    @builder  # noqa: F811
+    @IntWrapperProtocol()
+    def wrapped_f(x, y):  # noqa: F811
+        return IntWrapper(x * y)
+
+    assert builder.build().get("f") == 6
+    assert call_counter.times_called() == 1
+
+
 def test_versioning_auto_with_local_refs(builder, make_counter):
     call_counter = make_counter()
 


### PR DESCRIPTION
With this change, Bionic now hashes classes with entity values as part
of content hash to invalidate cache. There are still some gaps with
this approach, like not hashing class properties. I'll add support for
class properties in a future PR, which will give me the opportunity to
get feedback on the approach as well.