### PR TITLE
Fix artifact deletion bug

### DIFF
--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -74,6 +74,12 @@ Upcoming Version (Not Yet Released)
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
 
+Bug Fixes
+.........
+
+- Fixed a bug where Bionic could crash when using parallel execution after manually
+  deleting some persisted artifacts (such as with the :ref:`Cache API <cache-api>`).
+
 Improvements
 ............
 


### PR DESCRIPTION
We had a bug where Bionic could crash (throw an exception) if we ran in
parallel mode after an artifact was manually deleted. This commit fixes
the bug and adds a couple of tests for this situation.

The problem was this: our system is supposed to detect artifact deletion
by clearing each TaskState's cache state when we create a new
TaskRunnerEntry for it. However, when we execute a task remotely, we
send over a whole subgraph that may include tasks that we never created
entries for, so we may have stale data for those tasks and think they
still have artifacts when they don't. When we try to actually run the
subgraph remotely, we fail to load those artifacts and then try to
re-run those tasks, but since we stripped off the Task object, that
fails.

To fix this, I updated the logic to explicitly identify and check the
task entries that need to be cached. This mostly involved refactoring
the subgraph code: instead of looking at which TaskStates are already
cahced (which could be stale), we identify the states that logically
need to be cached, and then let the runner code figure out if they
actually are.

I also made two other small changes:

1. We now handle the case where some of the outputs ("target states") of
a subgraph are already completed. This can happen if one function
generates multiple artifacts, and then just one of them is manually
deleted.

2. I tweaked the definition of "cached". Previously it was possible for
a persistable task to be "cached" if it had a memoized result but not
persisted artifact; this could only happen if the artifact was deleted,
and this case breaks the subgraph assumptions above. Now persistable
tasks are only "cached" if they have an artifact.