### PR TITLE
Skip code object references for hashing

### DIFF
--- a/tests/test_code_hasher.py
+++ b/tests/test_code_hasher.py
@@ -316,6 +316,27 @@ def test_complex_type_warning():
     assert len(warnings) == 0
 
 
+def test_code_type_refs_warning():
+    code1 = import_code.__code__
+    code2 = check_hash_equivalence.__code__
+
+    def print_code1():
+        logging.info(code1)
+
+    def print_code2():
+        logging.info(code2)
+
+    with pytest.warns(
+        UserWarning,
+        match="Found a complex object",
+    ):
+        assert CodeHasher.hash(print_code1) == CodeHasher.hash(print_code2)
+
+    with pytest.warns(None) as warnings:
+        assert CodeHasher.hash(print_code1, True) == CodeHasher.hash(print_code2, True)
+    assert len(warnings) == 0
+
+
 def test_same_func_different_names():
     def f1():
         v = 10


### PR DESCRIPTION
We find references for a function from it's code object using the code
context created from the function. These references won't necessarily
share the same context with the function.

This change stops sending the code context to hash the references. But
without a code context, we cannot hash a code object efficiently (since
we can't find it's references). For any references that are code
objects, this change also treats them as a complex type and emits a
warning instead.