### PR TITLE
Clarify TupleProtocol error message

### DIFF
--- a/bionic/protocols.py
+++ b/bionic/protocols.py
@@ -83,7 +83,7 @@ class BaseProtocol:
     def _raise_validation_exception(self, descriptor_text, exception):
         message = f"""
         Value received for {descriptor_text} is not valid for
-        {self.__class__.__name__} due to {exception.__class__}:
+        {self.__class__.__name__} due to {exception.__class__.__name__}:
         {exception}
         """
         raise EntityValueError(oneline(message)) from exception
@@ -876,8 +876,16 @@ class TupleProtocol(BaseProtocol):
     def validate(self, value):
         try:
             items = tuple(value)
-        except TypeError as e:
-            raise AssertionError(str(e))
+        except TypeError:
+            message = f"""
+            Expected a sequence with length {self._expected_length};
+            instead, got non-sequence value {value!r}.
+            """
+            if self._expected_length == 1:
+                message += f"""
+                {"Did you mean to use @output instead of @outputs?"}
+                """
+            raise AssertionError(oneline(message))
         if len(items) != self._expected_length:
             message = f"""
             Expected a sequence with length {self._expected_length};

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -107,6 +107,11 @@ Improvements
   serialized non-deterministically, which could lead to downstream values being
   spuriously recomputed. (Unfortunately this fix doesn't help with other objects that
   happen to contain sets.)
+- Clarified an `error message <https://github.com/square/bionic/issues/331>`__ that
+  occurs when users pass a single argument to @bn.outputs instead of using @bn.output.
+  TupleProtocol's validate method now provides more information about what is expected
+  and, in the case when a user passes a single argument, asks if the user meant to
+  use @bn.output instead.
 
 Bug Fixes
 .........

--- a/tests/test_flow/test_outputs.py
+++ b/tests/test_flow/test_outputs.py
@@ -126,9 +126,21 @@ def test_wrong_number_of_outputs(builder):
 def test_non_sequence_outputs(builder):
     @builder
     @bn.outputs("a", "b")
-    def three_outputs():
+    def non_sequence_output():
         return 1
 
     flow = builder.build()
     with pytest.raises(EntityValueError):
         flow.get("a")
+
+
+def test_non_sequence_outputs_message(builder):
+    @builder
+    @bn.outputs("a")
+    def non_sequence_output():
+        return 7
+
+    flow = builder.build()
+    with pytest.raises(EntityValueError) as e:
+        flow.get("a")
+        assert "did you mean to use @output instead of @outputs?" in e.value


### PR DESCRIPTION
Addressing the confusing error message issue in #331 - added a _raise_validation_exception message specific to TupleProtocol with a clearer message. Added test_non_sequence_output to test_outputs.py for thoroughness, and changed function name `three_outputs` in `test_non_sequence_outputs` to `non_sequence_output` since that function just returns a single int. 