### PR TITLE
Always emit versioning warnings when appropriate

### DIFF
--- a/bionic/datatypes.py
+++ b/bionic/datatypes.py
@@ -327,7 +327,7 @@ class CodeVersioningPolicy:
 
     version: CodeVersion = attr.ib()
     suppress_bytecode_warnings: bool = attr.ib(
-        converter=attr.converters.default_if_none(True)
+        converter=attr.converters.default_if_none(False)
     )
 
 

--- a/bionic/decorators.py
+++ b/bionic/decorators.py
@@ -87,16 +87,19 @@ def version(
         A decorator which can be applied to an entity function.
     """
 
-    if ignore_bytecode is None:
-        ignore_bytecode = False
-    if not isinstance(ignore_bytecode, bool):
+    # We don't replace any None values with defaults here; instead we let the
+    # CodeVersion and CodeVersioningPolicy constructors apply their own
+    # defaults. That way the defaults for this decorator are the same as for an
+    # undecorated function. (However, we do have to make sure the documentation
+    # of this decorator stays in sync with those defaults.)
+
+    if not isinstance(ignore_bytecode, (bool, type(None))):
         raise ValueError(
             f"Argument ignore_bytecode must be a boolean; got {ignore_bytecode!r}"
         )
+    includes_bytecode = None if ignore_bytecode is None else not ignore_bytecode
 
-    if suppress_bytecode_warnings is None:
-        suppress_bytecode_warnings = False
-    if not isinstance(suppress_bytecode_warnings, bool):
+    if not isinstance(suppress_bytecode_warnings, (bool, type(None))):
         message = f"""
         Argument suppress_bytecode_warnings must be a boolean; got
         {suppress_bytecode_warnings!r}
@@ -111,7 +114,7 @@ def version(
                 version=CodeVersion(
                     major=major,
                     minor=minor,
-                    includes_bytecode=(not ignore_bytecode),
+                    includes_bytecode=includes_bytecode,
                 ),
                 suppress_bytecode_warnings=suppress_bytecode_warnings,
             ),
@@ -124,6 +127,9 @@ def version_no_warnings(major=None, minor=None):
     Same as the `@version` decorator, but it suppresses all bytecode
     warnings.
     """
+    if callable(major):
+        func = major
+        return version_no_warnings()(func)
     return version(major, minor, suppress_bytecode_warnings=True)
 
 

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -82,6 +82,8 @@ Bug Fixes
 - Fixed a bug in Bionic's automatic versioning where Bionic would warn about
   dynamic imports even when warning suppression was requested. The warning
   messages themselves were also improved.
+- Fixed a bug where Bionic would incorrectly suppress versioning warnings for
+  functions that hadn't been decorated with the ``@version`` decorator.
 
 Improvements
 ............

--- a/tests/test_flow/generate_test_compatibility_cache.py
+++ b/tests/test_flow/generate_test_compatibility_cache.py
@@ -48,16 +48,19 @@ class Harness:
         builder.assign("uppercase_chars", frozenset("ABCDEF"))
 
         @builder
+        @bn.version_no_warnings
         def lowercase_sum(lowercase_chars):
             lowercase_sum_counter.mark()
             return sum(ord(char) for char in lowercase_chars)
 
         @builder
+        @bn.version_no_warnings
         def uppercase_sum(uppercase_chars):
             uppercase_sum_counter.mark()
             return sum(ord(char) for char in uppercase_chars)
 
         @builder
+        @bn.version_no_warnings
         def total_sum(lowercase_sum, uppercase_sum):
             total_sum_counter.mark()
             return lowercase_sum + uppercase_sum

--- a/tests/test_flow/test_persistence_gcs.py
+++ b/tests/test_flow/test_persistence_gcs.py
@@ -55,6 +55,7 @@ def test_gcs_caching(
     builder = preset_gcs_builder
 
     @builder
+    @bn.version_no_warnings
     @call_counter
     def xy(x, y):
         return x * y
@@ -138,6 +139,7 @@ def test_versioning(preset_gcs_builder, make_counter):
     assert flow.setting("x", 4).get("xy") == 12
 
     @builder  # noqa: F811
+    @bn.version_no_warnings
     def xy(x, y):  # noqa: F811
         call_counter.mark()
         return y * x
@@ -264,6 +266,7 @@ def test_multifile_serialization(preset_gcs_builder, make_counter):
 
     @builder
     @bn.protocol.dask
+    @bn.version_no_warnings
     @call_counter
     def df():
         return dask_df
@@ -289,8 +292,8 @@ def test_file_path_copying(preset_gcs_builder, make_counter):
     file_contents = "DATA"
 
     @builder
-    @call_counter
     @bn.protocol.path(operation="move")
+    @bn.version_no_warnings
     def data_path():
         call_counter.mark()
         fd, filename = tempfile.mkstemp()


### PR DESCRIPTION
It looks like we were defaulting to emitting versioning warnings for
functions decorated with `@version`, but not for undecorated functions.
This commit should make us always default to emitting warnings (unless
auto/assist versioning is not enabled).

To do this, I changed the `@version` decorator to defer to the defaults
of the CodeVersion and CodeVersioningPolicy constructors instead of
trying to apply its own defaults; that way they should always stay in
sync.

I also had to apply @version_no_warnings` to a bunch more functions in
our tests.

@namanjain could you confirm that I haven't done something dumb here?