### PR TITLE
Exclude pyrsistent version 0.19.1 from deps

### DIFF
--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -20,10 +20,8 @@ jobs:
       # version.)
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         include:
-          - python-version: 3.6
-            shard-id: 0
           - python-version: 3.7
             shard-id: 1
           - python-version: 3.8

--- a/.github/workflows/bionic-test.yml
+++ b/.github/workflows/bionic-test.yml
@@ -44,7 +44,7 @@ jobs:
         # build failures.
         pip freeze
     - name: Set up gcloud
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@main
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true

--- a/bionic/__init__.py
+++ b/bionic/__init__.py
@@ -19,4 +19,4 @@ from .decorators import (  # noqa: F401
 from . import protocol  # noqa: F401
 from . import util  # noqa: F401
 
-__version__ = u"0.11.0"
+__version__ = "0.11.0"

--- a/bionic/code_hasher.py
+++ b/bionic/code_hasher.py
@@ -37,9 +37,6 @@ from .utils.reload import is_internal_file
 
 
 PREFIX_SEPARATOR = b"$"
-# This is gross but types.MethodWrapperType was introduced in Python 3.7
-# and does not exist in 3.6 which Bionic supports.
-METHOD_WRAPPER_TYPE = type("".__str__)
 
 
 class CodeHasher:
@@ -290,7 +287,9 @@ class CodeHasher:
                 obj_bytes=self._check_and_hash(builtin_name, code_context),
             )
 
-        elif inspect.ismethoddescriptor(obj) or isinstance(obj, METHOD_WRAPPER_TYPE):
+        elif inspect.ismethoddescriptor(obj) or isinstance(
+            obj, types.MethodWrapperType
+        ):
             if inspect.ismethoddescriptor(obj):
                 type_prefix = TypePrefix.METHOD_DESCRIPTOR
             else:

--- a/bionic/deps/extras.py
+++ b/bionic/deps/extras.py
@@ -54,6 +54,7 @@ extras["dev"] = combine(
         "flake8",
         "flake8-print",
         "flake8-fixme",
+        "importlib-metadata<5",  # flake8 is incompatible with importlib 5.0.0
         "sphinx!=3.2.0",
         "sphinx_rtd_theme",
         "sphinx-autobuild",

--- a/bionic/flake8/check_dnode_match.py
+++ b/bionic/flake8/check_dnode_match.py
@@ -216,4 +216,4 @@ if __name__ == "__main__":
         code = Path(filename).read_text()
         tree = ast.parse(code)
         for message in Checker(tree).run():
-            print(message)  # noqa: T001
+            print(message)  # noqa: T201

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,12 +16,12 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
 
-project = u"bionic"
-copyright = u"2019, Square"
-author = u"Janek Klawe"
+project = "bionic"
+copyright = "2019, Square"
+author = "Janek Klawe"
 
 # The short X.Y version
-version = u"0.11.0"
+version = "0.11.0"
 # The full version, including alpha/beta/rc tags
 release = version
 
@@ -67,7 +67,7 @@ language = None
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = [
-    u"_build",
+    "_build",
     "Thumbs.db",
     ".DS_Store",
     "**.ipynb_checkpoints",
@@ -135,7 +135,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "bionic.tex", u"bionic Documentation", u"Janek Klawe", "manual"),
+    (master_doc, "bionic.tex", "bionic Documentation", "Janek Klawe", "manual"),
 ]
 
 
