### PR TITLE
Ignore __module__ field on classes when hashing

### DIFF
--- a/bionic/code_hasher.py
+++ b/bionic/code_hasher.py
@@ -418,7 +418,9 @@ class CodeHasher:
             for (m_name, m_value) in inspect.getmembers(obj)
             if not (
                 inspect.isgetsetdescriptor(m_value)
-                or m_name in {"__class__", "__dict__", "__members__"}
+                # We ignore __module__ because it can vary depending on whether
+                # that class's module was run as __main__.
+                or m_name in {"__class__", "__dict__", "__members__", "__module__"}
             )
         ]
         add_to_hash(

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -65,14 +65,20 @@ For each release, we list the following types of change (in this order):
 - **Development Changes**: Significant changes to Bionic's development process, such
   as changes to our Pytest configuration or our Continuous Integration ("CI").
 
-.. Upcoming Version (Not Yet Released)
-.. -----------------------------------
+Upcoming Version (Not Yet Released)
+-----------------------------------
 
 .. Record any notable changes in this section. When we update the current version,
    add a new version heading below, and then comment out the heading above until more
    changes are added. This way, the "Upcoming Version" section will be never be visible
    in the "stable" docs (corresponding to the last release) but will be visible in the
    "latest" docs (corresponding to the master branch).
+
+Bug Fixes
+---------
+
+- Fixes an issue where automatic versioning erroneously treated classes as
+  having changed if the module they were defined in was run as ``__main__``.
 
 0.10.0 (Feb 23, 2021)
 --------------------

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -333,3 +333,9 @@ def import_code(code, vars_dict={}, is_module_internal=False):
     module.__dict__.update(vars_dict)
     exec(code, module.__dict__)
     return module
+
+
+# This exists because we have a test case that requires two identical classes
+# defined in different modules.
+class EmptyClass:
+    pass

--- a/tests/test_code_hasher.py
+++ b/tests/test_code_hasher.py
@@ -557,6 +557,15 @@ def test_class_references():
     check_hash_equivalence([[type(1), type(2)], [type("str1"), type("str2")]])
 
 
+def test_same_class_different_module():
+    from . import helpers
+
+    class EmptyClass:
+        pass
+
+    check_hash_equivalence([[EmptyClass, helpers.EmptyClass]])
+
+
 def test_changes_in_references():
     v = 10
 


### PR DESCRIPTION
When computing the hash a class, we now ignore the `__module__` field.
This field usually contains the name of the module the class was defined
in, but if that module was run directly from the command line then it
contains `__main__` instead. That means we can get different values
depending on whether we run a python module directly or load it from
somewhere else (like a Jupyter notebook), causing our smart caching to
detect a spurious change.