### PR TITLE
Run CI on all PRs

### DIFF
--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Currently our CI (GitHub Actions) is configured to run all checks
whenever a branch is pushed to the repo. This means we don't run checks
when external contributors open PRs (because they're forking the repo
rather than pushing a branch).

This commit adds configuration to also run tests on all PRs and when
triggered manually (`workflow_dispatch`). I'm not sure if this will end
up creating a bunch of duplicate test runs; if so, we may want to
disable running tests on pushes.