### PR TITLE
Suppress import warnings

### DIFF
--- a/bionic/code_references.py
+++ b/bionic/code_references.py
@@ -206,18 +206,21 @@ def get_referenced_objects(code, context, suppress_warnings=False):
                 # module using the import statement. If a user is importing
                 # modules inside a function, they probably don't want to import
                 # the module until the function execution time.
-                message = f"""
-                Entity function in file {code.co_filename} imports the
-                '{op.argval}' module at line {lineno};
-                Bionic will not be able to automatically detect any changes to this
-                module.
-                To enable automatic detection of changes, import the module at the
-                global level (outside the function) instead.
+                if not suppress_warnings:
+                    message = f"""
+                    Entity function in file {code.co_filename} imports the
+                    '{op.argval}' module at line {lineno};
+                    Bionic will not be able to automatically detect any
+                    changes to this module.
+                    To enable automatic detection of changes, import the
+                    module at the global level (outside the function)
+                    instead.
 
-                To suppress this warning, remove the `suppress_bytecode_warnings`
-                override from the `@version` decorator on the corresponding function.
-                f"""
-                warnings.warn(oneline(message))
+                    To suppress this warning, remove the
+                    `suppress_bytecode_warnings` override from the `@version`
+                    decorator on the corresponding function.
+                    f"""
+                    warnings.warn(oneline(message))
                 set_tos(None)
             elif op.opname in ["LOAD_METHOD", "LOAD_ATTR"]:
                 if isinstance(tos, ReferenceProxy):

--- a/bionic/code_references.py
+++ b/bionic/code_references.py
@@ -84,7 +84,27 @@ def get_code_context(func) -> CodeContext:
     if inspect.ismethod(func):
         varnames = {"self": func.__self__}
 
-    return CodeContext(globals=func.__globals__, cells=cells, varnames=varnames)
+    return CodeContext(
+        globals=func.__globals__,
+        cells=cells,
+        varnames=varnames,
+    )
+
+
+def make_suppression_advice(func_name=None):
+    message = """
+    To suppress this warning, apply the following decorator to the top-level
+    Bionic entity function:
+    @version(suppress_bytecode_warnings=True).
+    """
+    if func_name is not None:
+        message = (
+            f"""
+        The issue is in the {func_name!s} function.
+        """
+            + message
+        )
+    return message
 
 
 def get_referenced_objects(code, context, suppress_warnings=False):
@@ -167,11 +187,7 @@ def get_referenced_objects(code, context, suppress_warnings=False):
                     Please raise a new issue at
                     https://github.com/square/bionic/issues to let us know.
                     """
-                message += """
-                You can also suppress this warning by removing the
-                `suppress_bytecode_warnings` override from the
-                `@version` decorator on the corresponding function.
-                """
+                message += make_suppression_advice(code.co_name)
                 warnings.warn(oneline(message))
             # Sometimes starts_line is None, in which case let's just remember the
             # previous start_line (if any). This way when there's an exception we at
@@ -208,19 +224,16 @@ def get_referenced_objects(code, context, suppress_warnings=False):
                 # the module until the function execution time.
                 if not suppress_warnings:
                     message = f"""
-                    Entity function in file {code.co_filename} imports the
-                    '{op.argval}' module at line {lineno};
-                    Bionic will not be able to automatically detect any
-                    changes to this module.
-                    To enable automatic detection of changes, import the
-                    module at the global level (outside the function)
-                    instead.
-
-                    To suppress this warning, remove the
-                    `suppress_bytecode_warnings` override from the `@version`
-                    decorator on the corresponding function.
-                    f"""
-                    warnings.warn(oneline(message))
+                    The function {code.co_name!r} in file {code.co_filename}
+                    imports the '{op.argval}' module at line {lineno};
+                    if this module's code changes, Bionic will not be able to
+                    detect that this function needs to be recomputed.
+                    To make this detection possible, import the module at the
+                    global level (outside the function) instead.
+                    """
+                    warnings.warn(
+                        oneline(message + make_suppression_advice(code.co_name))
+                    )
                 set_tos(None)
             elif op.opname in ["LOAD_METHOD", "LOAD_ATTR"]:
                 if isinstance(tos, ReferenceProxy):

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -80,7 +80,8 @@ Bug Fixes
 - Fixes an issue where automatic versioning erroneously treated classes as
   having changed if the module they were defined in was run as ``__main__``.
 - Fixed a bug in Bionic's automatic versioning where Bionic would warn about
