### PR TITLE
Don't suppress bytecode warnings by default

### DIFF
--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -1,6 +1,7 @@
 from .flow import Flow, FlowBuilder  # noqa: F401
 from .decorators import (  # noqa: F401
     version,
+    version_no_warnings,
     output,
     outputs,
     docs,

--- a/bionic/code_hasher.py
+++ b/bionic/code_hasher.py
@@ -39,7 +39,6 @@ PREFIX_SEPARATOR = b"$"
 
 # List of things we should do before releasing Smart Caching:
 # - verify that we hash all Python constant types
-# - version.suppress_bytecode_warnings TODO
 # - skip and warn for referenced code objects
 # - add support for class properties and attr.Attribute
 

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -78,7 +78,7 @@ def version(
     ignore_bytecode: Boolean (default False)
         Whether this entity's bytecode should be ignored.
 
-    suppress_bytecode_warnings: Boolean (default True)
+    suppress_bytecode_warnings: Boolean (default False)
         Whether warnings from this entity's bytecode analysis should be ignored.
 
     Returns
@@ -95,7 +95,7 @@ def version(
         )
 
     if suppress_bytecode_warnings is None:
-        suppress_bytecode_warnings = True
+        suppress_bytecode_warnings = False
     if not isinstance(suppress_bytecode_warnings, bool):
         message = f"""
         Argument suppress_bytecode_warnings must be a boolean; got
@@ -117,6 +117,14 @@ def version(
             ),
         )
     )
+
+
+def version_no_warnings(major=None, minor=None):
+    """
+    Same as the `@version` decorator, but it suppresses all bytecode
+    warnings.
+    """
+    return version(major, minor, suppress_bytecode_warnings=True)
 
 
 # In the future I expect we'll have other caching options -- disabling in-memory

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -246,7 +246,7 @@ def test_versioning(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x * y
@@ -257,7 +257,7 @@ def test_versioning(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
@@ -268,7 +268,7 @@ def test_versioning(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(major=1, minor=1)
+    @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
@@ -277,7 +277,7 @@ def test_versioning(builder, make_counter):
     assert call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(major=1, minor=1)
+    @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x ** y
@@ -288,7 +288,7 @@ def test_versioning(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(major=2)
+    @bn.version_no_warnings(major=2)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x ** y
@@ -327,7 +327,7 @@ def test_indirect_versioning(builder, make_counter):
     assert f_call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return 4
@@ -337,7 +337,7 @@ def test_indirect_versioning(builder, make_counter):
     assert f_call_counter.times_called() == 1
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return len("xxxx")
@@ -347,7 +347,7 @@ def test_indirect_versioning(builder, make_counter):
     assert f_call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(1, minor=1)
+    @bn.version_no_warnings(1, minor=1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return len("xxxx")
@@ -399,7 +399,7 @@ def test_versioning_assist(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x * y
@@ -410,7 +410,7 @@ def test_versioning_assist(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
@@ -421,7 +421,7 @@ def test_versioning_assist(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(major=1, minor=1)
+    @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
@@ -430,7 +430,7 @@ def test_versioning_assist(builder, make_counter):
     assert call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(major=1, minor=1)
+    @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x ** y
@@ -441,7 +441,7 @@ def test_versioning_assist(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(major=2)
+    @bn.version_no_warnings(major=2)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x ** y
@@ -477,7 +477,7 @@ def test_versioning_assist_with_refs(builder, make_counter):
         builder.build().get("f")
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return op(x, y)
@@ -492,7 +492,7 @@ def test_versioning_assist_with_refs(builder, make_counter):
         builder.build().get("f")
 
     @builder  # noqa: F811
-    @bn.version(major=1, minor=1)
+    @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return op(x, y)
@@ -507,7 +507,7 @@ def test_versioning_assist_with_refs(builder, make_counter):
         builder.build().get("f")
 
     @builder  # noqa: F811
-    @bn.version(major=2)
+    @bn.version_no_warnings(major=2)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return op(x, y)
@@ -547,7 +547,7 @@ def test_indirect_versioning_assist(builder, make_counter):
         builder.build().get("f")
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return 4
@@ -557,7 +557,7 @@ def test_indirect_versioning_assist(builder, make_counter):
     assert f_call_counter.times_called() == 1
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return len("xxxx")
@@ -566,7 +566,7 @@ def test_indirect_versioning_assist(builder, make_counter):
         builder.build().get("f")
 
     @builder  # noqa: F811
-    @bn.version(1, minor=1)
+    @bn.version_no_warnings(1, minor=1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return len("xxxx")
@@ -685,7 +685,7 @@ def test_versioning_auto(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x * y
@@ -696,7 +696,7 @@ def test_versioning_auto(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
@@ -707,7 +707,7 @@ def test_versioning_auto(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(major=1, minor=1)
+    @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
@@ -716,7 +716,7 @@ def test_versioning_auto(builder, make_counter):
     assert call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(major=1, minor=1)
+    @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x ** y
@@ -727,7 +727,7 @@ def test_versioning_auto(builder, make_counter):
     builder.delete("f")
 
     @builder  # noqa: F811
-    @bn.version(major=2)
+    @bn.version_no_warnings(major=2)
     def f(x, y):  # noqa: F811
         call_counter.mark()
         return x ** y
@@ -768,7 +768,7 @@ def test_indirect_versioning_auto(builder, make_counter):
     assert f_call_counter.times_called() == 1
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return 4
@@ -780,7 +780,7 @@ def test_indirect_versioning_auto(builder, make_counter):
     assert f_call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(1)
+    @bn.version_no_warnings(1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return len("xxxx")
@@ -792,7 +792,7 @@ def test_indirect_versioning_auto(builder, make_counter):
     assert f_call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(1, minor=1)
+    @bn.version_no_warnings(1, minor=1)
     def y():  # noqa: F811
         y_call_counter.mark()
         return len("xxxx")
@@ -1083,7 +1083,7 @@ def test_versioning_auto_version_options(builder):
     # With suppress_bytecode_warnings as False, bytecode analysis
     # throws a warning.
     @builder  # noqa: F811
-    @bn.version(major=2, suppress_bytecode_warnings=False)
+    @bn.version(major=2)
     def x():  # noqa: F811
         assert complex_number is not None
         return 1

--- a/tests/test_flow/test_persistence_fuzz.py
+++ b/tests/test_flow/test_persistence_fuzz.py
@@ -170,7 +170,7 @@ class SimpleFlowModel:
                 f"""
             @builder
             @bn.changes_per_run({e.is_nondeterministic})
-            @bn.version(major={e.major_version}, minor={e.minor_version})
+            @bn.version_no_warnings(major={e.major_version}, minor={e.minor_version})
             def {name}({', '.join(e.dep_names)}):
                 noop_func({e.nonfunc_value})
                 record_call("{name}")

--- a/tests/test_flow/test_persistence_gcs.py
+++ b/tests/test_flow/test_persistence_gcs.py
@@ -152,7 +152,7 @@ def test_versioning(preset_gcs_builder, make_counter):
         flow.get("xy")
 
     @builder  # noqa: F811
-    @bn.version(minor=1)
+    @bn.version_no_warnings(minor=1)
     def xy(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
@@ -171,7 +171,7 @@ def test_versioning(preset_gcs_builder, make_counter):
     assert call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(major=1)
+    @bn.version_no_warnings(major=1)
     def xy(x, y):  # noqa: F811
         call_counter.mark()
         return x ** y
@@ -195,7 +195,7 @@ def test_indirect_versioning(preset_gcs_builder, make_counter):
     builder = preset_gcs_builder
 
     @builder
-    @bn.version(major=1)
+    @bn.version_no_warnings(major=1)
     def xy(x, y):
         call_counter.mark()
         return x ** y
@@ -214,7 +214,7 @@ def test_indirect_versioning(preset_gcs_builder, make_counter):
     assert call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(major=1)
+    @bn.version_no_warnings(major=1)
     def xy(x, y):  # noqa: F811
         call_counter.mark()
         return int(float(x)) ** y
@@ -224,7 +224,7 @@ def test_indirect_versioning(preset_gcs_builder, make_counter):
         flow.get("xy_plus")
 
     @builder  # noqa: F811
-    @bn.version(major=1, minor=1)
+    @bn.version_no_warnings(major=1, minor=1)
     def xy(x, y):  # noqa: F811
         call_counter.mark()
         return int(float(y)) ** x
@@ -235,7 +235,7 @@ def test_indirect_versioning(preset_gcs_builder, make_counter):
     assert call_counter.times_called() == 0
 
     @builder  # noqa: F811
-    @bn.version(major=2)
+    @bn.version_no_warnings(major=2)
     def xy(x, y):  # noqa: F811
         call_counter.mark()
         return y ** x

--- a/tests/test_flow/test_persistence_random.py
+++ b/tests/test_flow/test_persistence_random.py
@@ -455,7 +455,7 @@ class ModelBinding:
         raw_func_code = f"""
         @builder
         {output_decorator_fragment}
-        @bn.version({self.annotated_func_version})
+        @bn.version_no_warnings({self.annotated_func_version})
         @bn.persist({self.should_persist})
         @bn.memoize({self.should_memoize})
         def _({joined_dep_entity_names}):


### PR DESCRIPTION
I also considered skipping `ResettingCallCounter` in `CodeHasher`
logic. But I think that it's cleaner to have a bunch of version
decorators with `suppress_bytecode_warnings=True` than to bleed
test behavior into the real hashing logic.