@@ -143,7 +143,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "bionic", u"bionic Documentation", [author], 1)]
+man_pages = [(master_doc, "bionic", "bionic Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------------
@@ -155,7 +155,7 @@ texinfo_documents = [
     (
         master_doc,
         "bionic",
-        u"bionic Documentation",
+        "bionic Documentation",
         author,
         "bionic",
         "One line description of project.",

--- a/docs/get-started.rst
+++ b/docs/get-started.rst
@@ -39,7 +39,7 @@ performance for some workloads.  LibYAML is also available via Homebrew:
 
     brew install libyaml
 
-Bionic supports Python 3.6 and above.
+Bionic supports Python 3.7 and above.
 
 .. _extra-packages:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,8 @@ ignore =
     T102  # "fixme found (XXX)"
 per-file-ignores =
     # Allow print statements in example code.
-    example/*:T001
+    build/lib/example/*:T201
+    example/*:T201
 
 # NOTE On my MacBook this plugin adds about 1 extra second to Flake8's runtime, making
 # it about 5s total. That's not trivial, so it might not be worth it to have this

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ requirements = [
     "pandas",
     "pyarrow",
     "pyrsistent!=0.19.1",
+    "decorator<5",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require=extras_require,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
     keywords="bionic",
     classifiers=[
@@ -52,6 +52,6 @@ setup(
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ requirements = [
     "numpy",
     "pandas",
     "pyarrow",
-    "pyrsistent",
+    "pyrsistent!=0.19.1",
 ]
 
 setup(

--- a/tests/test_code_hasher.py
+++ b/tests/test_code_hasher.py
@@ -87,7 +87,7 @@ def test_code_hasher():
         return x - one()
 
     def quadratic_eq(a, b, c):
-        d = b ** 2 - 4 * a * c
+        d = b**2 - 4 * a * c
         s1 = (b - cmath.sqrt(d)) / (2 * a)
         s2 = (-b - cmath.sqrt(d)) / (2 * a)
         return (s1, s2)

--- a/tests/test_flow/conftest.py
+++ b/tests/test_flow/conftest.py
@@ -200,7 +200,7 @@ def real_gcs_session_tmp_url_prefix(real_gcs_url_stem) -> Optional[str]:
 
     gcs_fs = get_gcs_fs_without_warnings()
 
-    random_hex_str = "%016x" % random.randint(0, 2 ** 64)
+    random_hex_str = "%016x" % random.randint(0, 2**64)
     path_str = f"{getpass.getuser()}/BNTESTDATA/{random_hex_str}"
 
     gs_url = real_gcs_url_stem + "/" + path_str + "/"

--- a/tests/test_flow/test_cache_api.py
+++ b/tests/test_flow/test_cache_api.py
@@ -106,7 +106,7 @@ def preset_flow(builder):
 
     @builder
     def xy_squared(xy):
-        return xy ** 2
+        return xy**2
 
     return builder.build()
 
@@ -134,7 +134,7 @@ def test_get_entries(preset_flow):
     @builder  # noqa: F811
     @bn.version(1)
     def xy(x, y):  # noqa: F811
-        return x ** y
+        return x**y
 
     tester.flow = builder.build()
 

--- a/tests/test_flow/test_interactions.py
+++ b/tests/test_flow/test_interactions.py
@@ -14,7 +14,7 @@ def preset_builder(builder):
 
     @builder
     def ys(xs):
-        return [x ** 2 for x in xs]
+        return [x**2 for x in xs]
 
     return builder
 

--- a/tests/test_flow/test_merge.py
+++ b/tests/test_flow/test_merge.py
@@ -128,7 +128,7 @@ def merge_tester(builder):
 
     @fb
     def x(root_x):
-        return root_x ** 2
+        return root_x**2
 
     tester.add("DerivedSingle", fb.build())
 
@@ -167,7 +167,7 @@ def merge_tester(builder):
     @fb  # noqa: F811
     @bn.persist(False)
     def x(root_x):  # noqa: F811
-        return root_x ** 2
+        return root_x**2
 
     tester.add("DS", fb.build())
 

--- a/tests/test_flow/test_persistence.py
+++ b/tests/test_flow/test_persistence.py
@@ -280,7 +280,7 @@ def test_versioning(builder, make_counter):
     @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
-        return x ** y
+        return x**y
 
     assert builder.build().get("f") == 6
     assert call_counter.times_called() == 0
@@ -291,7 +291,7 @@ def test_versioning(builder, make_counter):
     @bn.version_no_warnings(major=2)
     def f(x, y):  # noqa: F811
         call_counter.mark()
-        return x ** y
+        return x**y
 
     assert builder.build().get("f") == 8
     assert call_counter.times_called() == 1
@@ -435,7 +435,7 @@ def test_versioning_assist(builder, make_counter):
     @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
-        return x ** y
+        return x**y
 
     with raises_versioning_error_for_entity("f"):
         builder.build().get("f")
@@ -446,7 +446,7 @@ def test_versioning_assist(builder, make_counter):
     @bn.version_no_warnings(major=2)
     def f(x, y):  # noqa: F811
         call_counter.mark()
-        return x ** y
+        return x**y
 
     assert builder.build().get("f") == 8
     assert call_counter.times_called() == 1
@@ -504,7 +504,7 @@ def test_versioning_assist_with_refs(builder, make_counter):
     assert call_counter.times_called() == 0
 
     def op(x, y):  # noqa: F811
-        return x ** y
+        return x**y
 
     with raises_versioning_error_for_entity("f"):
         builder.build().get("f")
@@ -733,7 +733,7 @@ def test_versioning_auto(builder, make_counter):
     @bn.version_no_warnings(major=1, minor=1)
     def f(x, y):  # noqa: F811
         call_counter.mark()
-        return x ** y
+        return x**y
 
     assert builder.build().get("f") == 8
     assert call_counter.times_called() == 1
@@ -744,7 +744,7 @@ def test_versioning_auto(builder, make_counter):
     @bn.version_no_warnings(major=2)
     def f(x, y):  # noqa: F811
         call_counter.mark()
-        return x ** y
+        return x**y
 
     assert builder.build().get("f") == 8
     assert call_counter.times_called() == 1

--- a/tests/test_flow/test_persistence_compatibility.py
+++ b/tests/test_flow/test_persistence_compatibility.py
@@ -1,6 +1,5 @@
 import pytest
 import shutil
-import sys
 
 from .generate_test_compatibility_cache import Harness, CACHE_TEST_DIR
 
@@ -26,15 +25,7 @@ def older_serialized_cache_harness(make_counter, tmp_path):
 # To renegerate cache, run the following command from bionic/ dir
 #   `python -m tests.test_flow.generate_test_compatibility_cache`
 def test_caching_compatibility(older_serialized_cache_harness):
-    # The auto-versioned flow generates different bytecode hashes on Python 3.6
-    # compared to 3.7 and 3.8 This is because Python 3.7 added new
-    # bytecode instructions like LOAD_METHOD and uses them widely.
-    # We skip the auto-versioned flow for Python 3.6 and only test it on
-    # Python 3.7+.
-    if sys.version_info < (3, 7):
-        flows = [older_serialized_cache_harness.manual_flow]
-    else:
-        flows = older_serialized_cache_harness.flows
+    flows = older_serialized_cache_harness.flows
 
     for flow in flows:
         assert (

--- a/tests/test_flow/test_persistence_gcs.py
+++ b/tests/test_flow/test_persistence_gcs.py
@@ -176,7 +176,7 @@ def test_versioning(preset_gcs_builder, make_counter):
     @bn.version_no_warnings(major=1)
     def xy(x, y):  # noqa: F811
         call_counter.mark()
-        return x ** y
+        return x**y
 
     flow = builder.build()
 
@@ -200,7 +200,7 @@ def test_indirect_versioning(preset_gcs_builder, make_counter):
     @bn.version_no_warnings(major=1)
     def xy(x, y):
         call_counter.mark()
-        return x ** y
+        return x**y
 
     flow = builder.build()
     assert flow.get("xy") == 8
@@ -240,7 +240,7 @@ def test_indirect_versioning(preset_gcs_builder, make_counter):
     @bn.version_no_warnings(major=2)
     def xy(x, y):  # noqa: F811
         call_counter.mark()
-        return y ** x
+        return y**x
 
     flow = builder.build()
 


### PR DESCRIPTION
`Pyrsistent` 0.19.1 had a regression in 0.19.1 which was fixed in 0.19.2 
The regression was on pmap where inserted elements were unreliably
inserted. See https://github.com/tobgu/pyrsistent/issues/263