-  dynamic imports even when warning suppression was requested.
+  dynamic imports even when warning suppression was requested. The warning
+  messages themselves were also improved.
 
 Improvements
 ............

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -68,12 +68,6 @@ For each release, we list the following types of change (in this order):
 Upcoming Version (Not Yet Released)
 -----------------------------------
 
-Improvements
-............
-
-- Added a line to the SVG DAG visualization mouse hover tooltips indicating whether 
-  an entity is persisted.
-
 .. Record any notable changes in this section. When we update the current version,
    add a new version heading below, and then comment out the heading above until more
    changes are added. This way, the "Upcoming Version" section will be never be visible
@@ -81,13 +75,28 @@ Improvements
    "latest" docs (corresponding to the master branch).
 
 Bug Fixes
----------
+.........
 
 - Fixes an issue where automatic versioning erroneously treated classes as
   having changed if the module they were defined in was run as ``__main__``.
+- Fixed a bug in Bionic's automatic versioning where Bionic would warn about
+  dynamic imports even when warning suppression was requested.
+
+Improvements
+............
+
+- Added a line to the SVG DAG visualization mouse hover tooltips indicating
+  whether an entity is persisted.
+- Clarified an `error message
+  <https://github.com/square/bionic/issues/331>`__ that occurs when users pass
+  a single argument to ``@bn.outputs`` instead of using ``@bn.output``. The
+  error message now provides more information about what is expected and, in
+  the case when a user passes a single argument, asks if the user meant to
+  use ``@bn.output`` instead.
+
 
 0.10.0 (Feb 23, 2021)
---------------------
+---------------------
 
 New Features
 ............
@@ -107,11 +116,6 @@ Improvements
   serialized non-deterministically, which could lead to downstream values being
   spuriously recomputed. (Unfortunately this fix doesn't help with other objects that
   happen to contain sets.)
-- Clarified an `error message <https://github.com/square/bionic/issues/331>`__ that
-  occurs when users pass a single argument to @bn.outputs instead of using @bn.output.
-  TupleProtocol's validate method now provides more information about what is expected
-  and, in the case when a user passes a single argument, asks if the user meant to
-  use @bn.output instead.
 
 Bug Fixes
 .........

--- a/tests/test_code_references.py
+++ b/tests/test_code_references.py
@@ -50,7 +50,9 @@ def test_empty_references():
 
         return warnings
 
-    with pytest.warns(UserWarning, match=".*imports the 'warnings' module.*"):
+    with pytest.warns(
+        UserWarning, match="function 'x'.*imports the 'warnings' module.*"
+    ):
         assert get_references(x) == []
 
     with pytest.warns(None) as recorded_warnings:

--- a/tests/test_code_references.py
+++ b/tests/test_code_references.py
@@ -14,9 +14,9 @@ from bionic.utils.misc import oneline
 global_val = 42
 
 
-def get_references(func):
+def get_references(func, **kwargs):
     context = get_code_context(func)
-    return get_referenced_objects(func.__code__, context)
+    return get_referenced_objects(func.__code__, context, **kwargs)
 
 
 def test_bytecode_instructions():
@@ -52,6 +52,10 @@ def test_empty_references():
 
     with pytest.warns(UserWarning, match=".*imports the 'warnings' module.*"):
         assert get_references(x) == []
+
+    with pytest.warns(None) as recorded_warnings:
+        assert get_references(x, suppress_warnings=True) == []
+    assert len(recorded_warnings) == 0
 
 
 def test_global_references():


### PR DESCRIPTION
Bionic was wasn't respecting the `suppress_warnings` flag when it
encountered a dynamic import during automatic versioning. This fixes it.